### PR TITLE
Use `std::unique_ptr`s for storing model definitions 

### DIFF
--- a/src/HealthGPS.Console/model_parser.cpp
+++ b/src/HealthGPS.Console/model_parser.cpp
@@ -43,7 +43,7 @@ hgps::BaselineAdjustment load_baseline_adjustments(const poco::BaselineInfo &inf
     }
 }
 
-std::shared_ptr<hgps::HierarchicalLinearModelDefinition>
+std::unique_ptr<hgps::HierarchicalLinearModelDefinition>
 load_static_risk_model_definition(const poco::json &opt) {
     MEASURE_FUNCTION();
     std::map<int, hgps::HierarchicalLevel> levels;
@@ -102,11 +102,11 @@ load_static_risk_model_definition(const poco::json &opt) {
                 .variances = at.variances});
     }
 
-    return std::make_shared<hgps::HierarchicalLinearModelDefinition>(std::move(models),
+    return std::make_unique<hgps::HierarchicalLinearModelDefinition>(std::move(models),
                                                                      std::move(levels));
 }
 
-std::shared_ptr<hgps::LiteHierarchicalModelDefinition>
+std::unique_ptr<hgps::LiteHierarchicalModelDefinition>
 load_dynamic_risk_model_definition(const poco::json &opt) {
     MEASURE_FUNCTION();
     auto percentage = 0.05;
@@ -178,11 +178,11 @@ load_dynamic_risk_model_definition(const poco::json &opt) {
         equations.emplace(age_key, std::move(age_equations));
     }
 
-    return std::make_shared<hgps::LiteHierarchicalModelDefinition>(
+    return std::make_unique<hgps::LiteHierarchicalModelDefinition>(
         std::move(equations), std::move(variables), percentage);
 }
 
-std::shared_ptr<hgps::EnergyBalanceModelDefinition>
+std::unique_ptr<hgps::EnergyBalanceModelDefinition>
 load_newebm_risk_model_definition(const poco::json &opt, const poco::SettingsInfo &settings) {
     MEASURE_FUNCTION();
     std::unordered_map<hgps::core::Identifier, double> energy_equation;
@@ -225,7 +225,7 @@ load_newebm_risk_model_definition(const poco::json &opt, const poco::SettingsInf
     age_mean_height.emplace(hgps::core::Gender::male, std::move(male_height));
     age_mean_height.emplace(hgps::core::Gender::female, std::move(female_height));
 
-    return std::make_shared<hgps::EnergyBalanceModelDefinition>(
+    return std::make_unique<hgps::EnergyBalanceModelDefinition>(
         std::move(energy_equation), std::move(nutrient_equations), std::move(age_mean_height));
 }
 
@@ -234,7 +234,7 @@ void register_risk_factor_model_definitions(hgps::CachedRepository &repository,
                                             const poco::SettingsInfo &settings) {
     MEASURE_FUNCTION();
     hgps::HierarchicalModelType model_type;
-    std::shared_ptr<hgps::RiskFactorModelDefinition> model_definition;
+    std::unique_ptr<hgps::RiskFactorModelDefinition> model_definition;
 
     for (auto &model : info.risk_factor_models) {
         const auto &model_filename = model.second;

--- a/src/HealthGPS.Console/model_parser.h
+++ b/src/HealthGPS.Console/model_parser.h
@@ -15,20 +15,20 @@ hgps::BaselineAdjustment load_baseline_adjustments(const poco::BaselineInfo &inf
 /// @brief Loads the full hierarchical linear regression model definition from a JSON file
 /// @param opt The parsed model definition JSON file
 /// @return An instance of the hgps::HierarchicalLinearModelDefinition type
-std::shared_ptr<hgps::HierarchicalLinearModelDefinition>
+std::unique_ptr<hgps::HierarchicalLinearModelDefinition>
 load_static_risk_model_definition(const poco::json &opt);
 
 /// @brief Loads the lite hierarchical linear regression model definition from a JSON file
 /// @param opt The parsed model definition JSON file
 /// @return An instance of the hgps::LiteHierarchicalModelDefinition type
-std::shared_ptr<hgps::LiteHierarchicalModelDefinition>
+std::unique_ptr<hgps::LiteHierarchicalModelDefinition>
 load_dynamic_risk_model_definition(const poco::json &opt);
 
 /// @brief Loads the new energy balance model definition from a JSON file
 /// @param opt The parsed model definition JSON file
 /// @param settings The main model settings
 /// @return An instance of the hgps::LiteHierarchicalModelDefinition type
-std::shared_ptr<hgps::EnergyBalanceModelDefinition>
+std::unique_ptr<hgps::EnergyBalanceModelDefinition>
 load_newebm_risk_model_definition(const poco::json &opt, const poco::SettingsInfo &settings);
 
 /// @brief Registers a risk factor model definition with the repository

--- a/src/HealthGPS/repository.cpp
+++ b/src/HealthGPS/repository.cpp
@@ -22,7 +22,7 @@ void CachedRepository::register_risk_factor_model_definition(
     rf_model_definition_.emplace(model_type, std::move(definition));
 }
 
-void CachedRepository::register_baseline_adjustment_definition(BaselineAdjustment &&definition) {
+void CachedRepository::register_baseline_adjustment_definition(BaselineAdjustment definition) {
     std::unique_lock<std::mutex> lock(mutex_);
     baseline_adjustments_ = std::move(definition);
 }

--- a/src/HealthGPS/repository.cpp
+++ b/src/HealthGPS/repository.cpp
@@ -10,7 +10,7 @@ CachedRepository::CachedRepository(core::Datastore &manager)
     : mutex_{}, data_manager_{manager}, rf_model_definition_{}, baseline_adjustments_{},
       diseases_info_{}, diseases_{}, lms_parameters_{} {}
 
-bool CachedRepository::register_risk_factor_model_definition(
+void CachedRepository::register_risk_factor_model_definition(
     const HierarchicalModelType &model_type,
     std::shared_ptr<RiskFactorModelDefinition> definition) {
     std::unique_lock<std::mutex> lock(mutex_);
@@ -19,14 +19,12 @@ bool CachedRepository::register_risk_factor_model_definition(
         rf_model_definition_.erase(model_type);
     }
 
-    auto result = rf_model_definition_.emplace(model_type, std::move(definition));
-    return result.second;
+    rf_model_definition_.emplace(model_type, std::move(definition));
 }
 
-bool CachedRepository::register_baseline_adjustment_definition(BaselineAdjustment &&definition) {
+void CachedRepository::register_baseline_adjustment_definition(BaselineAdjustment &&definition) {
     std::unique_lock<std::mutex> lock(mutex_);
     baseline_adjustments_ = std::move(definition);
-    return true;
 }
 
 core::Datastore &CachedRepository::manager() noexcept { return data_manager_; }

--- a/src/HealthGPS/repository.cpp
+++ b/src/HealthGPS/repository.cpp
@@ -12,7 +12,7 @@ CachedRepository::CachedRepository(core::Datastore &manager)
 
 void CachedRepository::register_risk_factor_model_definition(
     const HierarchicalModelType &model_type,
-    std::shared_ptr<RiskFactorModelDefinition> definition) {
+    std::unique_ptr<RiskFactorModelDefinition> definition) {
     std::unique_lock<std::mutex> lock(mutex_);
 
     if (rf_model_definition_.contains(model_type)) {
@@ -29,10 +29,10 @@ void CachedRepository::register_baseline_adjustment_definition(BaselineAdjustmen
 
 core::Datastore &CachedRepository::manager() noexcept { return data_manager_; }
 
-std::shared_ptr<RiskFactorModelDefinition>
-CachedRepository::get_risk_factor_model_definition(const HierarchicalModelType &model_type) {
+const RiskFactorModelDefinition &
+CachedRepository::get_risk_factor_model_definition(const HierarchicalModelType &model_type) const {
     std::scoped_lock<std::mutex> lock(mutex_);
-    return rf_model_definition_.at(model_type);
+    return *rf_model_definition_.at(model_type);
 }
 
 BaselineAdjustment &CachedRepository::get_baseline_adjustment_definition() {

--- a/src/HealthGPS/repository.h
+++ b/src/HealthGPS/repository.h
@@ -8,6 +8,7 @@
 #include "modelinput.h"
 #include "riskfactor_adjustment_types.h"
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <optional>
 
@@ -32,8 +33,8 @@ class Repository {
     /// @brief Gets a user-provided risk factor model definition
     /// @param model_type Static or Dynamic
     /// @return The risk factor model definition
-    virtual std::shared_ptr<RiskFactorModelDefinition>
-    get_risk_factor_model_definition(const HierarchicalModelType &model_type) = 0;
+    virtual const RiskFactorModelDefinition &
+    get_risk_factor_model_definition(const HierarchicalModelType &model_type) const = 0;
 
     /// @brief Gets the user provided baseline risk factors adjustment dataset
     /// @return Baseline risk factors adjustments
@@ -78,7 +79,7 @@ class CachedRepository final : public Repository {
     /// @param definition The risk factor model definition instance
     void
     register_risk_factor_model_definition(const HierarchicalModelType &model_type,
-                                          std::shared_ptr<RiskFactorModelDefinition> definition);
+                                          std::unique_ptr<RiskFactorModelDefinition> definition);
 
     /// @brief Register a user provided baseline risk factors adjustments dataset
     /// @param definition The baseline risk factors adjustments dataset
@@ -86,8 +87,8 @@ class CachedRepository final : public Repository {
 
     core::Datastore &manager() noexcept override;
 
-    std::shared_ptr<RiskFactorModelDefinition>
-    get_risk_factor_model_definition(const HierarchicalModelType &model_type) override;
+    const RiskFactorModelDefinition &
+    get_risk_factor_model_definition(const HierarchicalModelType &model_type) const override;
 
     BaselineAdjustment &get_baseline_adjustment_definition() override;
 
@@ -103,9 +104,9 @@ class CachedRepository final : public Repository {
     void clear_cache() noexcept;
 
   private:
-    std::mutex mutex_;
+    mutable std::mutex mutex_;
     std::reference_wrapper<core::Datastore> data_manager_;
-    std::map<HierarchicalModelType, std::shared_ptr<RiskFactorModelDefinition>>
+    std::map<HierarchicalModelType, std::unique_ptr<RiskFactorModelDefinition>>
         rf_model_definition_;
     BaselineAdjustment baseline_adjustments_;
     std::vector<core::DiseaseInfo> diseases_info_;

--- a/src/HealthGPS/repository.h
+++ b/src/HealthGPS/repository.h
@@ -76,15 +76,13 @@ class CachedRepository final : public Repository {
     /// @brief Register a user provided risk factor model definition
     /// @param model_type Static or Dynamic
     /// @param definition The risk factor model definition instance
-    /// @return true, if the operation succeeds; otherwise, false.
-    bool
+    void
     register_risk_factor_model_definition(const HierarchicalModelType &model_type,
                                           std::shared_ptr<RiskFactorModelDefinition> definition);
 
     /// @brief Register a user provided baseline risk factors adjustments dataset
     /// @param definition The baseline risk factors adjustments dataset
-    /// @return true, if the operation succeeds; otherwise, false.
-    bool register_baseline_adjustment_definition(BaselineAdjustment &&definition);
+    void register_baseline_adjustment_definition(BaselineAdjustment &&definition);
 
     core::Datastore &manager() noexcept override;
 

--- a/src/HealthGPS/repository.h
+++ b/src/HealthGPS/repository.h
@@ -82,7 +82,7 @@ class CachedRepository final : public Repository {
 
     /// @brief Register a user provided baseline risk factors adjustments dataset
     /// @param definition The baseline risk factors adjustments dataset
-    void register_baseline_adjustment_definition(BaselineAdjustment &&definition);
+    void register_baseline_adjustment_definition(BaselineAdjustment definition);
 
     core::Datastore &manager() noexcept override;
 

--- a/src/HealthGPS/riskfactor.cpp
+++ b/src/HealthGPS/riskfactor.cpp
@@ -67,15 +67,15 @@ build_risk_factor_module(Repository &repository, [[maybe_unused]] const ModelInp
     auto models = std::map<HierarchicalModelType, std::unique_ptr<HierarchicalLinearModel>>{};
 
     // Static (initialisation) model
-    auto static_definition =
+    const auto &static_definition =
         repository.get_risk_factor_model_definition(HierarchicalModelType::Static);
-    auto static_model = static_definition->create_model();
+    auto static_model = static_definition.create_model();
     models.emplace(HierarchicalModelType::Static, std::move(static_model));
 
     // Dynamic (update) model
-    auto dynamic_definition =
+    const auto &dynamic_definition =
         repository.get_risk_factor_model_definition(HierarchicalModelType::Dynamic);
-    auto dynamic_model = dynamic_definition->create_model();
+    auto dynamic_model = dynamic_definition.create_model();
     models.emplace(HierarchicalModelType::Dynamic, std::move(dynamic_model));
 
     auto adjustment_model =


### PR DESCRIPTION
I fancied tinkering with some code rather than just config files, so I did this, even though it's not in the backlog and is a pretty minor refactor :stuck_out_tongue:.

Currently, the model definitions are stored in the repository (of type ``CachedRepository``) as ``std::shared_ptr``s, even though they don't really need to be "shared", because the repository object will outlive any of the users of these model definitions. So instead, I've changed these to be ``std::unique_ptr``s; when they're needed they can be accessed as good old-fashioned const refs.

I also changed a couple of small issues I spotted on the way.