### PR TITLE
ci.yml: Remove unneeded uses for step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,6 @@ jobs:
         id: upload-review
 
       # If there are any comments, fail the check
-      - uses: ZedThree/clang-tidy-review/upload@v0.13.1
       - if: steps.review.outputs.total_comments > 0 && matrix.compiler == 'gcc-default'
         run: exit 1
 


### PR DESCRIPTION
I must have introduced this when copying and pasting at some point. We don't need a "uses" key for this step, so let's remove it.