### PR TITLE
Fix documentation generation on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ${{github.workspace}}/out/build/${{env.RELEASE_PRESET}}/src/html
+          publish_dir: ${{github.workspace}}/out/build/linux-release/src/html
           destination_dir: html
           enable_jekyll: true
           commit_message: ${{ github.ref_name }} - ${{ github.event.head_commit.message }}


### PR DESCRIPTION
It turned out to be a one-line config file fix. I forgot to update one of the places where a variable was used when I merged the CI configs.

I've tested this by commenting out the `if` guard that makes documentation only build for releases and new documentation was pushed to `gh-pages`.

Fixes #131.