### PR TITLE
Added support for EasyBuild integration

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -104,7 +104,7 @@ jobs:
         name: health-gps-archive
         path: artifact/health_gps_linux.zip
 
-    - name: Release
+    - name: Upload release artefacts
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+# release.yml - Automatic creation of sha256 file for release tarball
+
+name: Release action
+run-name: ${{ github.actor }} is publishing release ${{ github.ref_name }}
+on:
+  release:
+    types: [published]
+    branches: [ main ]
+jobs:
+  sha256:
+    name: sha256
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tarball url
+        run: echo "${{ github.server_url }}/${{ github.repository }}/archive/refs/tags/${{ github.ref_name }}.tar.gz"
+      - name: Create tarball sha256 
+        run: curl -sL "${{ github.server_url }}/${{ github.repository }}/archive/refs/tags/${{ github.ref_name }}.tar.gz" | shasum -a 256 > sha256sum.txt
+      - name: Upload sha256sum file
+        uses: softprops/action-gh-release@v1
+        with:
+          files: sha256sum.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 # release.yml - Automatic creation of sha256 file for release tarball
 
-name: Release action
-run-name: ${{ github.actor }} is publishing release ${{ github.ref_name }}
+name: Release
+run-name: Publishing release ${{ github.ref_name }}
 on:
-  push:
   release:
     types: [published]
     branches: [ main ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@
 name: Release action
 run-name: ${{ github.actor }} is publishing release ${{ github.ref_name }}
 on:
+  push:
   release:
     types: [published]
     branches: [ main ]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -102,7 +102,7 @@ jobs:
         name: health-gps-archive
         path: artifact/health_gps_win64.zip
 
-    - name: Release
+    - name: Upload release artefacts
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 project(HealthGPS
-        VERSION 1.2.0.1
+        VERSION 1.2.1.0
         DESCRIPTION "Global Health Policy Simulation model (Health-GPS)"
         HOMEPAGE_URL "https://github.com/imperialCHEPI/healthgps"
         LANGUAGES CXX)
@@ -23,7 +23,7 @@ message(STATUS "Compiler ID: ${CMAKE_CXX_COMPILER_ID}")
 if(MSVC)
     add_compile_options(/W4 /permissive-) # /WX 
 else()
-    add_compile_options(-Wall -Wextra -Wpedantic) # -Werror
+    add_compile_options(-Wall -Wextra -Wpedantic) # -Werror -march=native
 endif()
 
 include(CTest)


### PR DESCRIPTION
Create a GitHub action will sign and add a sha256sum file to the release artefacts. The checksum file is required to create a EasyBuild config script.