### PR TITLE
Add clang and latest gcc to CI system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [linux, windows]
         include:
           - platform: linux
             os: ubuntu-22.04
+            compiler: gcc
+          - platform: linux
+            os: ubuntu-22.04
+            compiler: clang
           - platform: windows
             os: windows-2022
+            compiler: msvc
 
     env:
       VCPKG_ROOT: "vcpkg"
@@ -50,6 +54,14 @@ jobs:
           sudo apt upgrade -y
           sudo apt install --no-install-recommends build-essential libtbb-dev ninja-build doxygen graphviz
 
+      - name: Install clang (Linux)
+        if: matrix.platform == 'linux' && matrix.compiler == 'clang'
+        run: |
+          sudo apt install --no-install-recommends clang
+
+          # Use environment variable to tell CMake to compile with clang
+          echo "CXX=clang++" >> "$GITHUB_ENV"
+
       - name: Install VCPKG
         run: |
           git clone https://github.com/Microsoft/vcpkg.git
@@ -69,6 +81,7 @@ jobs:
           cmake --build --preset=release-build-${{ matrix.platform }} --target=install
 
       - name: Upload artifacts
+        if: matrix.compiler != 'clang'
         uses: actions/upload-artifact@v3
         with:
           name: health-gps-${{ matrix.platform }}
@@ -79,20 +92,20 @@ jobs:
         run: ctest --preset=core-test-${{ matrix.platform }}
 
       - name: Zip output folder
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && matrix.compiler != 'clang'
         working-directory: ${{github.workspace}}/out/install/${{ matrix.platform }}-release/bin/
         run: |
           mkdir ${{github.workspace}}/artifact
           7z a -tzip ${{github.workspace}}/artifact/health_gps_${{ matrix.platform }}.zip *.dll *.Console*
 
       - name: Upload release artifacts
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && matrix.compiler != 'clang'
         uses: softprops/action-gh-release@v1
         with:
           files: artifact/health_gps_${{ matrix.platform }}.zip
 
       - name: Doxygen release API deploy
-        if: matrix.platform == 'linux' && startsWith(github.ref, 'refs/tags/')
+        if: matrix.platform == 'linux' && matrix.compiler != 'clang' && startsWith(github.ref, 'refs/tags/')
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-2022]
+        platform: [linux, windows]
         include:
-          - os: ubuntu-22.04
-            platform: linux
-          - os: windows-2022
-            platform: windows
+          - platform: linux
+            os: ubuntu-22.04
+          - platform: windows
+            os: windows-2022
 
     env:
       VCPKG_ROOT: "vcpkg"
@@ -38,13 +38,13 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up MSVC (Windows)
-        if: matrix.os == 'windows-2022'
+        if: matrix.platform == 'windows'
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x64
 
       - name: Install dependencies (Linux)
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.platform == 'linux'
         run: |
           sudo apt update
           sudo apt upgrade -y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,15 +27,19 @@ jobs:
           - platform: linux
             os: ubuntu-22.04
             compiler: gcc-default
+            is_main: true
           - platform: linux
             os: ubuntu-22.04
             compiler: gcc-latest
+            is_main: false
           - platform: linux
             os: ubuntu-22.04
             compiler: clang
+            is_main: false
           - platform: windows
             os: windows-2022
             compiler: msvc
+            is_main: true
 
     env:
       VCPKG_ROOT: "vcpkg"
@@ -97,7 +101,7 @@ jobs:
           cmake --build --preset=release-build-${{ matrix.platform }} --target=install
 
       - name: Upload artifacts
-        if: matrix.platform != 'linux' || matrix.compiler == 'gcc-default'
+        if: matrix.is_main
         uses: actions/upload-artifact@v3
         with:
           name: health-gps-${{ matrix.platform }}
@@ -108,14 +112,14 @@ jobs:
         run: ctest --preset=core-test-${{ matrix.platform }}
 
       - name: Zip output folder
-        if: startsWith(github.ref, 'refs/tags/') && (matrix.platform != 'linux' || matrix.compiler == 'gcc-default')
+        if: startsWith(github.ref, 'refs/tags/') && matrix.is_main
         working-directory: ${{github.workspace}}/out/install/${{ matrix.platform }}-release/bin/
         run: |
           mkdir ${{github.workspace}}/artifact
           7z a -tzip ${{github.workspace}}/artifact/health_gps_${{ matrix.platform }}.zip *.dll *.Console*
 
       - name: Upload release artifacts
