### PR TITLE
[OSB] Fix spelling in function name

### DIFF
--- a/src/HealthGPS/modulefactory.cpp
+++ b/src/HealthGPS/modulefactory.cpp
@@ -10,7 +10,7 @@ namespace hgps {
 		return builders_.size();
 	}
 
-	bool SimulationModuleFactory::countains(const SimulationModuleType type) const noexcept {
+	bool SimulationModuleFactory::contains(const SimulationModuleType type) const noexcept {
 		return builders_.contains(type);
 	}
 

--- a/src/HealthGPS/modulefactory.h
+++ b/src/HealthGPS/modulefactory.h
@@ -19,7 +19,7 @@ namespace hgps {
 
         std::size_t size() const noexcept;
 
-        bool countains(const SimulationModuleType type) const noexcept;
+        bool contains(const SimulationModuleType type) const noexcept;
 
         void register_builder(const SimulationModuleType type, const ConcreteBuilder builder);
 


### PR DESCRIPTION
Found one typo: countains => contains