### PR TITLE
Bump CI version of vcpkg and fix cxxopts build bug

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -47,7 +47,6 @@ jobs:
       run: |
         git clone https://github.com/Microsoft/vcpkg.git
         cd vcpkg
-        git checkout --force 2023.04.15
         ./bootstrap-vcpkg.sh -disableMetrics
 
     - name: Tool Check

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         git clone https://github.com/Microsoft/vcpkg.git
         cd vcpkg
-        git checkout --force 2023.01.09
+        git checkout --force 2023.04.15
         ./bootstrap-vcpkg.sh -disableMetrics
 
     - name: Tool Check

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         git clone https://github.com/Microsoft/vcpkg.git
         cd vcpkg
-        git checkout --force 2023.01.09
+        git checkout --force 2023.04.15
         .\bootstrap-vcpkg.bat -disableMetrics    
 
     - name: Install Ninja

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,7 +37,6 @@ jobs:
       run: |
         git clone https://github.com/Microsoft/vcpkg.git
         cd vcpkg
-        git checkout --force 2023.04.15
         .\bootstrap-vcpkg.bat -disableMetrics    
 
     - name: Install Ninja

--- a/src/HealthGPS.Console/configuration.cpp
+++ b/src/HealthGPS.Console/configuration.cpp
@@ -135,7 +135,7 @@ namespace host
 
 			cmd.success = cmd.exit_code == EXIT_SUCCESS;
 		}
-		catch (const cxxopts::OptionException& ex) {
+		catch (const cxxopts::exceptions::exception& ex) {
 			fmt::print(fg(fmt::color::red), "\nInvalid command line argument: {}.\n", ex.what());
 			fmt::print("\n{}\n", options.help());
 			cmd.success = false;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,5 +11,5 @@
     "gtest",
     "benchmark"
   ],
-  "builtin-baseline": "501db0f17ef6df184fcdbfbe0f87cde2313b6ab1"
+  "builtin-baseline": "1e334d770ac71a89d1c36d51019e60dd08b68f76"
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,5 +10,6 @@
     "crossguid",
     "gtest",
     "benchmark"
-  ]
+  ],
+  "builtin-baseline": "501db0f17ef6df184fcdbfbe0f87cde2313b6ab1"
 }


### PR DESCRIPTION
Health-GPS won't build with the current version of vcpkg, due to a breaking change in the cxxopts dependency. Fix up the code and bump the vcpkg version to the latest release.

Fixes #105.

@israel-vieira I've tagged you to keep you in the loop, in case that's something you want, but obviously don't feel any obligation to review PRs etc. going forward (unless you want to!). Let me know if you would/wouldn't like this for future PRs.