### PR TITLE
pop_diff_new assertion typo.

### DIFF
--- a/src/HealthGPS/demographic.cpp
+++ b/src/HealthGPS/demographic.cpp
@@ -131,7 +131,7 @@ void PopulationModule::initialise_population(RuntimeContext &context) {
             }
 
             [[maybe_unused]] auto pop_diff_new = pop_size - (index + num_males + num_females);
-            assert(pop_diff == 0);
+            assert(pop_diff_new == 0);
         } else if (pop_diff < 0) {
             pop_diff *= -1;
             if (entry.second.males > entry.second.females) {


### PR DESCRIPTION
One-liner fix. It seems one of the linters (maybe?) didn't apply changes properly, causing an assertion failure in population initialisation (see code). Fixed here.