### PR TITLE
Fix: Don't unconditionally catch exceptions in `main()`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,19 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+if(NOT DEFINED CATCH_EXCEPTIONS)
+    # By default, catch all exceptions for release builds only
+    string(REGEX MATCH "Rel" RELEASE_MATCH "${CMAKE_BUILD_TYPE}")
+    if(NOT RELEASE_MATCH STREQUAL "")
+        set(CATCH_EXCEPTIONS TRUE)
+    endif()
+endif()
+
+# Catch uncaught exceptions in main()
+if(CATCH_EXCEPTIONS)
+    add_definitions(-DCATCH_EXCEPTIONS)
+endif()
+
 project(Health-GPS
         VERSION 1.2.2.0
         DESCRIPTION "Global Health Policy Simulation model (Health-GPS)"

--- a/src/HealthGPS.Console/program.cpp
+++ b/src/HealthGPS.Console/program.cpp
@@ -52,7 +52,9 @@ int main(int argc, char *argv[]) {
         core::run_async(load_datatable_from_csv, std::ref(input_table), config.file.name,
                         config.file.columns, config.file.delimiter);
 
+#ifdef NDEBUG
     try {
+#endif
         // Create back-end data store, cached data repository wrapper
         auto data_api = data::DataManager(cmd_args.storage_folder, config.verbosity);
         auto data_repository = hgps::CachedRepository{data_api};
@@ -156,9 +158,15 @@ int main(int argc, char *argv[]) {
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
         fmt::print(fg(fmt::color::light_green), "\nCompleted, elapsed time : {}ms\n\n", runtime);
         event_monitor.stop();
+
+#ifdef NDEBUG
     } catch (const std::exception &ex) {
         fmt::print(fg(fmt::color::red), "\n\nFailed with message: {}.\n\n", ex.what());
+
+        // Rethrow exception so it can be handled by OS's default handler
+        throw;
     }
+#endif // NDEBUG
 
     return exit_application(EXIT_SUCCESS);
 }

--- a/src/HealthGPS.Console/program.cpp
+++ b/src/HealthGPS.Console/program.cpp
@@ -52,7 +52,7 @@ int main(int argc, char *argv[]) {
         core::run_async(load_datatable_from_csv, std::ref(input_table), config.file.name,
                         config.file.columns, config.file.delimiter);
 
-#ifdef NDEBUG
+#ifdef CATCH_EXCEPTIONS
     try {
 #endif
         // Create back-end data store, cached data repository wrapper
@@ -159,14 +159,14 @@ int main(int argc, char *argv[]) {
         fmt::print(fg(fmt::color::light_green), "\nCompleted, elapsed time : {}ms\n\n", runtime);
         event_monitor.stop();
 
-#ifdef NDEBUG
+#ifdef CATCH_EXCEPTIONS
     } catch (const std::exception &ex) {
         fmt::print(fg(fmt::color::red), "\n\nFailed with message: {}.\n\n", ex.what());
 
         // Rethrow exception so it can be handled by OS's default handler
         throw;
     }
-#endif // NDEBUG
+#endif // CATCH_EXCEPTIONS
 
     return exit_application(EXIT_SUCCESS);
 }


### PR DESCRIPTION
Currently, any uncaught exceptions in Health-GPS will percolate up to the `main()` function, where there is a `try...catch` block around all the code. The `catch` part just displays an error message (minus the stack trace!) then exits the program. This makes debugging difficult as debuggers will not be able to break into the code where the exception was thrown or display a stack trace.

The only reason for keeping the `try...catch` and not getting rid of it altogether is that on Windows, the default handler for uncaught exceptions just displays an uninformative "error has occurred" dialog to users, without giving any more information.

In this PR I've made this behaviour configurable at compile time. By default, exceptions will be caught on release builds and not on debug builds, however I have added a `CATCH_EXCEPTIONS` CMake option in case the user wants to opt in/out of this (e.g. if debugging a release build).

Closes #121.