### PR TITLE
Fix: Throw error if invalid model specified (+ refactor)

### DIFF
--- a/src/HealthGPS.Console/model_parser.h
+++ b/src/HealthGPS.Console/model_parser.h
@@ -17,12 +17,14 @@ hgps::BaselineAdjustment load_baseline_adjustments(const poco::BaselineInfo &inf
 /// @brief Loads the full hierarchical linear regression model definition from a JSON file
 /// @param opt The parsed model definition JSON file
 /// @return An instance of the hgps::HierarchicalLinearModelDefinition type
+/// @throw std::invalid_argument if static model is unrecognised
 std::unique_ptr<hgps::RiskFactorModelDefinition>
 load_static_risk_model_definition(const poco::json &opt);
 
 /// @brief Loads a dynamic model from a JSON file
 /// @param opt The parsed model definition JSON file
-/// @return An instance of the hgps::LiteHierarchicalModelDefinition type
+/// @return An instance of the hgps::RiskFactorModelDefinition type
+/// @throw std::invalid_argument if dynamic model is unrecognised
 std::unique_ptr<hgps::RiskFactorModelDefinition>
 load_dynamic_risk_model_definition(const poco::json &opt);
 
@@ -51,6 +53,7 @@ load_risk_model_definition(const std::string &model_type, const poco::json &opt,
 /// @brief Load and parse the model file
 /// @param model_filename The path to the model
 /// @return The parsed JSON
+/// @throw std::invalid_argument if file is missing
 poco::json load_json(const std::string &model_filename);
 
 /// @brief Registers a risk factor model definition with the repository

--- a/src/HealthGPS.Console/model_parser.h
+++ b/src/HealthGPS.Console/model_parser.h
@@ -5,6 +5,8 @@
 #include "jsonparser.h"
 #include "options.h"
 
+#include <utility>
+
 namespace host {
 
 /// @brief Loads baseline adjustments information from a file
@@ -15,21 +17,41 @@ hgps::BaselineAdjustment load_baseline_adjustments(const poco::BaselineInfo &inf
 /// @brief Loads the full hierarchical linear regression model definition from a JSON file
 /// @param opt The parsed model definition JSON file
 /// @return An instance of the hgps::HierarchicalLinearModelDefinition type
-std::unique_ptr<hgps::HierarchicalLinearModelDefinition>
+std::unique_ptr<hgps::RiskFactorModelDefinition>
 load_static_risk_model_definition(const poco::json &opt);
 
-/// @brief Loads the lite hierarchical linear regression model definition from a JSON file
+/// @brief Loads a dynamic model from a JSON file
+/// @param opt The parsed model definition JSON file
+/// @return An instance of the hgps::LiteHierarchicalModelDefinition type
+std::unique_ptr<hgps::RiskFactorModelDefinition>
+load_dynamic_risk_model_definition(const poco::json &opt);
+
+/// @brief Loads the old energy balance model definition from a JSON file
 /// @param opt The parsed model definition JSON file
 /// @return An instance of the hgps::LiteHierarchicalModelDefinition type
 std::unique_ptr<hgps::LiteHierarchicalModelDefinition>
-load_dynamic_risk_model_definition(const poco::json &opt);
+load_ebhlm_risk_model_definition(const poco::json &opt);
 
 /// @brief Loads the new energy balance model definition from a JSON file
 /// @param opt The parsed model definition JSON file
 /// @param settings The main model settings
-/// @return An instance of the hgps::LiteHierarchicalModelDefinition type
+/// @return An instance of the hgps::EnergyBalanceModelDefinition type
 std::unique_ptr<hgps::EnergyBalanceModelDefinition>
 load_newebm_risk_model_definition(const poco::json &opt, const poco::SettingsInfo &settings);
+
+/// @brief Loads a risk model definition from a JSON file
+/// @param model_type The type of model ("dynamic"/"static") to load
+/// @param opt The parsed model definition JSON file
+/// @param settings The main model settings
+/// @return A std::pair containing the model type and model definition
+std::pair<hgps::HierarchicalModelType, std::unique_ptr<hgps::RiskFactorModelDefinition>>
+load_risk_model_definition(const std::string &model_type, const poco::json &opt,
+                           const poco::SettingsInfo &settings);
+
+/// @brief Load and parse the model file
+/// @param model_filename The path to the model
+/// @return The parsed JSON
+poco::json load_json(const std::string &model_filename);
 
 /// @brief Registers a risk factor model definition with the repository
 /// @param repository The repository instance to register

--- a/src/HealthGPS.Console/model_parser.h
+++ b/src/HealthGPS.Console/model_parser.h
@@ -19,14 +19,15 @@ hgps::BaselineAdjustment load_baseline_adjustments(const poco::BaselineInfo &inf
 /// @return An instance of the hgps::HierarchicalLinearModelDefinition type
 /// @throw std::invalid_argument if static model is unrecognised
 std::unique_ptr<hgps::RiskFactorModelDefinition>
-load_static_risk_model_definition(const poco::json &opt);
+load_static_risk_model_definition(const std::string &model_name, const poco::json &opt);
 
 /// @brief Loads a dynamic model from a JSON file
 /// @param opt The parsed model definition JSON file
 /// @return An instance of the hgps::RiskFactorModelDefinition type
 /// @throw std::invalid_argument if dynamic model is unrecognised
 std::unique_ptr<hgps::RiskFactorModelDefinition>
-load_dynamic_risk_model_definition(const poco::json &opt);
+load_dynamic_risk_model_definition(const std::string &model_name, const poco::json &opt,
+                                   const poco::SettingsInfo &settings);
 
 /// @brief Loads the old energy balance model definition from a JSON file
 /// @param opt The parsed model definition JSON file

--- a/src/HealthGPS.Console/model_parser.h
+++ b/src/HealthGPS.Console/model_parser.h
@@ -15,6 +15,7 @@ namespace host {
 hgps::BaselineAdjustment load_baseline_adjustments(const poco::BaselineInfo &info);
 
 /// @brief Loads the full hierarchical linear regression model definition from a JSON file
+/// @param model_name The name of the model to use
 /// @param opt The parsed model definition JSON file
 /// @return An instance of the hgps::HierarchicalLinearModelDefinition type
 /// @throw std::invalid_argument if static model is unrecognised
@@ -22,7 +23,9 @@ std::unique_ptr<hgps::RiskFactorModelDefinition>
 load_static_risk_model_definition(const std::string &model_name, const poco::json &opt);
 
 /// @brief Loads a dynamic model from a JSON file
+/// @param model_name The name of the model to use
 /// @param opt The parsed model definition JSON file
+/// @param settings The main model settings
 /// @return An instance of the hgps::RiskFactorModelDefinition type
 /// @throw std::invalid_argument if dynamic model is unrecognised
 std::unique_ptr<hgps::RiskFactorModelDefinition>


### PR DESCRIPTION
I've been playing around with `clang-tidy` as part of my work on #89 and it flagged a problem in `model_parser.cpp`. The issue is that if the JSON file contains an invalid model name, although an error message is printed, the code doesn't abort and will happily register a `nullptr` model definition in the cache.

I think part of the problem is that the `register_risk_factor_model_definitions` is rather long and with a lot of different branches in it, so it's easy to lose track of what the code is doing. I've split up the model loading into a series of separate functions with appropriate error handling in each.