### PR TITLE
Remove dynamic risk factor mechanism

### DIFF
--- a/example/France.Config.json
+++ b/example/France.Config.json
@@ -91,7 +91,6 @@
                 "range": [13.88, 39.48983]
             }
         ],
-        "dynamic_risk_factor": "",
         "risk_factor_models": {
             "static": "France.HLM.json",
             "dynamic": "France.EBHLM.json"

--- a/example/France.Config.json
+++ b/example/France.Config.json
@@ -49,12 +49,6 @@
                 "range": [-2.316299, 2.296689]
             },
             {
-                "name": "Carbohydrate",
-                "level": 0,
-                "proxy": "",
-                "range": [40.0, 400.0]
-            },
-            {
                 "name": "Sodium",
                 "level": 1,
                 "proxy": "",

--- a/src/HealthGPS.Console/configuration.cpp
+++ b/src/HealthGPS.Console/configuration.cpp
@@ -210,24 +210,6 @@ Configuration load_configuration(CommandOptions &options) {
             }
         }
 
-        if (!config.modelling.dynamic_risk_factor.empty()) {
-            auto found_dynamic_factor = false;
-            for (auto &factor : config.modelling.risk_factors) {
-                if (core::case_insensitive::equals(factor.name,
-                                                   config.modelling.dynamic_risk_factor)) {
-                    found_dynamic_factor = true;
-                    break;
-                }
-            }
-
-            if (!found_dynamic_factor) {
-                fmt::print(
-                    fg(fmt::color::red),
-                    "\nInvalid configuration, dynamic risk factor: {} is not a risk factor.\n",
-                    config.modelling.dynamic_risk_factor);
-            }
-        }
-
         // Run-time
         opt["running"]["start_time"].get_to(config.start_time);
         opt["running"]["stop_time"].get_to(config.stop_time);