-        if: startsWith(github.ref, 'refs/tags/') && (matrix.platform != 'linux' || matrix.compiler == 'gcc-default')
+        if: startsWith(github.ref, 'refs/tags/') && matrix.is_main
         uses: softprops/action-gh-release@v1
         with:
           files: artifact/health_gps_${{ matrix.platform }}.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,10 @@ jobs:
         include:
           - platform: linux
             os: ubuntu-22.04
-            compiler: gcc
+            compiler: gcc-default
+          - platform: linux
+            os: ubuntu-22.04
+            compiler: gcc-latest
           - platform: linux
             os: ubuntu-22.04
             compiler: clang
@@ -37,6 +40,9 @@ jobs:
     env:
       VCPKG_ROOT: "vcpkg"
       VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
+
+      # Update when there is a new version of gcc available
+      LATEST_GCC_VERSION: 13
 
     steps:
       - uses: actions/checkout@v3
@@ -54,13 +60,23 @@ jobs:
           sudo apt upgrade -y
           sudo apt install --no-install-recommends build-essential libtbb-dev ninja-build doxygen graphviz
 
+      - name: Install latest gcc (Linux)
+        if: matrix.compiler == 'gcc-latest'
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install g++-$LATEST_GCC_VERSION
+
+          # Use environment variable to tell CMake to compile with this version of gcc
+          echo CXX=g++-$LATEST_GCC_VERSION >> "$GITHUB_ENV"
+
       - name: Install clang (Linux)
         if: matrix.platform == 'linux' && matrix.compiler == 'clang'
         run: |
           sudo apt install --no-install-recommends clang
 
           # Use environment variable to tell CMake to compile with clang
-          echo "CXX=clang++" >> "$GITHUB_ENV"
+          echo CXX=clang++ >> "$GITHUB_ENV"
 
       - name: Install VCPKG
         run: |
@@ -81,7 +97,7 @@ jobs:
           cmake --build --preset=release-build-${{ matrix.platform }} --target=install
 
       - name: Upload artifacts
-        if: matrix.compiler != 'clang'
+        if: matrix.platform != 'linux' || matrix.compiler == 'gcc-default'
         uses: actions/upload-artifact@v3
         with:
           name: health-gps-${{ matrix.platform }}
@@ -92,20 +108,20 @@ jobs:
         run: ctest --preset=core-test-${{ matrix.platform }}
 
       - name: Zip output folder
-        if: startsWith(github.ref, 'refs/tags/') && matrix.compiler != 'clang'
+        if: startsWith(github.ref, 'refs/tags/') && (matrix.platform != 'linux' || matrix.compiler == 'gcc-default')
         working-directory: ${{github.workspace}}/out/install/${{ matrix.platform }}-release/bin/
         run: |
           mkdir ${{github.workspace}}/artifact
           7z a -tzip ${{github.workspace}}/artifact/health_gps_${{ matrix.platform }}.zip *.dll *.Console*
 
       - name: Upload release artifacts
-        if: startsWith(github.ref, 'refs/tags/') && matrix.compiler != 'clang'
+        if: startsWith(github.ref, 'refs/tags/') && (matrix.platform != 'linux' || matrix.compiler == 'gcc-default')
         uses: softprops/action-gh-release@v1
         with:
           files: artifact/health_gps_${{ matrix.platform }}.zip
 
       - name: Doxygen release API deploy
-        if: matrix.platform == 'linux' && matrix.compiler != 'clang' && startsWith(github.ref, 'refs/tags/')
+        if: matrix.compiler == 'gcc-default' && startsWith(github.ref, 'refs/tags/')
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,10 @@ repos:
       - id: check-merge-conflict
       - id: check-json
       - id: check-yaml
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.23.3
+    hooks:
+      - id: check-github-workflows
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v16.0.6
     hooks:

--- a/src/HealthGPS/energy_balance_model.cpp
+++ b/src/HealthGPS/energy_balance_model.cpp
@@ -51,7 +51,7 @@ void EnergyBalanceModel::update_risk_factors(RuntimeContext &context) {
             current_risk_factors.at(age_key) = model_age;
         }
 
-        double energy_intake = 0.0;
+        [[maybe_unused]] double energy_intake = 0.0;
         std::unordered_map<core::Identifier, double> nutrient_intakes;
 
         // Initialise nutrients to zero.


### PR DESCRIPTION
This PR adds clang and the latest version of gcc to the compilers tested on the CI (both running on Ubuntu), which should increase our coverage.

Closes #76. Closes #84.