### PR TITLE
Optional TBB linking

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -101,8 +101,8 @@ jobs:
       id: upload_zip
       uses: actions/upload-artifact@v3
       with:
-        name: health_gps_linux.zip
-        path: ${{github.workspace}}/out/install/${{env.RELEASE_PRESET}}/bin/*.Console*
+        name: health-gps-archive
+        path: artifact/health_gps_linux.zip
 
     - name: Upload release artefacts
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Install TBB library
       id: install_tbb
-      run: echo "sudo apt install libtbb-dev"
+      run: sudo apt install libtbb-dev
 
     - name: Install Ninja
       id: install_ninja
@@ -101,8 +101,8 @@ jobs:
       id: upload_zip
       uses: actions/upload-artifact@v3
       with:
-        name: health-gps-archive
-        path: artifact/health_gps_linux.zip
+        name: health_gps_linux.zip
+        path: ${{github.workspace}}/out/install/${{env.RELEASE_PRESET}}/bin/*.Console*
 
     - name: Upload release artefacts
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Install TBB library
       id: install_tbb
-      run: sudo apt install libtbb-dev
+      run: echo "sudo apt install libtbb-dev"
 
     - name: Install Ninja
       id: install_ninja

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,10 @@ jobs:
     steps:
       - name: Tarball url
         run: echo "${{ github.server_url }}/${{ github.repository }}/archive/refs/tags/${{ github.ref_name }}.tar.gz"
-      - name: Create tarball sha256 
-        run: curl -sL "${{ github.server_url }}/${{ github.repository }}/archive/refs/tags/${{ github.ref_name }}.tar.gz" | shasum -a 256 > sha256sum.txt
+      - name: Create tarball sha256
+        run: |
+          curl -O -sL "${{ github.server_url }}/${{ github.repository }}/archive/refs/tags/${{ github.ref_name }}.tar.gz" | sha256sum > sha256sum.txt
+          sha256sum ${{ github.ref_name }}.tar.gz > sha256sum.txt
       - name: Upload sha256sum file
         uses: softprops/action-gh-release@v1
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 project(HealthGPS
-        VERSION 1.2.1.0
+        VERSION 1.2.2.0
         DESCRIPTION "Global Health Policy Simulation model (Health-GPS)"
         HOMEPAGE_URL "https://github.com/imperialCHEPI/healthgps"
         LANGUAGES CXX)

--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ To start working on the *Health GPS* code base, the suggested development machin
 5. [Microsoft Visual Studio](https://visualstudio.microsoft.com) 2022 or newer with CMake presets integration.
 6. [GCC](https://gcc.gnu.org/) 11.1 or newer installed on *Linux* environment, plus.
    * [Intel TBB](https://github.com/oneapi-src/oneTBB) library version 2018 or later installed (e.g. `sudo apt update && sudo apt install libtbb-dev`) 
-7. The latest [vcpkg](https://github.com/microsoft/vcpkg) installed globally for Visual Studio projects, and the VCPKG_ROOT environment variable set to the installation directory.
+7. The latest [vcpkg](https://github.com/microsoft/vcpkg) installed globally for Visual Studio projects, and the `VCPKG_ROOT` *environment variable* set to the installation directory.
 8. Internet connection.
 
 Download the *Health GPS* source code to the local machine, we recommend somewhere like root `/src` or `/source`, since otherwise you may run into path issues with the build systems.
 ```cmd
 > git clone https://github.com/imperialCHEPI/healthgps
 ```
-Finally, open the `.../healthgps` folder in Visual Studio and hit build. The first build takes considerably longer than normal due to the initial work required by CMake and the package manager.
+Finally, open the `healthgps` folder in Visual Studio and build. The first build takes considerably longer than normal due to the initial work required by CMake and the package manager.
 
 >**NOTE:** *This is the current toolset being used for developing the HealthGPS model, however CMake is supported by VS Code and many other IDE of choice, e.g. the model is current being compiled and built on Ubuntu Linux 22.04 LTS using only the CMake command line.*
 

--- a/src/HealthGPS.Benchmarks/CMakeLists.txt
+++ b/src/HealthGPS.Benchmarks/CMakeLists.txt
@@ -2,6 +2,7 @@ find_package(fmt CONFIG REQUIRED)
 find_package(cxxopts CONFIG REQUIRED)
 find_package(benchmark CONFIG REQUIRED)
 find_package(Threads REQUIRED)
+find_package(TBB QUIET)
 
 add_executable(HealthGPS.Benchmarks "")
 target_compile_features(HealthGPS.Tests PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
@@ -12,7 +13,7 @@ target_sources(HealthGPS.Benchmarks
     "string_benchs.h"
     "identifier_benchs.h")
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if(TBB_FOUND AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
     target_link_libraries(HealthGPS.Benchmarks
     PRIVATE
         HealthGPS.Core

--- a/src/HealthGPS.Console/CMakeLists.txt
+++ b/src/HealthGPS.Console/CMakeLists.txt
@@ -4,6 +4,7 @@ find_package(indicators CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 find_path(RAPIDCSV_INCLUDE_DIRS "rapidcsv.h")
 find_package(Threads REQUIRED)
+find_package(TBB QUIET)
 
 add_executable(HealthGPS.Console "")
 target_compile_features(HealthGPS.Console PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
@@ -39,7 +40,8 @@ if(WIN32)
 	target_sources(HealthGPS.Console PRIVATE versioninfo.rc)
 endif(WIN32)
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+message(STATUS "TBB found: ${TBB_FOUND}")
+if(TBB_FOUND AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
 	target_link_libraries(HealthGPS.Console
 	PRIVATE
 		HealthGPS.Core

--- a/src/HealthGPS.Console/configuration.h
+++ b/src/HealthGPS.Console/configuration.h
@@ -21,6 +21,8 @@ CommandOptions parse_arguments(cxxopts::Options& options, int& argc, char* argv[
 
 Configuration load_configuration(CommandOptions& options);
 
+bool create_output_folder(std::filesystem::path folder_path, unsigned int num_retries = 3);
+
 std::vector<hgps::core::DiseaseInfo> get_diseases(hgps::core::Datastore& data_api, Configuration& config);
 
 hgps::ModelInput create_model_input(hgps::core::DataTable& input_table, hgps::core::Country country,

--- a/src/HealthGPS.Tests/CMakeLists.txt
+++ b/src/HealthGPS.Tests/CMakeLists.txt
@@ -2,6 +2,7 @@ find_package(fmt CONFIG REQUIRED)
 find_package(cxxopts CONFIG REQUIRED)
 find_package(GTest CONFIG REQUIRED)
 find_package(Threads REQUIRED)
+find_package(TBB QUIET)
 
 include(CTest)
 include(GoogleTest)
@@ -40,7 +41,7 @@ target_sources(HealthGPS.Tests
         "CountryModule.h"
         "RiskFactorData.h")
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if(TBB_FOUND AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
     target_link_libraries(HealthGPS.Tests
     PRIVATE
         HealthGPS.Core


### PR DESCRIPTION
Made optional the linking with TBB on Linux environment, this is a requirement from the GCC to support STL parallel algorithms and the HPC does not have good support for non-OpenMP threads. To use the TBB, one needs to use advanced PBS job script constructs and have a good knowledge of the HPC hardware, otherwise the job can be killed by the PBS scheduler.