@@ -353,21 +335,12 @@ ModelInput create_model_input(core::DataTable &input_table, core::Country countr
 
     auto mapping = std::vector<MappingEntry>();
     for (auto &item : config.modelling.risk_factors) {
-        if (core::case_insensitive::equals(item.name, config.modelling.dynamic_risk_factor)) {
-            if (item.range.empty()) {
-                mapping.emplace_back(
-                    MappingEntry(item.name, item.level, core::Identifier{item.proxy}, true));
-            } else {
-                auto boundary = FactorRange{item.range[0], item.range[1]};
-                mapping.emplace_back(MappingEntry(item.name, item.level,
-                                                  core::Identifier{item.proxy}, boundary, true));
-            }
-        } else if (!item.range.empty()) {
+        if (item.range.empty()) {
+            mapping.emplace_back(MappingEntry{item.name, item.level, core::Identifier{item.proxy}});
+        } else {
             auto boundary = FactorRange{item.range[0], item.range[1]};
             mapping.emplace_back(
                 MappingEntry{item.name, item.level, core::Identifier{item.proxy}, boundary});
-        } else {
-            mapping.emplace_back(MappingEntry{item.name, item.level, core::Identifier{item.proxy}});
         }
     }
 

--- a/src/HealthGPS.Console/configuration.cpp
+++ b/src/HealthGPS.Console/configuration.cpp
@@ -336,11 +336,10 @@ ModelInput create_model_input(core::DataTable &input_table, core::Country countr
     auto mapping = std::vector<MappingEntry>();
     for (auto &item : config.modelling.risk_factors) {
         if (item.range.empty()) {
-            mapping.emplace_back(MappingEntry{item.name, item.level, core::Identifier{item.proxy}});
+            mapping.emplace_back(item.name, item.level, item.proxy);
         } else {
             auto boundary = FactorRange{item.range[0], item.range[1]};
-            mapping.emplace_back(
-                MappingEntry{item.name, item.level, core::Identifier{item.proxy}, boundary});
+            mapping.emplace_back(item.name, item.level, item.proxy, boundary);
         }
     }
 

--- a/src/HealthGPS.Console/jsonparser.cpp
+++ b/src/HealthGPS.Console/jsonparser.cpp
@@ -127,14 +127,12 @@ void from_json(const json &j, RiskFactorInfo &p) {
 
 void to_json(json &j, const ModellingInfo &p) {
     j = json{{"risk_factors", p.risk_factors},
-             {"dynamic_risk_factor", p.dynamic_risk_factor},
              {"risk_factor_models", p.risk_factor_models},
              {"baseline_adjustments", p.baseline_adjustment}};
 }
 
 void from_json(const json &j, ModellingInfo &p) {
     j.at("risk_factors").get_to(p.risk_factors);
-    j.at("dynamic_risk_factor").get_to(p.dynamic_risk_factor);
     j.at("risk_factor_models").get_to(p.risk_factor_models);
     j.at("baseline_adjustments").get_to(p.baseline_adjustment);
 }

--- a/src/HealthGPS.Console/poco.h
+++ b/src/HealthGPS.Console/poco.h
@@ -41,7 +41,6 @@ struct RiskFactorInfo {
 
 struct ModellingInfo {
     std::vector<RiskFactorInfo> risk_factors;
-    std::string dynamic_risk_factor;
     std::unordered_map<std::string, std::string> risk_factor_models;
     BaselineInfo baseline_adjustment;
 };

--- a/src/HealthGPS.Console/poco.h
+++ b/src/HealthGPS.Console/poco.h
@@ -34,7 +34,7 @@ struct BaselineInfo {
 
 struct RiskFactorInfo {
     std::string name;
-    short level{};
+    int level{};
     std::string proxy;
     std::vector<double> range;
 };

--- a/src/HealthGPS.Console/riskmodel.h
+++ b/src/HealthGPS.Console/riskmodel.h
@@ -51,7 +51,7 @@ struct HierarchicalModelInfo {
 
 struct VariableInfo {
     std::string name;
-    short level{};
+    int level{};
     std::string factor;
 };
 

--- a/src/HealthGPS.Tests/HealthGPS.Test.cpp
+++ b/src/HealthGPS.Tests/HealthGPS.Test.cpp
@@ -17,7 +17,7 @@ namespace fs = std::filesystem;
 
 static std::vector<hgps::MappingEntry> create_mapping_entries() {
     using namespace hgps;
-    return std::vector<MappingEntry>{MappingEntry("Year", 0, core::Identifier::empty(), true),
+    return std::vector<MappingEntry>{MappingEntry("Year", 0, core::Identifier::empty()),
                                      MappingEntry("Gender", 0, core::Identifier{"gender"}),
                                      MappingEntry("Age", 0, core::Identifier{"age"}),
                                      MappingEntry("SmokingStatus", 1),

--- a/src/HealthGPS.Tests/HealthGPS.Test.cpp
+++ b/src/HealthGPS.Tests/HealthGPS.Test.cpp
@@ -17,12 +17,12 @@ namespace fs = std::filesystem;
 
 static std::vector<hgps::MappingEntry> create_mapping_entries() {
     using namespace hgps;
-    return std::vector<MappingEntry>{MappingEntry("Year", 0, core::Identifier::empty()),
-                                     MappingEntry("Gender", 0, core::Identifier{"gender"}),
-                                     MappingEntry("Age", 0, core::Identifier{"age"}),
-                                     MappingEntry("SmokingStatus", 1),
-                                     MappingEntry("AlcoholConsumption", 1),
-                                     MappingEntry("BMI", 2)};
+    return {MappingEntry("Year", 0, core::Identifier::empty()),
+            MappingEntry("Gender", 0, core::Identifier{"gender"}),
+            MappingEntry("Age", 0, core::Identifier{"age"}),
+            MappingEntry("SmokingStatus", 1),
+            MappingEntry("AlcoholConsumption", 1),
+            MappingEntry("BMI", 2)};
 }
 
 void create_test_datatable(hgps::core::DataTable &data) {

--- a/src/HealthGPS.Tests/HealthGPS.Test.cpp
+++ b/src/HealthGPS.Tests/HealthGPS.Test.cpp
@@ -17,12 +17,9 @@ namespace fs = std::filesystem;
 
 static std::vector<hgps::MappingEntry> create_mapping_entries() {
     using namespace hgps;
-    return {MappingEntry("Year", 0, core::Identifier::empty()),
-            MappingEntry("Gender", 0, core::Identifier{"gender"}),
-            MappingEntry("Age", 0, core::Identifier{"age"}),
-            MappingEntry("SmokingStatus", 1),
-            MappingEntry("AlcoholConsumption", 1),
-            MappingEntry("BMI", 2)};
+    return {MappingEntry("Gender", 0, core::Identifier{"gender"}),
+            MappingEntry("Age", 0, core::Identifier{"age"}), MappingEntry("SmokingStatus", 1),
+            MappingEntry("AlcoholConsumption", 1), MappingEntry("BMI", 2)};
 }
 
 void create_test_datatable(hgps::core::DataTable &data) {

--- a/src/HealthGPS.Tests/HierarchicalMapping.Test.cpp
+++ b/src/HealthGPS.Tests/HierarchicalMapping.Test.cpp
@@ -4,12 +4,9 @@
 
 static std::vector<hgps::MappingEntry> create_mapping_entries() {
     using namespace hgps;
-    return {MappingEntry("Year", 0, core::Identifier::empty()),
-            MappingEntry("Gender", 0, core::Identifier{"gender"}),
-            MappingEntry("Age", 0, core::Identifier{"age"}),
-            MappingEntry("SmokingStatus", 1),
-            MappingEntry("AlcoholConsumption", 1),
-            MappingEntry("BMI", 2)};
+    return {MappingEntry("Gender", 0, core::Identifier{"gender"}),
+            MappingEntry("Age", 0, core::Identifier{"age"}), MappingEntry("SmokingStatus", 1),
+            MappingEntry("AlcoholConsumption", 1), MappingEntry("BMI", 2)};
 }
 
 TEST(TestHealthGPS_Mapping, CreateEmpty) {
@@ -36,7 +33,7 @@ TEST(TestHealthGPS_Mapping, CreateFull) {
     ASSERT_EQ(exp_size, mapping.size());
     ASSERT_EQ(2, mapping.max_level());
 
-    ASSERT_EQ(3, level_zero.size());
+    ASSERT_EQ(2, level_zero.size());
     ASSERT_EQ(2, level_one.size());
     ASSERT_EQ(1, level_two.size());
 }
@@ -117,7 +114,7 @@ TEST(TestHealthGPS_Mapping, AccessAllLevelEntries) {
     using namespace hgps;
 
     auto entries = create_mapping_entries();
-    std::vector<int> exp_size = {3, 2, 1};
+    std::vector<int> exp_size = {2, 2, 1};
     auto mapping = HierarchicalMapping(std::move(entries));
     auto level_0_entries = mapping.at_level(0);
     auto level_1_entries = mapping.at_level(1);

--- a/src/HealthGPS.Tests/HierarchicalMapping.Test.cpp
+++ b/src/HealthGPS.Tests/HierarchicalMapping.Test.cpp
@@ -4,12 +4,12 @@
 
 static std::vector<hgps::MappingEntry> create_mapping_entries() {
     using namespace hgps;
-    return std::vector<MappingEntry>{MappingEntry("Year", 0, core::Identifier::empty()),
-                                     MappingEntry("Gender", 0, core::Identifier{"gender"}),
-                                     MappingEntry("Age", 0, core::Identifier{"age"}),
-                                     MappingEntry("SmokingStatus", 1),
-                                     MappingEntry("AlcoholConsumption", 1),
-                                     MappingEntry("BMI", 2)};
+    return {MappingEntry("Year", 0, core::Identifier::empty()),
+            MappingEntry("Gender", 0, core::Identifier{"gender"}),
+            MappingEntry("Age", 0, core::Identifier{"age"}),
+            MappingEntry("SmokingStatus", 1),
+            MappingEntry("AlcoholConsumption", 1),
+            MappingEntry("BMI", 2)};
 }
 
 TEST(TestHealthGPS_Mapping, CreateEmpty) {

--- a/src/HealthGPS.Tests/HierarchicalMapping.Test.cpp
+++ b/src/HealthGPS.Tests/HierarchicalMapping.Test.cpp
@@ -4,7 +4,7 @@
 
 static std::vector<hgps::MappingEntry> create_mapping_entries() {
     using namespace hgps;
-    return std::vector<MappingEntry>{MappingEntry("Year", 0, core::Identifier::empty(), true),
+    return std::vector<MappingEntry>{MappingEntry("Year", 0, core::Identifier::empty()),
                                      MappingEntry("Gender", 0, core::Identifier{"gender"}),
                                      MappingEntry("Age", 0, core::Identifier{"age"}),
                                      MappingEntry("SmokingStatus", 1),
@@ -73,22 +73,6 @@ TEST(TestHealthGPS_Mapping, AccessByConstInterator) {
     }
 }
 
-TEST(TestHealthGPS_Mapping, CanIdentifyDynamicFactor) {
-    using namespace hgps;
-
-    auto entries = create_mapping_entries();
-    auto mapping = HierarchicalMapping(std::move(entries));
-    auto dynamic_factor = core::Identifier{"year"};
-
-    for (auto &entry : mapping) {
-        if (entry.key() == dynamic_factor) {
-            ASSERT_TRUE(entry.is_dynamic_factor());
-        } else {
-            ASSERT_FALSE(entry.is_dynamic_factor());
-        }
-    }
-}
-
 TEST(TestHealthGPS_Mapping, AccessAllEntries) {
     using namespace hgps;
 
@@ -129,17 +113,6 @@ TEST(TestHealthGPS_Mapping, AccessSingleEntryThrowForUnknowKey) {
     }
 }
 
-TEST(TestHealthGPS_Mapping, AccessEntriesWithoutDynamicFactor) {
-    using namespace hgps;
-
-    auto entries = create_mapping_entries();
-    auto exp_size = entries.size() - 1u;
-    auto mapping = HierarchicalMapping(std::move(entries));
-    auto all_entries = mapping.entries_without_dynamic();
-
-    ASSERT_EQ(exp_size, all_entries.size());
-}
-
 TEST(TestHealthGPS_Mapping, AccessAllLevelEntries) {
     using namespace hgps;
 
@@ -149,21 +122,6 @@ TEST(TestHealthGPS_Mapping, AccessAllLevelEntries) {
     auto level_0_entries = mapping.at_level(0);
     auto level_1_entries = mapping.at_level(1);
     auto level_2_entries = mapping.at_level(2);
-
-    ASSERT_EQ(exp_size[0], level_0_entries.size());
-    ASSERT_EQ(exp_size[1], level_1_entries.size());
-    ASSERT_EQ(exp_size[2], level_2_entries.size());
-}
-
-TEST(TestHealthGPS_Mapping, AccessLevelEntriesWithoutDynamicFactor) {
-    using namespace hgps;
-
-    auto entries = create_mapping_entries();
-    std::vector<int> exp_size = {2, 2, 1};
-    auto mapping = HierarchicalMapping(std::move(entries));
-    auto level_0_entries = mapping.at_level_without_dynamic(0);
-    auto level_1_entries = mapping.at_level_without_dynamic(1);
-    auto level_2_entries = mapping.at_level_without_dynamic(2);
 
     ASSERT_EQ(exp_size[0], level_0_entries.size());
     ASSERT_EQ(exp_size[1], level_1_entries.size());

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -368,7 +368,7 @@ void AnalysisModule::initialise_output_channels(RuntimeContext &context) {
     }
 
     channels_.push_back("count");
-    for (auto &factor : context.mapping().entries_without_dynamic()) {
+    for (auto &factor : context.mapping().entries()) {
         channels_.emplace_back(factor.key().to_string());
     }
 
@@ -404,4 +404,5 @@ std::unique_ptr<AnalysisModule> build_analysis_module(Repository &repository,
                                             config.settings().age_range(),
                                             config.run().comorbidities);
 }
+
 } // namespace hgps

--- a/src/HealthGPS/energy_balance_hierarchical_model.cpp
+++ b/src/HealthGPS/energy_balance_hierarchical_model.cpp
@@ -37,8 +37,7 @@ void EnergyBalanceHierarchicalModel::update_risk_factors(RuntimeContext &context
             continue;
         }
 
-        auto current_risk_factors =
-            get_current_risk_factors(context.mapping(), entity, context.time_now());
+        auto current_risk_factors = get_current_risk_factors(context.mapping(), entity);
 
         // Model calibrated on previous year's age
         auto model_age = static_cast<int>(entity.age - 1);
@@ -107,15 +106,11 @@ void EnergyBalanceHierarchicalModel::update_risk_factors_exposure(
 
 std::map<core::Identifier, double>
 EnergyBalanceHierarchicalModel::get_current_risk_factors(const HierarchicalMapping &mapping,
-                                                         Person &entity, int time_year) const {
+                                                         Person &entity) const {
     auto entity_risk_factors = std::map<core::Identifier, double>();
     entity_risk_factors.emplace(InterceptKey, entity.get_risk_factor_value(InterceptKey));
     for (const auto &factor : mapping) {
-        if (factor.is_dynamic_factor()) {
-            entity_risk_factors.emplace(factor.key(), time_year - 1);
-        } else {
-            entity_risk_factors.emplace(factor.key(), entity.get_risk_factor_value(factor.key()));
-        }
+        entity_risk_factors.emplace(factor.key(), entity.get_risk_factor_value(factor.key()));
     }
 
     return entity_risk_factors;

--- a/src/HealthGPS/energy_balance_hierarchical_model.h
+++ b/src/HealthGPS/energy_balance_hierarchical_model.h
@@ -67,8 +67,7 @@ class EnergyBalanceHierarchicalModel final : public HierarchicalLinearModel {
         const std::map<core::Identifier, FactorDynamicEquation> &equations);
 
     std::map<core::Identifier, double> get_current_risk_factors(const HierarchicalMapping &mapping,
-                                                                Person &entity,
-                                                                int time_year) const;
+                                                                Person &entity) const;
 
     double sample_normal_with_boundary(Random &random, double mean, double standard_deviation,
                                        double boundary) const;

--- a/src/HealthGPS/hierarchical_model_static.cpp
+++ b/src/HealthGPS/hierarchical_model_static.cpp
@@ -32,7 +32,7 @@ void StaticHierarchicalLinearModel::generate_risk_factors(RuntimeContext &contex
             if (level_factors_cache.contains(level)) {
                 level_factors = level_factors_cache.at(level);
             } else {
-                level_factors = context.mapping().at_level_without_dynamic(level);
+                level_factors = context.mapping().at_level(level);
                 level_factors_cache.emplace(level, level_factors);
             }
 
@@ -54,7 +54,7 @@ void StaticHierarchicalLinearModel::update_risk_factors(RuntimeContext &context)
             if (level_factors_cache.contains(level)) {
                 level_factors = level_factors_cache.at(level);
             } else {
-                level_factors = context.mapping().at_level_without_dynamic(level);
+                level_factors = context.mapping().at_level(level);
                 level_factors_cache.emplace(level, level_factors);
             }
 
@@ -96,7 +96,7 @@ void StaticHierarchicalLinearModel::generate_for_entity(RuntimeContext &context,
     auto determ_risk_factors = std::map<core::Identifier, double>();
     determ_risk_factors.emplace(InterceptKey, entity.get_risk_factor_value(InterceptKey));
     for (const auto &item : context.mapping()) {
-        if (item.level() < level && !item.is_dynamic_factor()) {
+        if (item.level() < level) {
             determ_risk_factors.emplace(item.key(),
                                         entity.get_risk_factor_value(item.entity_key()));
         }

--- a/src/HealthGPS/mapping.cpp
+++ b/src/HealthGPS/mapping.cpp
@@ -7,24 +7,17 @@
 #include <tuple>
 
 namespace hgps {
-hgps::MappingEntry::MappingEntry(std::string name, short level, core::Identifier entity_key,
-                                 FactorRange range, bool dynamic_factor)
-    : name_{name}, name_key_{core::Identifier{name}}, level_{level},
-      entity_key_{std::move(entity_key)}, range_{range}, dynamic_factor_{dynamic_factor} {}
-
-MappingEntry::MappingEntry(std::string name, short level, core::Identifier entity_key,
-                           bool dynamic_factor)
-    : MappingEntry(name, level, entity_key, FactorRange{}, dynamic_factor) {}
 
 MappingEntry::MappingEntry(std::string name, short level, core::Identifier entity_key,
                            FactorRange range)
-    : MappingEntry(name, level, entity_key, range, false) {}
+    : name_{name}, name_key_{core::Identifier{name}}, level_{level},
+      entity_key_{std::move(entity_key)}, range_{range} {}
 
 MappingEntry::MappingEntry(std::string name, short level, core::Identifier entity_key)
-    : MappingEntry(name, level, entity_key, FactorRange{}, false) {}
+    : MappingEntry(name, level, entity_key, FactorRange{}) {}
 
 MappingEntry::MappingEntry(std::string name, short level)
-    : MappingEntry(name, level, core::Identifier::empty(), FactorRange{}, false) {}
+    : MappingEntry(name, level, core::Identifier::empty(), FactorRange{}) {}
 
 const std::string &MappingEntry::name() const noexcept { return name_; }
 
@@ -35,8 +28,6 @@ const core::Identifier &MappingEntry::entity_key() const noexcept {
 }
 
 bool MappingEntry::is_entity() const noexcept { return !entity_key_.is_empty(); }
-
-bool MappingEntry::is_dynamic_factor() const noexcept { return dynamic_factor_; }
 
 const core::Identifier &MappingEntry::key() const noexcept { return name_key_; }
 
@@ -68,14 +59,6 @@ HierarchicalMapping::HierarchicalMapping(std::vector<MappingEntry> &&mapping)
 
 const std::vector<MappingEntry> &HierarchicalMapping::entries() const noexcept { return mapping_; }
 
-std::vector<MappingEntry> HierarchicalMapping::entries_without_dynamic() const noexcept {
-    std::vector<MappingEntry> result;
-    std::copy_if(mapping_.begin(), mapping_.end(), std::back_inserter(result),
-                 [](const auto &elem) { return !elem.is_dynamic_factor(); });
-
-    return result;
-}
-
 std::size_t HierarchicalMapping::size() const noexcept { return mapping_.size(); }
 
 int HierarchicalMapping::max_level() const noexcept {
@@ -105,12 +88,4 @@ std::vector<MappingEntry> HierarchicalMapping::at_level(int level) const noexcep
     return result;
 }
 
-std::vector<MappingEntry> HierarchicalMapping::at_level_without_dynamic(int level) const noexcept {
-    std::vector<MappingEntry> result;
-    std::copy_if(
-        mapping_.cbegin(), mapping_.cend(), std::back_inserter(result),
-        [&level](const auto &elem) { return elem.level() == level && !elem.is_dynamic_factor(); });
-
-    return result;
-}
 } // namespace hgps

--- a/src/HealthGPS/mapping.cpp
+++ b/src/HealthGPS/mapping.cpp
@@ -8,20 +8,20 @@
 
 namespace hgps {
 
-MappingEntry::MappingEntry(std::string name, short level, core::Identifier entity_key,
+MappingEntry::MappingEntry(std::string name, int level, core::Identifier entity_key,
                            FactorRange range)
     : name_{name}, name_key_{core::Identifier{name}}, level_{level},
       entity_key_{std::move(entity_key)}, range_{range} {}
 
-MappingEntry::MappingEntry(std::string name, short level, core::Identifier entity_key)
+MappingEntry::MappingEntry(std::string name, int level, core::Identifier entity_key)
     : MappingEntry(name, level, entity_key, FactorRange{}) {}
 
-MappingEntry::MappingEntry(std::string name, short level)
+MappingEntry::MappingEntry(std::string name, int level)
     : MappingEntry(name, level, core::Identifier::empty(), FactorRange{}) {}
 
 const std::string &MappingEntry::name() const noexcept { return name_; }
 
-short MappingEntry::level() const noexcept { return level_; }
+int MappingEntry::level() const noexcept { return level_; }
 
 const core::Identifier &MappingEntry::entity_key() const noexcept {
     return is_entity() ? entity_key_ : name_key_;

--- a/src/HealthGPS/mapping.h
+++ b/src/HealthGPS/mapping.h
@@ -53,18 +53,18 @@ class MappingEntry {
     /// @param level The hierarchical level
     /// @param entity_key The associated Person property, if exists
     /// @param range The factor range
-    MappingEntry(std::string name, short level, core::Identifier entity_key, FactorRange range);
+    MappingEntry(std::string name, int level, core::Identifier entity_key, FactorRange range);
 
     /// @brief Initialises a new instance of the MappingEntry class
     /// @param name Risk factor name
     /// @param level The hierarchical level
     /// @param entity_key The associated Person property, if exists
-    MappingEntry(std::string name, short level, core::Identifier entity_key);
+    MappingEntry(std::string name, int level, core::Identifier entity_key);
 
     /// @brief Initialises a new instance of the MappingEntry class
     /// @param name Risk factor name
     /// @param level The hierarchical level
-    MappingEntry(std::string name, short level);
+    MappingEntry(std::string name, int level);
 
     /// @brief Gets the factor name
     /// @return Factor name
@@ -72,7 +72,7 @@ class MappingEntry {
 
     /// @brief Gets the factor hierarchical level
     /// @return Factor level
-    short level() const noexcept;
+    int level() const noexcept;
 
     /// @brief Gets the factor unique identification
     /// @return Factor identification
@@ -98,7 +98,7 @@ class MappingEntry {
   private:
     std::string name_;
     core::Identifier name_key_;
-    short level_{};
+    int level_{};
     core::Identifier entity_key_;
     FactorRange range_;
 };

--- a/src/HealthGPS/mapping.h
+++ b/src/HealthGPS/mapping.h
@@ -53,22 +53,6 @@ class MappingEntry {
     /// @param level The hierarchical level
     /// @param entity_key The associated Person property, if exists
     /// @param range The factor range
-    /// @param dynamic_factor indicates whether this is the dynamic factor
-    MappingEntry(std::string name, short level, core::Identifier entity_key, FactorRange range,
-                 bool dynamic_factor);
-
-    /// @brief Initialises a new instance of the MappingEntry class
-    /// @param name Risk factor name
-    /// @param level The hierarchical level
-    /// @param entity_key The associated Person property, if exists
-    /// @param dynamic_factor indicates whether this is the dynamic factor
-    MappingEntry(std::string name, short level, core::Identifier entity_key, bool dynamic_factor);
-
-    /// @brief Initialises a new instance of the MappingEntry class
-    /// @param name Risk factor name
-    /// @param level The hierarchical level
-    /// @param entity_key The associated Person property, if exists
-    /// @param range The factor range
     MappingEntry(std::string name, short level, core::Identifier entity_key, FactorRange range);
 
     /// @brief Initialises a new instance of the MappingEntry class
@@ -102,10 +86,6 @@ class MappingEntry {
     /// @return true, if the factor has an associated property; otherwise, false.
     bool is_entity() const noexcept;
 
-    /// @brief Determine whether this instance is a dynamic factor
-    /// @return true, for the dynamic factor; otherwise, false.
-    bool is_dynamic_factor() const noexcept;
-
     /// @brief Gets the factor allowed values range
     /// @return Factor values range
     const FactorRange &range() const noexcept;
@@ -121,7 +101,6 @@ class MappingEntry {
     short level_{};
     core::Identifier entity_key_;
     FactorRange range_;
-    bool dynamic_factor_;
 };
 
 /// @brief Defines the hierarchical model mapping data type
@@ -142,10 +121,6 @@ class HierarchicalMapping {
     /// @return The mapping entries
     const std::vector<MappingEntry> &entries() const noexcept;
 
-    /// @brief Gets the collection of mapping entries without the dynamic factor
-    /// @return The mapping entries without dynamic factor
-    std::vector<MappingEntry> entries_without_dynamic() const noexcept;
-
     /// @brief Gets the size of the mappings collection
     /// @return The mappings collection size
     std::size_t size() const noexcept;
@@ -164,11 +139,6 @@ class HierarchicalMapping {
     /// @param level The hierarchical level
     /// @return The collection of mappings
     std::vector<MappingEntry> at_level(int level) const noexcept;
-
-    /// @brief Gets the mapping entries at a given hierarchical level without the dynamic factor
-    /// @param level The hierarchical level
-    /// @return The collection of mappings without the dynamic factor
-    std::vector<MappingEntry> at_level_without_dynamic(int level) const noexcept;
 
     /// @brief Gets an iterator to the beginning of the mappings
     /// @return Iterator to the first mapping
@@ -197,4 +167,5 @@ class HierarchicalMapping {
   private:
     std::vector<MappingEntry> mapping_;
 };
+
 } // namespace hgps


### PR DESCRIPTION
Should be straightforward. Just a bunch of deleted code for the unused dynamic risk factor mechanism that is no longer needed in the hierarchical linear regression models.

I'll include @israel-vieira in the loop, if interested. Obviously no commitment to a review expected though!

Fixes #183 
