### PR TITLE
Add `clang-tidy` readability checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,6 +4,7 @@ Checks: >
     clang-diagnostic-*,
     clang-analyzer-*,
     bugprone-*,
+    readability-*,
 
     # Checks to exclude
     -*,
@@ -11,6 +12,11 @@ Checks: >
     -clang-analyzer-fuchsia.*,
     -clang-analyzer-optin.osx.*,
     -bugprone-easily-swappable-parameters,
-    -bugprone-narrowing-conversions
+    -bugprone-narrowing-conversions,
+    -readability-identifier-length,
+    -readability-implicit-bool-conversion,
+    -readability-uppercase-literal-suffix,
+    -readability-magic-numbers,
+    -readability-isolate-declaration,
 FormatStyle: LLVM
 WarningsAsErrors: "*"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,5 +18,8 @@ Checks: >
     -readability-uppercase-literal-suffix,
     -readability-magic-numbers,
     -readability-isolate-declaration,
+CheckOptions:
+    - key: readability-function-cognitive-complexity.IgnoreMacros
+      value: true
 FormatStyle: LLVM
 WarningsAsErrors: "*"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,15 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-osx.*,-clang-analyzer-fuchsia.*,-clang-analyzer-optin.osx.*,bugprone-*,-bugprone-easily-swappable-parameters,-bugprone-narrowing-conversions'
-FormatStyle:     LLVM
-WarningsAsErrors: '*'
-...
+Checks: >
+    # Checks to include
+    clang-diagnostic-*,
+    clang-analyzer-*,
+    bugprone-*,
+
+    # Checks to exclude
+    -clang-analyzer-osx.*,
+    -clang-analyzer-fuchsia.*,
+    -clang-analyzer-optin.osx.*,
+    -bugprone-easily-swappable-parameters,
+    -bugprone-narrowing-conversions
+FormatStyle: LLVM
+WarningsAsErrors: "*"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,7 @@ Checks: >
     bugprone-*,
 
     # Checks to exclude
+    -*,
     -clang-analyzer-osx.*,
     -clang-analyzer-fuchsia.*,
     -clang-analyzer-optin.osx.*,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     rev: v3.0.2
     hooks:
       - id: prettier
-        files: '.*\.(json|yaml|yml)'
+        files: '(.*\.(json|yaml|yml)|\.clang-tidy)$'
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.35.0
     hooks:

--- a/src/HealthGPS.Console/configuration.cpp
+++ b/src/HealthGPS.Console/configuration.cpp
@@ -249,7 +249,7 @@ create_intervention_scenario(SyncChannel &channel, const poco::PolicyScenarioInf
     fmt::print(fg(fmt::color::light_coral), "\nIntervention policy: {}.\n\n", info.identifier);
     auto period = PolicyInterval(info.active_period.start_time, info.active_period.finish_time);
     auto risk_impacts = std::vector<PolicyImpact>{};
-    for (auto &item : info.impacts) {
+    for (const auto &item : info.impacts) {
         risk_impacts.emplace_back(PolicyImpact{core::Identifier{item.risk_factor},
                                                item.impact_value, item.from_age, item.to_age});
     }
@@ -285,7 +285,7 @@ create_intervention_scenario(SyncChannel &channel, const poco::PolicyScenarioInf
         const auto cutoff_age = info.child_cutoff_age.value();
         // NOLINTEND(bugprone-unchecked-optional-access)
 
-        auto &adjustment = info.adjustments.at(0);
+        const auto &adjustment = info.adjustments.at(0);
         auto definition = FoodLabellingDefinition{
             .active_period = period,
             .impacts = risk_impacts,
@@ -329,12 +329,12 @@ std::string expand_environment_variables(const std::string &path) {
     }
 
     std::string variable = post.substr(0, post.find('}'));
-    std::string value = "";
+    std::string value;
 
     post = post.substr(post.find('}') + 1);
-    const char *v = std::getenv(variable.c_str()); // C4996, but safe here.
-    if (v != NULL)
-        value = std::string(v);
+    if (const char *v = std::getenv(variable.c_str())) { // C4996, but safe here.
+        value = v;
+    }
 
     return expand_environment_variables(pre + value + post);
 }

--- a/src/HealthGPS.Console/csvparser.cpp
+++ b/src/HealthGPS.Console/csvparser.cpp
@@ -21,7 +21,7 @@ namespace hc = hgps::core;
 hc::StringDataTableColumnBuilder parse_string_column(const std::string &name,
                                                      const std::vector<std::string> &data) {
     auto builder = hc::StringDataTableColumnBuilder(name);
-    for (auto &value : data) {
+    for (const auto &value : data) {
         // trim string
         auto str = hc::trim(value);
 
@@ -39,7 +39,7 @@ hc::StringDataTableColumnBuilder parse_string_column(const std::string &name,
 hc::IntegerDataTableColumnBuilder parse_int_column(const std::string &name,
                                                    const std::vector<std::string> &data) {
     auto builder = hc::IntegerDataTableColumnBuilder(name);
-    for (auto &value : data) {
+    for (const auto &value : data) {
         if (value.length() > 0) {
             builder.append(std::stoi(value));
             continue;
@@ -54,7 +54,7 @@ hc::IntegerDataTableColumnBuilder parse_int_column(const std::string &name,
 hc::FloatDataTableColumnBuilder parse_float_column(const std::string &name,
                                                    const std::vector<std::string> &data) {
     auto builder = hc::FloatDataTableColumnBuilder(name);
-    for (auto &value : data) {
+    for (const auto &value : data) {
         if (value.length() > 0) {
             builder.append(std::stof(value));
             continue;
@@ -69,7 +69,7 @@ hc::FloatDataTableColumnBuilder parse_float_column(const std::string &name,
 hc::DoubleDataTableColumnBuilder parse_double_column(const std::string &name,
                                                      const std::vector<std::string> &data) {
     auto builder = hc::DoubleDataTableColumnBuilder(name);
-    for (auto &value : data) {
+    for (const auto &value : data) {
         if (value.length() > 0) {
             builder.append(std::stod(value));
             continue;

--- a/src/HealthGPS.Console/event_monitor.cpp
+++ b/src/HealthGPS.Console/event_monitor.cpp
@@ -9,8 +9,7 @@
 
 namespace host {
 EventMonitor::EventMonitor(hgps::EventAggregator &event_bus, ResultWriter &result_writer)
-    : result_writer_{result_writer}, threads_{}, handlers_{}, info_queue_{}, results_queue_{},
-      cancel_source_{} {
+    : result_writer_{result_writer} {
     handlers_.emplace_back(
         event_bus.subscribe(hgps::EventType::runner, std::bind(&EventMonitor::info_event_handler,
                                                                this, std::placeholders::_1)));

--- a/src/HealthGPS.Console/model_parser.cpp
+++ b/src/HealthGPS.Console/model_parser.cpp
@@ -62,7 +62,7 @@ load_static_risk_model_definition(const std::string &model_name, const poco::jso
         opt["levels"].get<std::unordered_map<std::string, poco::HierarchicalLevelInfo>>();
 
     for (const auto &model_item : model_info.models) {
-        auto &at = model_item.second;
+        const auto &at = model_item.second;
 
         std::unordered_map<hgps::core::Identifier, hgps::Coefficient> coeffs;
         for (const auto &pair : at.coefficients) {
@@ -146,7 +146,7 @@ load_ebhlm_risk_model_definition(const poco::json &opt) {
 
     info.variables = opt["Variables"].get<std::vector<poco::VariableInfo>>();
     for (const auto &it : opt["Equations"].items()) {
-        auto &age_key = it.key();
+        const auto &age_key = it.key();
         info.equations.emplace(
             age_key, std::map<std::string, std::vector<poco::FactorDynamicEquationInfo>>());
 

--- a/src/HealthGPS.Console/model_parser.cpp
+++ b/src/HealthGPS.Console/model_parser.cpp
@@ -128,6 +128,7 @@ load_dynamic_risk_model_definition(const std::string &model_name, const poco::js
         fmt::format("Dynamic model name '{}' is not recognised.", model_name)};
 }
 
+// NOLINTBEGIN(readability-function-cognitive-complexity)
 std::unique_ptr<hgps::LiteHierarchicalModelDefinition>
 load_ebhlm_risk_model_definition(const poco::json &opt) {
     MEASURE_FUNCTION();
@@ -203,6 +204,7 @@ load_ebhlm_risk_model_definition(const poco::json &opt) {
     return std::make_unique<hgps::LiteHierarchicalModelDefinition>(
         std::move(equations), std::move(variables), percentage);
 }
+// NOLINTEND(readability-function-cognitive-complexity)
 
 std::unique_ptr<hgps::EnergyBalanceModelDefinition>
 load_newebm_risk_model_definition(const poco::json &opt, const host::Configuration &config) {

--- a/src/HealthGPS.Console/result_file_writer.cpp
+++ b/src/HealthGPS.Console/result_file_writer.cpp
@@ -98,7 +98,7 @@ void ResultFileWriter::write_json_begin(const std::filesystem::path output) {
 
 void ResultFileWriter::write_json_end() { stream_ << "]}"; }
 
-std::string ResultFileWriter::to_json_string(const hgps::ResultEventMessage &message) const {
+std::string ResultFileWriter::to_json_string(const hgps::ResultEventMessage &message) {
     using json = nlohmann::ordered_json;
     using namespace hgps::core;
 
@@ -149,7 +149,7 @@ std::string ResultFileWriter::to_json_string(const hgps::ResultEventMessage &mes
 
 void ResultFileWriter::write_csv_header(const hgps::ResultEventMessage &message) {
     csvstream_ << "source,run,time,gender_name,index_id";
-    for (auto &chan : message.content.series.channels()) {
+    for (const auto &chan : message.content.series.channels()) {
         csvstream_ << "," << chan;
     }
 
@@ -160,8 +160,8 @@ void ResultFileWriter::write_csv_header(const hgps::ResultEventMessage &message)
 void ResultFileWriter::write_csv_channels(const hgps::ResultEventMessage &message) {
     using namespace hgps::core;
 
-    auto sep = ",";
-    auto &series = message.content.series;
+    const auto *sep = ",";
+    const auto &series = message.content.series;
     std::stringstream mss;
     std::stringstream fss;
 
@@ -170,7 +170,7 @@ void ResultFileWriter::write_csv_channels(const hgps::ResultEventMessage &messag
             << "male" << sep << index;
         fss << message.source << sep << message.run_number << sep << message.model_time << sep
             << "female" << sep << index;
-        for (auto &key : series.channels()) {
+        for (const auto &key : series.channels()) {
             mss << sep << series.at(Gender::male, key).at(index);
             fss << sep << series.at(Gender::female, key).at(index);
         }

--- a/src/HealthGPS.Console/result_file_writer.h
+++ b/src/HealthGPS.Console/result_file_writer.h
@@ -41,7 +41,7 @@ class ResultFileWriter final : public ResultWriter {
     void write_json_begin(const std::filesystem::path output);
     void write_json_end();
 
-    std::string to_json_string(const hgps::ResultEventMessage &message) const;
+    static std::string to_json_string(const hgps::ResultEventMessage &message);
     void write_csv_channels(const hgps::ResultEventMessage &message);
     void write_csv_header(const hgps::ResultEventMessage &message);
 };

--- a/src/HealthGPS.Core/datatable.cpp
+++ b/src/HealthGPS.Core/datatable.cpp
@@ -59,7 +59,7 @@ DataTable::column_if_exists(const std::string &name) const {
 std::string DataTable::to_string() const noexcept {
     std::stringstream ss;
     std::size_t longestColumnName = 0;
-    for (auto &col : columns_) {
+    for (const auto &col : columns_) {
         longestColumnName = std::max(longestColumnName, col->name().length());
     }
 
@@ -70,7 +70,7 @@ std::string DataTable::to_string() const noexcept {
     ss << fmt::format("|{:-<{}}|\n", '-', width);
     ss << fmt::format("| {:{}} : {:10} : {:>10} |\n", "Column Name", pad, "Data Type", "# Nulls");
     ss << fmt::format("|{:-<{}}|\n", '-', width);
-    for (auto &col : columns_) {
+    for (const auto &col : columns_) {
         ss << fmt::format("| {:{}} : {:10} : {:10} |\n", col->name(), pad, col->type(),
                           col->null_count());
     }

--- a/src/HealthGPS.Core/string_util.cpp
+++ b/src/HealthGPS.Core/string_util.cpp
@@ -4,12 +4,15 @@
 namespace hgps::core {
 
 std::string trim(std::string value) noexcept {
-    while (!value.empty() && std::isspace(value.back()))
+    while (!value.empty() && std::isspace(value.back())) {
         value.pop_back();
+    }
 
     std::size_t pos = 0;
-    while (pos < value.size() && std::isspace(value[pos]))
+    while (pos < value.size() && std::isspace(value[pos])) {
         ++pos;
+    }
+
     return value.substr(pos);
 }
 
@@ -62,7 +65,8 @@ std::weak_ordering case_insensitive::compare(const std::string_view &left,
     int cmp = to_lower(left).compare(to_lower(right));
     if (cmp < 0) {
         return std::weak_ordering::less;
-    } else if (cmp > 0) {
+    }
+    if (cmp > 0) {
         return std::weak_ordering::greater;
     }
 
@@ -86,8 +90,8 @@ bool case_insensitive::contains(const std::string_view &text,
         return false;
     }
 
-    auto it = std::search(text.cbegin(), text.cend(), str.cbegin(), str.cend(),
-                          [](char a, char b) { return std::tolower(a) == std::tolower(b); });
+    const auto *it = std::search(text.cbegin(), text.cend(), str.cbegin(), str.cend(),
+                                 [](char a, char b) { return std::tolower(a) == std::tolower(b); });
 
     return it != text.cend();
 }
@@ -99,8 +103,9 @@ bool case_insensitive::starts_with(const std::string_view &text,
         return false;
     }
 
-    auto it = std::search(text.cbegin(), text.cbegin() + str.length(), str.cbegin(), str.cend(),
-                          [](char a, char b) { return std::tolower(a) == std::tolower(b); });
+    const auto *it =
+        std::search(text.cbegin(), text.cbegin() + str.length(), str.cbegin(), str.cend(),
+                    [](char a, char b) { return std::tolower(a) == std::tolower(b); });
 
     return it == text.cbegin();
 }

--- a/src/HealthGPS.Core/string_util.cpp
+++ b/src/HealthGPS.Core/string_util.cpp
@@ -90,8 +90,10 @@ bool case_insensitive::contains(const std::string_view &text,
         return false;
     }
 
-    const auto *it = std::search(text.cbegin(), text.cend(), str.cbegin(), str.cend(),
-                                 [](char a, char b) { return std::tolower(a) == std::tolower(b); });
+    // "it" is a pointer type on gcc, but not MSVC, so "const auto *it" won't work
+    // NOLINTNEXTLINE(readability-qualified-auto)
+    const auto it = std::search(text.cbegin(), text.cend(), str.cbegin(), str.cend(),
+                                [](char a, char b) { return std::tolower(a) == std::tolower(b); });
 
     return it != text.cend();
 }
@@ -103,7 +105,9 @@ bool case_insensitive::starts_with(const std::string_view &text,
         return false;
     }
 
-    const auto *it =
+    // "it" is a pointer type on gcc, but not MSVC, so "const auto *it" won't work
+    // NOLINTNEXTLINE(readability-qualified-auto)
+    const auto it =
         std::search(text.cbegin(), text.cbegin() + str.length(), str.cbegin(), str.cend(),
                     [](char a, char b) { return std::tolower(a) == std::tolower(b); });
 

--- a/src/HealthGPS.Core/univariate_summary.cpp
+++ b/src/HealthGPS.Core/univariate_summary.cpp
@@ -122,7 +122,7 @@ void UnivariateSummary::append(const std::optional<double> &option) noexcept {
 }
 
 void UnivariateSummary::append(const std::vector<double> &values) noexcept {
-    for (auto &v : values) {
+    for (const auto &v : values) {
         append(v);
     }
 }

--- a/src/HealthGPS.Datastore/datamanager.cpp
+++ b/src/HealthGPS.Datastore/datamanager.cpp
@@ -176,8 +176,8 @@ DataManager::get_mortality(Country country,
 std::vector<DiseaseInfo> DataManager::get_diseases() const {
     auto result = std::vector<DiseaseInfo>();
     if (index_.contains("diseases")) {
-        auto &registry = index_["diseases"]["registry"];
-        for (auto &item : registry) {
+        const auto &registry = index_["diseases"]["registry"];
+        for (const auto &item : registry) {
             auto info = DiseaseInfo{};
             auto group_str = std::string{};
             auto code_srt = std::string{};
@@ -203,10 +203,10 @@ std::vector<DiseaseInfo> DataManager::get_diseases() const {
 
 DiseaseInfo DataManager::get_disease_info(const core::Identifier &code) const {
     if (index_.contains("diseases")) {
-        auto &registry = index_["diseases"]["registry"];
+        const auto &registry = index_["diseases"]["registry"];
         auto disease_code_str = code.to_string();
         auto info = DiseaseInfo{};
-        for (auto &item : registry) {
+        for (const auto &item : registry) {
             auto item_code_str = std::string{};
             item["id"].get_to(item_code_str);
             if (item_code_str == disease_code_str) {
@@ -297,7 +297,7 @@ RelativeRiskEntity DataManager::get_relative_risk_to_disease(DiseaseInfo source,
     if (index_.contains("diseases")) {
         auto diseases_path = index_["diseases"]["path"].get<std::string>();
         auto disease_folder = index_["diseases"]["disease"]["path"].get<std::string>();
-        auto &risk_node = index_["diseases"]["disease"]["relative_risk"];
+        const auto &risk_node = index_["diseases"]["disease"]["relative_risk"];
         auto default_value = risk_node["to_disease"]["default_value"].get<float>();
 
         auto risk_folder = risk_node["path"].get<std::string>();
@@ -347,15 +347,14 @@ RelativeRiskEntity DataManager::get_relative_risk_to_disease(DiseaseInfo source,
             }
 
             return table;
-        } else {
-            notify_warning(fmt::format("{} to {} relative risk file not found, using default.",
-                                       source_code_str, target_code_str));
         }
+        notify_warning(fmt::format("{} to {} relative risk file not found, using default.",
+                                   source_code_str, target_code_str));
 
         return generate_default_relative_risk_to_disease();
-    } else {
-        notify_warning("index has no 'diseases' entry.");
     }
+
+    notify_warning("index has no 'diseases' entry.");
 
     return RelativeRiskEntity();
 }
@@ -372,7 +371,7 @@ DataManager::get_relative_risk_to_risk_factor(DiseaseInfo source, Gender gender,
     // Creates full file name from store configuration
     auto diseases_path = index_["diseases"]["path"].get<std::string>();
     auto disease_folder = index_["diseases"]["disease"]["path"].get<std::string>();
-    auto &risk_node = index_["diseases"]["disease"]["relative_risk"];
+    const auto &risk_node = index_["diseases"]["disease"]["relative_risk"];
 
     auto risk_folder = risk_node["path"].get<std::string>();
     auto file_folder = risk_node["to_risk_factor"]["path"].get<std::string>();
@@ -426,9 +425,9 @@ CancerParameterEntity DataManager::get_disease_parameter(DiseaseInfo info, Count
     auto disease_path = index_["diseases"]["path"].get<std::string>();
     auto disease_folder = index_["diseases"]["disease"]["path"].get<std::string>();
 
-    auto &params_node = index_["diseases"]["disease"]["parameters"];
+    const auto &params_node = index_["diseases"]["disease"]["parameters"];
     auto params_folder = params_node["path"].get<std::string>();
-    auto &params_files = params_node["files"];
+    const auto &params_files = params_node["files"];
 
     // Tokenized folder name X{info.code}X
     auto info_code_str = info.code.to_string();
@@ -444,7 +443,7 @@ CancerParameterEntity DataManager::get_disease_parameter(DiseaseInfo info, Count
         return table;
     }
 
-    for (auto &file : params_files.items()) {
+    for (const auto &file : params_files.items()) {
         auto file_name = (files_folder / file.value().get<std::string>());
         if (!std::filesystem::exists(file_name)) {
             notify_warning(fmt::format("{}, {} parameters file: '{}' not found.", info_code_str,
@@ -567,7 +566,7 @@ DiseaseAnalysisEntity DataManager::get_disease_analysis(const Country country) c
 
     auto analysis_folder = index_["analysis"]["path"].get<std::string>();
     auto disability_filename = index_["analysis"]["disability_file_name"].get<std::string>();
-    auto &cost_node = index_["analysis"]["cost_of_disease"];
+    const auto &cost_node = index_["analysis"]["cost_of_disease"];
 
     auto local_root_path = (root_ / analysis_folder);
     disability_filename = (local_root_path / disability_filename).string();
@@ -595,7 +594,7 @@ DiseaseAnalysisEntity DataManager::get_disease_analysis(const Country country) c
 RelativeRiskEntity DataManager::generate_default_relative_risk_to_disease() const {
     if (index_.contains("diseases")) {
         auto age_limits = index_["diseases"]["age_limits"].get<std::vector<int>>();
-        auto &to_disease = index_["diseases"]["disease"]["relative_risk"]["to_disease"];
+        const auto &to_disease = index_["diseases"]["disease"]["relative_risk"]["to_disease"];
         auto default_value = to_disease["default_value"].get<float>();
 
         auto table = RelativeRiskEntity();
@@ -607,9 +606,8 @@ RelativeRiskEntity DataManager::generate_default_relative_risk_to_disease() cons
         }
 
         return table;
-    } else {
-        notify_warning("index has no 'diseases' entry.");
     }
+    notify_warning("index has no 'diseases' entry.");
 
     return RelativeRiskEntity();
 }
@@ -683,7 +681,7 @@ std::vector<LifeExpectancyItem> DataManager::load_life_expectancy(const Country 
 }
 
 std::string DataManager::replace_string_tokens(std::string source,
-                                               std::vector<std::string> tokens) const {
+                                               std::vector<std::string> tokens) {
     std::string output = source;
     std::size_t tk_end = 0;
     for (auto &tk : tokens) {
@@ -702,9 +700,9 @@ std::string DataManager::replace_string_tokens(std::string source,
 
 std::map<std::string, std::size_t>
 DataManager::create_fields_index_mapping(const std::vector<std::string> &column_names,
-                                         const std::vector<std::string> fields) const {
+                                         const std::vector<std::string> fields) {
     auto mapping = std::map<std::string, std::size_t>();
-    for (auto &field : fields) {
+    for (const auto &field : fields) {
         auto field_index = core::case_insensitive::index_of(column_names, field);
         if (field_index < 0) {
             throw std::out_of_range(

--- a/src/HealthGPS.Datastore/datamanager.cpp
+++ b/src/HealthGPS.Datastore/datamanager.cpp
@@ -700,7 +700,7 @@ std::string DataManager::replace_string_tokens(std::string source,
 
 std::map<std::string, std::size_t>
 DataManager::create_fields_index_mapping(const std::vector<std::string> &column_names,
-                                         const std::vector<std::string> fields) {
+                                         const std::vector<std::string> &fields) {
     auto mapping = std::map<std::string, std::size_t>();
     for (const auto &field : fields) {
         auto field_index = core::case_insensitive::index_of(column_names, field);

--- a/src/HealthGPS.Datastore/datamanager.h
+++ b/src/HealthGPS.Datastore/datamanager.h
@@ -93,7 +93,7 @@ class DataManager : public Datastore {
 
     static std::map<std::string, std::size_t>
     create_fields_index_mapping(const std::vector<std::string> &column_names,
-                                const std::vector<std::string> fields);
+                                const std::vector<std::string> &fields);
 
     void notify_warning(const std::string_view message) const;
 };

--- a/src/HealthGPS.Datastore/datamanager.h
+++ b/src/HealthGPS.Datastore/datamanager.h
@@ -53,7 +53,7 @@ class DataManager : public Datastore {
 
     DiseaseInfo get_disease_info(const core::Identifier &code) const override;
 
-    DiseaseEntity get_disease(DiseaseInfo code, Country country) const override;
+    DiseaseEntity get_disease(DiseaseInfo info, Country country) const override;
 
     RelativeRiskEntity get_relative_risk_to_disease(DiseaseInfo source,
                                                     DiseaseInfo target) const override;
@@ -89,11 +89,11 @@ class DataManager : public Datastore {
 
     std::vector<LifeExpectancyItem> load_life_expectancy(const Country &country) const;
 
-    std::string replace_string_tokens(std::string source, std::vector<std::string> tokens) const;
+    static std::string replace_string_tokens(std::string source, std::vector<std::string> tokens);
 
-    std::map<std::string, std::size_t>
+    static std::map<std::string, std::size_t>
     create_fields_index_mapping(const std::vector<std::string> &column_names,
-                                const std::vector<std::string> fields) const;
+                                const std::vector<std::string> fields);
 
     void notify_warning(const std::string_view message) const;
 };

--- a/src/HealthGPS.Tests/Configuration.Test.cpp
+++ b/src/HealthGPS.Tests/Configuration.Test.cpp
@@ -101,7 +101,7 @@ class TempDir {
     mutable std::mt19937 rnd_;
     std::filesystem::path path_;
 
-    std::filesystem::path createTempDir() {
+    static std::filesystem::path createTempDir() {
         const auto rnd = std::random_device()();
         const auto path =
             std::filesystem::path{::testing::TempDir()} / "hgps" / std::to_string(rnd);
@@ -623,8 +623,8 @@ TEST_F(ConfigParsingFixture, LoadRunningInfo) {
     }
 
     // If any of the required keys are invalid then an error should be thrown
-    for (const auto key : {"start_time", "stop_time", "trial_runs", "sync_timeout_ms", "diseases",
-                           "seed", "interventions"}) {
+    for (const auto *const key : {"start_time", "stop_time", "trial_runs", "sync_timeout_ms",
+                                  "diseases", "seed", "interventions"}) {
         auto config = create_config();
         auto j = valid_running_info;
         j["running"][key] = nullptr; // None of the values should be null
@@ -649,7 +649,7 @@ TEST_F(ConfigParsingFixture, LoadOutputInfo) {
     }
 
     // If any of the required keys are invalid then an error should be thrown
-    for (const auto key : {"folder", "file_name", "comorbidities"}) {
+    for (const auto *const key : {"folder", "file_name", "comorbidities"}) {
         auto config = create_config();
         auto j = valid_output_info;
         j["output"][key] = nullptr; // None of the values should be null

--- a/src/HealthGPS.Tests/Core.Test.cpp
+++ b/src/HealthGPS.Tests/Core.Test.cpp
@@ -9,7 +9,7 @@ TEST(TestCore, CreateCountry) {
     using namespace hgps::core;
 
     unsigned short id = 826;
-    auto uk = "United Kingdom";
+    const auto *uk = "United Kingdom";
 
     auto c = Country{.code = id, .name = uk, .alpha2 = "GB", .alpha3 = "GBR"};
 
@@ -132,7 +132,7 @@ TEST(TestCore, TableColumnIterator) {
                                          {true, true, true, false, true, false, true});
 
     double loop_sum = 0.0;
-    for (auto &item : dbl_col) {
+    for (const auto &item : dbl_col) {
         loop_sum += item.value_or(0.0);
     }
 
@@ -172,8 +172,8 @@ TEST(TestCore, CreateDataTable) {
     table.add(int_builder.build());
 
     // Casting to columns type
-    auto &col = table.column("Integer");
-    auto &int_col = static_cast<const IntegerDataTableColumn &>(col);
+    const auto &col = table.column("Integer");
+    const auto &int_col = static_cast<const IntegerDataTableColumn &>(col);
 
     auto slow_value = std::any_cast<int>(col.value(1));
     auto safe_value = int_col.value_safe(1);
@@ -220,7 +220,7 @@ TEST(TestCore, DataTableFailDuplicateColumn) {
 TEST(TestCore, CaseInsensitiveString) {
     using namespace hgps::core;
 
-    auto source = "The quick brown fox jumps over the lazy dog";
+    const auto *source = "The quick brown fox jumps over the lazy dog";
 
     ASSERT_TRUE(case_insensitive::equals("fox", "Fox"));
     ASSERT_TRUE(case_insensitive::contains(source, "FOX"));
@@ -294,10 +294,10 @@ TEST(TestCore, CaseInsensitiveMap) {
 TEST(TestCore, SplitDelimitedString) {
     using namespace hgps::core;
 
-    auto source = "The quick brown fox jumps over the lazy dog";
+    const auto *source = "The quick brown fox jumps over the lazy dog";
     auto parts = split_string(source, " ");
 
-    auto csv_source = "The,quick,brown,fox,jumps,over,the,lazy,dog";
+    const auto *csv_source = "The,quick,brown,fox,jumps,over,the,lazy,dog";
     auto csv_parts = split_string(csv_source, ",");
 
     ASSERT_EQ(9, parts.size());

--- a/src/HealthGPS.Tests/EventAggregator.Test.cpp
+++ b/src/HealthGPS.Tests/EventAggregator.Test.cpp
@@ -7,13 +7,13 @@
 #include "HealthGPS/runner_message.h"
 
 struct TestHandler {
-    void handler_event(std::shared_ptr<hgps::EventMessage>) { counter++; }
+    void handler_event(std::shared_ptr<hgps::EventMessage> /*unused*/) { counter++; }
 
     int counter{};
 };
 
 static int global_counter = 0;
-static void free_handler_event(std::shared_ptr<hgps::EventMessage>) { global_counter++; }
+static void free_handler_event(std::shared_ptr<hgps::EventMessage> /*unused*/) { global_counter++; }
 
 TEST(TestHealthGPS_EventBus, CreateHandlerIdentifier) {
     using namespace hgps;

--- a/src/HealthGPS.Tests/HealthGPS.Test.cpp
+++ b/src/HealthGPS.Tests/HealthGPS.Test.cpp
@@ -37,10 +37,11 @@ void create_test_datatable(hgps::core::DataTable &data) {
         gender_builder.append(gender_values[i]);
         age_builder.append(age_values[i]);
         edu_builder.append(edu_values[i]);
-        if (std::isnan(inc_values[i]))
+        if (std::isnan(inc_values[i])) {
             inc_builder.append_null();
-        else
+        } else {
             inc_builder.append(inc_values[i]);
+        }
     }
 
     data.add(gender_builder.build());
@@ -272,10 +273,11 @@ TEST(TestHealthGPS, ModuleFactoryRegistry) {
     auto count = 10U;
     auto builder = core::FloatDataTableColumnBuilder("Test");
     for (size_t i = 0; i < count; i++) {
-        if ((i % 2) == 0)
+        if ((i % 2) == 0) {
             builder.append(i * 2.5f);
-        else
+        } else {
             builder.append_null();
+        }
     }
 
     auto data = core::DataTable();
@@ -310,7 +312,7 @@ TEST(TestHealthGPS, ModuleFactoryRegistry) {
                              });
 
     auto base_module = factory.create(SimulationModuleType::Analysis, config);
-    auto country_mod = static_cast<CountryModule *>(base_module.get());
+    auto *country_mod = static_cast<CountryModule *>(base_module.get());
     country_mod->execute("print");
 
     ASSERT_EQ(SimulationModuleType::Analysis, country_mod->type());
@@ -363,9 +365,9 @@ TEST(TestHealthGPS, CreateDemographicModule) {
 
     auto pop_module = build_population_module(repository, config);
     auto total_pop = pop_module->get_total_population_size(config.start_time());
-    auto &pop_dist = pop_module->get_population_distribution(config.start_time());
+    const auto &pop_dist = pop_module->get_population_distribution(config.start_time());
     auto sum_dist = 0.0f;
-    for (auto &pair : pop_dist) {
+    for (const auto &pair : pop_dist) {
         sum_dist += pair.second.total();
     }
     ASSERT_EQ(SimulationModuleType::Demographic, pop_module->type());

--- a/src/HealthGPS.Tests/HierarchicalMapping.Test.cpp
+++ b/src/HealthGPS.Tests/HierarchicalMapping.Test.cpp
@@ -67,7 +67,7 @@ TEST(TestHealthGPS_Mapping, AccessAllEntries) {
     auto entries = create_mapping_entries();
     auto exp_size = entries.size();
     auto mapping = HierarchicalMapping(std::move(entries));
-    auto &all_entries = mapping.entries();
+    const auto &all_entries = mapping.entries();
 
     ASSERT_EQ(exp_size, all_entries.size());
 }

--- a/src/HealthGPS.Tests/Interval.Test.cpp
+++ b/src/HealthGPS.Tests/Interval.Test.cpp
@@ -82,7 +82,7 @@ TEST(TestCore_Interval, ParseInteger) {
     auto upper = 10;
 
     auto animal = IntegerInterval{lower, upper};
-    auto any_str = "TheFox";
+    const auto *any_str = "TheFox";
     auto cat = parse_integer_interval(animal.to_string());
     ASSERT_EQ(animal, cat);
     ASSERT_THROW(parse_integer_interval(any_str), std::invalid_argument);
@@ -94,7 +94,7 @@ TEST(TestCore_Interval, ParseFloat) {
     auto upper = 10.f;
 
     auto animal = FloatInterval{lower, upper};
-    auto any_str = "TheFox";
+    const auto *any_str = "TheFox";
     auto cat = parse_float_interval(animal.to_string());
     ASSERT_EQ(animal, cat);
     ASSERT_THROW(parse_float_interval(any_str), std::invalid_argument);
@@ -106,7 +106,7 @@ TEST(TestCore_Interval, ParseDouble) {
     auto upper = 10.0;
 
     auto animal = DoubleInterval{lower, upper};
-    auto any_str = "TheFox";
+    const auto *any_str = "TheFox";
     auto cat = parse_double_interval(animal.to_string());
     ASSERT_EQ(animal, cat);
     ASSERT_THROW(parse_double_interval(any_str), std::invalid_argument);

--- a/src/HealthGPS.Tests/Repository.Test.cpp
+++ b/src/HealthGPS.Tests/Repository.Test.cpp
@@ -19,7 +19,7 @@ class RepositoryTest : public ::testing::Test {
 };
 
 TEST_F(RepositoryTest, CreateRepository) {
-    auto &diseases = repository.get_diseases();
+    const auto &diseases = repository.get_diseases();
     ASSERT_GT(diseases.size(), 0);
 }
 
@@ -27,14 +27,14 @@ TEST_F(RepositoryTest, DiseaseInfoIsCached) {
     using namespace std::chrono;
 
     auto start = steady_clock::now();
-    auto &diseases_cold = repository.get_diseases();
+    const auto &diseases_cold = repository.get_diseases();
     auto stop = steady_clock::now();
     auto duration_cold = (stop - start);
 
     auto number_of_trials = 13;
     for (auto i = 0; i < number_of_trials; i++) {
         start = steady_clock::now();
-        auto &diseases_hot = repository.get_diseases();
+        const auto &diseases_hot = repository.get_diseases();
         stop = steady_clock::now();
         auto duration_hot = (stop - start);
 
@@ -45,9 +45,9 @@ TEST_F(RepositoryTest, DiseaseInfoIsCached) {
 
 TEST_F(RepositoryTest, DiseaseInfoIsCaseInsensitive) {
     using namespace hgps;
-    auto &all_diseases = repository.get_diseases();
+    const auto &all_diseases = repository.get_diseases();
     ASSERT_GT(all_diseases.size(), 0);
-    auto &disease = all_diseases.at(0);
+    const auto &disease = all_diseases.at(0);
 
     auto code_title = disease.code.to_string();
     if (std::islower(code_title.at(0))) {

--- a/src/HealthGPS.Tests/TestMain.cpp
+++ b/src/HealthGPS.Tests/TestMain.cpp
@@ -27,7 +27,8 @@ int main(int argc, char **argv) {
     if (result.count("help")) {
         std::cout << options.help() << std::endl;
         return EXIT_SUCCESS;
-    } else if (result.count("storage")) {
+    }
+    if (result.count("storage")) {
         storage_path = std::filesystem::path{result["storage"].as<std::string>()};
         if (storage_path.is_relative()) {
             storage_path = std::filesystem::absolute(storage_path);

--- a/src/HealthGPS.Tests/data_config.cpp
+++ b/src/HealthGPS.Tests/data_config.cpp
@@ -3,7 +3,7 @@
 #include <filesystem>
 #include <stdexcept>
 
-std::string test_datastore_path = "";
+std::string test_datastore_path;
 
 std::string resolve_path(const std::string &relative_path) {
     namespace fs = std::filesystem;

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -17,7 +17,7 @@ inline constexpr double DALY_UNITS = 100'000.0;
 AnalysisModule::AnalysisModule(AnalysisDefinition &&definition, WeightModel &&classifier,
                                const core::IntegerInterval age_range, unsigned int comorbidities)
     : definition_{std::move(definition)}, weight_classifier_{std::move(classifier)},
-      residual_disability_weight_{create_age_gender_table<double>(age_range)}, channels_{},
+      residual_disability_weight_{create_age_gender_table<double>(age_range)},
       comorbidities_{comorbidities} {}
 
 SimulationModuleType AnalysisModule::type() const noexcept {
@@ -27,7 +27,7 @@ SimulationModuleType AnalysisModule::type() const noexcept {
 const std::string &AnalysisModule::name() const noexcept { return name_; }
 
 void AnalysisModule::initialise_population(RuntimeContext &context) {
-    auto &age_range = context.age_range();
+    const auto &age_range = context.age_range();
     auto expected_sum = create_age_gender_table<double>(age_range);
     auto expected_count = create_age_gender_table<int>(age_range);
     auto &pop = context.population();
@@ -290,12 +290,12 @@ void hgps::AnalysisModule::calculate_population_statistics(RuntimeContext &conte
         }
 
         series(gender, "count").at(age)++;
-        for (auto &factor : context.mapping().entries()) {
+        for (const auto &factor : context.mapping().entries()) {
             series(gender, factor.key().to_string()).at(age) +=
                 entity.get_risk_factor_value(factor.key());
         }
 
-        for (auto &item : entity.diseases) {
+        for (const auto &item : entity.diseases) {
             if (item.second.status == DiseaseStatus::active) {
                 series(gender, item.first.to_string()).at(age)++;
             }
@@ -318,7 +318,7 @@ void hgps::AnalysisModule::calculate_population_statistics(RuntimeContext &conte
 
     // Calculate in-place averages
     for (auto index = min_age; index <= max_age; index++) {
-        for (auto &chan : series.channels()) {
+        for (const auto &chan : series.channels()) {
             if (chan == "count") {
                 continue;
             }
@@ -368,11 +368,11 @@ void AnalysisModule::initialise_output_channels(RuntimeContext &context) {
     }
 
     channels_.push_back("count");
-    for (auto &factor : context.mapping().entries()) {
+    for (const auto &factor : context.mapping().entries()) {
         channels_.emplace_back(factor.key().to_string());
     }
 
-    for (auto &disease : context.diseases()) {
+    for (const auto &disease : context.diseases()) {
         channels_.emplace_back(disease.code.to_string());
     }
 

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -101,6 +101,7 @@ void AnalysisModule::publish_result_message(RuntimeContext &context) const {
         context.identifier(), context.current_run(), context.time_now(), result));
 }
 
+// NOLINTBEGIN(readability-function-cognitive-complexity)
 void AnalysisModule::calculate_historical_statistics(RuntimeContext &context,
                                                      ModelResult &result) const {
     auto risk_factors = std::map<core::Identifier, std::map<core::Gender, double>>();
@@ -211,6 +212,7 @@ void AnalysisModule::calculate_historical_statistics(RuntimeContext &context,
 
     result.indicators = daly_handle.get();
 }
+// NOLINTEND(readability-function-cognitive-complexity)
 
 double AnalysisModule::calculate_disability_weight(const Person &entity) const {
     auto sum = 1.0;
@@ -258,6 +260,7 @@ DALYsIndicator AnalysisModule::calculate_dalys(Population &population, unsigned 
                           .disability_adjusted_life_years = yll + yld};
 }
 
+// NOLINTBEGIN(readability-function-cognitive-complexity)
 void hgps::AnalysisModule::calculate_population_statistics(RuntimeContext &context,
                                                            DataSeries &series) const {
     using namespace core;
@@ -341,6 +344,7 @@ void hgps::AnalysisModule::calculate_population_statistics(RuntimeContext &conte
         }
     }
 }
+// NOLINTEND(readability-function-cognitive-complexity)
 
 void AnalysisModule::classify_weight(hgps::DataSeries &series, const hgps::Person &entity) const {
     auto weight_class = weight_classifier_.classify_weight(entity);

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -357,7 +357,7 @@ void AnalysisModule::classify_weight(hgps::DataSeries &series, const hgps::Perso
         series(entity.gender, "above_weight").at(entity.age)++;
         break;
     default:
-        throw std::logic_error("Unknow weight classification category.");
+        throw std::logic_error("Unknown weight classification category.");
         break;
     }
 }

--- a/src/HealthGPS/converter.cpp
+++ b/src/HealthGPS/converter.cpp
@@ -21,7 +21,7 @@ core::Gender StoreConverter::to_gender(const std::string name) {
 DiseaseTable StoreConverter::to_disease_table(const core::DiseaseEntity &entity) {
     auto measures = entity.measures;
     auto data = std::map<int, std::map<core::Gender, DiseaseMeasure>>();
-    for (auto &v : entity.items) {
+    for (const auto &v : entity.items) {
         data[v.with_age][v.gender] = DiseaseMeasure(v.measures);
     }
 
@@ -45,7 +45,7 @@ FloatAgeGenderTable StoreConverter::to_relative_risk_table(const core::RelativeR
     auto rows = std::vector<int>(num_rows);
     auto data = core::FloatArray2D(num_rows, num_cols);
     for (size_t i = 0; i < num_rows; i++) {
-        auto &row = entity.rows[i];
+        const auto &row = entity.rows[i];
         rows[i] = static_cast<int>(row[0]);
         for (size_t j = 1; j < row.size(); j++) {
             data(i, j - 1) = row[j];
@@ -78,7 +78,7 @@ RelativeRiskLookup StoreConverter::to_relative_risk_lookup(const core::RelativeR
 
 RelativeRisk create_relative_risk(const RelativeRiskInfo &info) {
     RelativeRisk result;
-    for (auto &item : info.inputs.diseases()) {
+    for (const auto &item : info.inputs.diseases()) {
         auto table = info.manager.get_relative_risk_to_disease(info.disease, item);
         if (!table.empty() && !table.is_default_value) {
             result.diseases.emplace(item.code, StoreConverter::to_relative_risk_table(table));
@@ -141,12 +141,12 @@ StoreConverter::to_analysis_definition(const core::DiseaseAnalysisEntity &entity
 LifeTable StoreConverter::to_life_table(const std::vector<core::BirthItem> &births,
                                         const std::vector<core::MortalityItem> &deaths) {
     auto table_births = std::map<int, Birth>{};
-    for (auto &item : births) {
+    for (const auto &item : births) {
         table_births.emplace(item.at_time, Birth{item.number, item.sex_ratio});
     }
 
     auto table_deaths = std::map<int, std::map<int, Mortality>>{};
-    for (auto &item : deaths) {
+    for (const auto &item : deaths) {
         table_deaths[item.at_time].emplace(item.with_age, Mortality(item.males, item.females));
     }
 
@@ -155,19 +155,19 @@ LifeTable StoreConverter::to_life_table(const std::vector<core::BirthItem> &birt
 
 DiseaseParameter StoreConverter::to_disease_parameter(const core::CancerParameterEntity &entity) {
     auto distribution = ParameterLookup{};
-    for (auto &item : entity.prevalence_distribution) {
+    for (const auto &item : entity.prevalence_distribution) {
         distribution.emplace(item.value, DoubleGenderValue(item.male, item.female));
     }
 
     auto survival = ParameterLookup{};
-    for (auto &item : entity.survival_rate) {
+    for (const auto &item : entity.survival_rate) {
         survival.emplace(item.value, DoubleGenderValue(item.male, item.female));
     }
 
     // Make sure that the deaths table is zero based!
     auto deaths = ParameterLookup{};
     auto offset = entity.death_weight.front().value;
-    for (auto &item : entity.death_weight) {
+    for (const auto &item : entity.death_weight) {
         deaths.emplace(item.value - offset, DoubleGenderValue(item.male, item.female));
     }
 
@@ -176,7 +176,7 @@ DiseaseParameter StoreConverter::to_disease_parameter(const core::CancerParamete
 
 LmsDefinition StoreConverter::to_lms_definition(const std::vector<core::LmsDataRow> &dataset) {
     auto lms_dataset = LmsDataset{};
-    for (auto &row : dataset) {
+    for (const auto &row : dataset) {
         lms_dataset[row.age][row.gender] =
             LmsRecord{.lambda = row.lambda, .mu = row.mu, .sigma = row.sigma};
     }

--- a/src/HealthGPS/data_series.cpp
+++ b/src/HealthGPS/data_series.cpp
@@ -5,7 +5,7 @@
 #include <stdexcept>
 
 namespace hgps {
-DataSeries::DataSeries(std::size_t sample_size) : sample_size_{sample_size}, channels_{}, data_{} {
+DataSeries::DataSeries(std::size_t sample_size) : sample_size_{sample_size} {
     data_.emplace(core::Gender::male, std::map<std::string, std::vector<double>>{});
     data_.emplace(core::Gender::female, std::map<std::string, std::vector<double>>{});
 }
@@ -36,7 +36,7 @@ void DataSeries::add_channel(std::string key) {
 }
 
 void DataSeries::add_channels(const std::vector<std::string> &keys) {
-    for (auto &item : keys) {
+    for (const auto &item : keys) {
         add_channel(item);
     }
 }

--- a/src/HealthGPS/default_cancer_model.cpp
+++ b/src/HealthGPS/default_cancer_model.cpp
@@ -45,7 +45,7 @@ void DefaultCancerModel::initialise_disease_status(RuntimeContext &context) {
 }
 
 void DefaultCancerModel::initialise_average_relative_risk(RuntimeContext &context) {
-    auto &age_range = context.age_range();
+    const auto &age_range = context.age_range();
     auto sum = create_age_gender_table<double>(age_range);
     auto count = create_age_gender_table<double>(age_range);
     auto &pop = context.population();
@@ -90,7 +90,7 @@ void DefaultCancerModel::update_disease_status(RuntimeContext &context) {
 }
 
 double DefaultCancerModel::get_excess_mortality(const Person &entity) const noexcept {
-    auto &disease_info = entity.diseases.at(disease_type());
+    const auto &disease_info = entity.diseases.at(disease_type());
     auto max_onset = definition_.get().parameters().max_time_since_onset;
     if (disease_info.time_since_onset < 0 || disease_info.time_since_onset >= max_onset) {
         return 0.0;
@@ -98,7 +98,7 @@ double DefaultCancerModel::get_excess_mortality(const Person &entity) const noex
 
     auto mortality_id = definition_.get().table().at(MeasureKey::mortality);
     auto excess_mortality = definition_.get().table()(entity.age, entity.gender).at(mortality_id);
-    auto &death_weight =
+    const auto &death_weight =
         definition_.get().parameters().death_weight.at(disease_info.time_since_onset);
     if (entity.gender == core::Gender::male) {
         return excess_mortality * death_weight.males;
@@ -108,7 +108,7 @@ double DefaultCancerModel::get_excess_mortality(const Person &entity) const noex
 }
 
 DoubleAgeGenderTable DefaultCancerModel::calculate_average_relative_risk(RuntimeContext &context) {
-    auto &age_range = context.age_range();
+    const auto &age_range = context.age_range();
     auto sum = create_age_gender_table<double>(age_range);
     auto count = create_age_gender_table<double>(age_range);
     auto &pop = context.population();
@@ -159,13 +159,13 @@ double DefaultCancerModel::calculate_combined_relative_risk(const Person &entity
 
 double DefaultCancerModel::calculate_relative_risk_for_risk_factors(const Person &entity) const {
     auto relative_risk_value = 1.0;
-    auto &relative_factors = definition_.get().relative_risk_factors();
-    for (auto &factor : entity.risk_factors) {
+    const auto &relative_factors = definition_.get().relative_risk_factors();
+    for (const auto &factor : entity.risk_factors) {
         if (!relative_factors.contains(factor.first)) {
             continue;
         }
 
-        auto &lut = relative_factors.at(factor.first).at(entity.gender);
+        const auto &lut = relative_factors.at(factor.first).at(entity.gender);
         auto factor_value =
             weight_classifier_.adjust_risk_factor_value(entity, factor.first, factor.second);
         auto lookup_value = static_cast<float>(factor_value);
@@ -180,8 +180,8 @@ double DefaultCancerModel::calculate_relative_risk_for_diseases(const Person &en
                                                                 const int &start_time,
                                                                 const int &time_now) const {
     auto relative_risk_value = 1.0;
-    auto &lut = definition_.get().relative_risk_diseases();
-    for (auto &disease : entity.diseases) {
+    const auto &lut = definition_.get().relative_risk_diseases();
+    for (const auto &disease : entity.diseases) {
         if (!lut.contains(disease.first)) {
             continue;
         }
@@ -228,7 +228,7 @@ void DefaultCancerModel::update_incidence_cases(RuntimeContext &context) {
         }
 
         if (entity.age == 0) {
-            if (entity.diseases.size() > 0) {
+            if (!entity.diseases.empty()) {
                 entity.diseases.clear(); // Should not have nay disease at birth!
             }
 
@@ -266,11 +266,11 @@ double DefaultCancerModel::calculate_incidence_probability(const Person &entity,
 int DefaultCancerModel::calculate_time_since_onset(RuntimeContext &context,
                                                    const core::Gender &gender) const {
 
-    auto &pdf = definition_.get().parameters().prevalence_distribution;
+    const auto &pdf = definition_.get().parameters().prevalence_distribution;
     auto values = std::vector<int>{};
     auto cumulative = std::vector<double>{};
     auto sum = 0.0;
-    for (auto &item : pdf) {
+    for (const auto &item : pdf) {
         auto p = item.second.males;
         if (gender != core::Gender::male) {
             p = item.second.females;

--- a/src/HealthGPS/default_disease_model.cpp
+++ b/src/HealthGPS/default_disease_model.cpp
@@ -43,7 +43,7 @@ void DefaultDiseaseModel::initialise_disease_status(RuntimeContext &context) {
 }
 
 void DefaultDiseaseModel::initialise_average_relative_risk(RuntimeContext &context) {
-    auto &age_range = context.age_range();
+    const auto &age_range = context.age_range();
     auto sum = create_age_gender_table<double>(age_range);
     auto count = create_age_gender_table<double>(age_range);
     auto &pop = context.population();
@@ -97,7 +97,7 @@ double DefaultDiseaseModel::get_excess_mortality(const Person &entity) const noe
 }
 
 DoubleAgeGenderTable DefaultDiseaseModel::calculate_average_relative_risk(RuntimeContext &context) {
-    auto &age_range = context.age_range();
+    const auto &age_range = context.age_range();
     auto sum = create_age_gender_table<double>(age_range);
     auto count = create_age_gender_table<double>(age_range);
     auto &pop = context.population();
@@ -148,13 +148,13 @@ double DefaultDiseaseModel::calculate_combined_relative_risk(const Person &entit
 
 double DefaultDiseaseModel::calculate_relative_risk_for_risk_factors(const Person &entity) const {
     auto relative_risk_value = 1.0;
-    auto &relative_factors = definition_.get().relative_risk_factors();
-    for (auto &factor : entity.risk_factors) {
+    const auto &relative_factors = definition_.get().relative_risk_factors();
+    for (const auto &factor : entity.risk_factors) {
         if (!relative_factors.contains(factor.first)) {
             continue;
         }
 
-        auto &lut = relative_factors.at(factor.first).at(entity.gender);
+        const auto &lut = relative_factors.at(factor.first).at(entity.gender);
         auto factor_value =
             weight_classifier_.adjust_risk_factor_value(entity, factor.first, factor.second);
         auto lookup_value = static_cast<float>(factor_value);
@@ -169,8 +169,8 @@ double DefaultDiseaseModel::calculate_relative_risk_for_diseases(const Person &e
                                                                  const int &start_time,
                                                                  const int &time_now) const {
     auto relative_risk_value = 1.0;
-    auto &lut = definition_.get().relative_risk_diseases();
-    for (auto &disease : entity.diseases) {
+    const auto &lut = definition_.get().relative_risk_diseases();
+    for (const auto &disease : entity.diseases) {
         if (!lut.contains(disease.first)) {
             continue;
         }
@@ -213,7 +213,7 @@ void DefaultDiseaseModel::update_incidence_cases(RuntimeContext &context) {
         }
 
         if (entity.age == 0) {
-            if (entity.diseases.size() > 0) {
+            if (!entity.diseases.empty()) {
                 entity.diseases.clear(); // Should not have nay disease at birth!
             }
 

--- a/src/HealthGPS/demographic.h
+++ b/src/HealthGPS/demographic.h
@@ -76,8 +76,8 @@ class PopulationModule final : public DemographicModule {
                                                           const DiseaseHostModule &disease_host);
 
     void update_residual_mortality(RuntimeContext &context, const DiseaseHostModule &disease_host);
-    double calculate_excess_mortality_product(const Person &entity,
-                                              const DiseaseHostModule &disease_host) const;
+    static double calculate_excess_mortality_product(const Person &entity,
+                                                     const DiseaseHostModule &disease_host);
     int update_age_and_death_events(RuntimeContext &context, const DiseaseHostModule &disease_host);
 };
 

--- a/src/HealthGPS/disease.cpp
+++ b/src/HealthGPS/disease.cpp
@@ -60,7 +60,7 @@ std::unique_ptr<DiseaseModule> build_disease_module(Repository &repository,
     auto registry = get_default_disease_model_registry();
     auto models = std::map<core::Identifier, std::shared_ptr<DiseaseModel>>();
 
-    auto &diseases = config.diseases();
+    const auto &diseases = config.diseases();
     std::mutex m;
     std::for_each(
         core::execution_policy, std::begin(diseases), std::end(diseases), [&](auto &info) {

--- a/src/HealthGPS/disease_table.cpp
+++ b/src/HealthGPS/disease_table.cpp
@@ -24,7 +24,8 @@ DiseaseTable::DiseaseTable(const core::DiseaseInfo &info, std::map<std::string, 
 
     if (info.code.is_empty()) {
         throw std::invalid_argument("Invalid disease information with empty identifier");
-    } else if (data_.empty()) {
+    }
+    if (data_.empty()) {
         return; // empty table
     }
 

--- a/src/HealthGPS/energy_balance_hierarchical_model.cpp
+++ b/src/HealthGPS/energy_balance_hierarchical_model.cpp
@@ -47,7 +47,7 @@ void EnergyBalanceHierarchicalModel::update_risk_factors(RuntimeContext &context
             current_risk_factors.at(age_key) = model_age;
         }
 
-        auto &equations = equations_at(model_age);
+        const auto &equations = equations_at(model_age);
         if (entity.gender == core::Gender::male) {
             update_risk_factors_exposure(context, entity, current_risk_factors, equations.male);
         } else {
@@ -57,7 +57,7 @@ void EnergyBalanceHierarchicalModel::update_risk_factors(RuntimeContext &context
 }
 
 const AgeGroupGenderEquation &EnergyBalanceHierarchicalModel::equations_at(const int &age) const {
-    for (auto &entry : equations_) {
+    for (const auto &entry : equations_) {
         if (entry.first.contains(age)) {
             // If there is an equation for the age, return it.
             return entry.second;
@@ -79,7 +79,7 @@ void EnergyBalanceHierarchicalModel::update_risk_factors_exposure(
     for (auto level = 1; level <= context.mapping().max_level(); level++) {
         auto level_factors = context.mapping().at_level(level);
         for (const auto &factor : level_factors) {
-            auto &factor_equation = equations.at(factor.key());
+            const auto &factor_equation = equations.at(factor.key());
 
             auto original_value = entity.get_risk_factor_value(factor.key());
             auto delta_factor = 0.0;
@@ -87,7 +87,7 @@ void EnergyBalanceHierarchicalModel::update_risk_factors_exposure(
                 if (current_risk_factors.contains(coeff.first)) {
                     delta_factor += coeff.second * current_risk_factors.at(coeff.first);
                 } else {
-                    auto &factor_key = variables_.at(coeff.first);
+                    const auto &factor_key = variables_.at(coeff.first);
                     delta_factor += coeff.second * delta_comp_factors.at(factor_key);
                 }
             }
@@ -108,7 +108,7 @@ void EnergyBalanceHierarchicalModel::update_risk_factors_exposure(
 
 std::map<core::Identifier, double>
 EnergyBalanceHierarchicalModel::get_current_risk_factors(const HierarchicalMapping &mapping,
-                                                         Person &entity) const {
+                                                         Person &entity) {
     auto entity_risk_factors = std::map<core::Identifier, double>();
     entity_risk_factors.emplace(InterceptKey, entity.get_risk_factor_value(InterceptKey));
     for (const auto &factor : mapping) {

--- a/src/HealthGPS/energy_balance_hierarchical_model.h
+++ b/src/HealthGPS/energy_balance_hierarchical_model.h
@@ -66,8 +66,8 @@ class EnergyBalanceHierarchicalModel final : public HierarchicalLinearModel {
         const std::map<core::Identifier, double> &current_risk_factors,
         const std::map<core::Identifier, FactorDynamicEquation> &equations);
 
-    std::map<core::Identifier, double> get_current_risk_factors(const HierarchicalMapping &mapping,
-                                                                Person &entity) const;
+    static std::map<core::Identifier, double>
+    get_current_risk_factors(const HierarchicalMapping &mapping, Person &entity);
 
     double sample_normal_with_boundary(Random &random, double mean, double standard_deviation,
                                        double boundary) const;

--- a/src/HealthGPS/energy_balance_model.cpp
+++ b/src/HealthGPS/energy_balance_model.cpp
@@ -5,6 +5,11 @@
 
 #include <algorithm>
 
+/*
+ * Suppress this clang-tidy warning for now, because most (all?) of these methods won't
+ * be suitable for converting to statics once the model is finished.
+ */
+// NOLINTBEGIN(readability-convert-member-functions-to-static)
 namespace hgps {
 
 // Risk factor keys.
@@ -304,3 +309,4 @@ std::unique_ptr<HierarchicalLinearModel> EnergyBalanceModelDefinition::create_mo
 }
 
 } // namespace hgps
+// NOLINTEND(readability-convert-member-functions-to-static)

--- a/src/HealthGPS/event_aggregator.h
+++ b/src/HealthGPS/event_aggregator.h
@@ -52,7 +52,7 @@ class EventSubscriber {
 
     /// @brief Gets the subscriber unique identifier
     /// @return The event handler identifier
-    [[nodiscard]] virtual const EventHandlerIdentifier id() const noexcept = 0;
+    [[nodiscard]] virtual EventHandlerIdentifier id() const noexcept = 0;
 };
 
 /// @brief Defines the event aggregator interface type

--- a/src/HealthGPS/event_bus.cpp
+++ b/src/HealthGPS/event_bus.cpp
@@ -48,7 +48,7 @@ bool DefaultEventBus::unsubscribe(const EventSubscriber &subscriber) {
                 }
             }
 
-            if (result == true) {
+            if (result) {
                 subscribers_.erase(sub_id);
             }
         }

--- a/src/HealthGPS/event_subscriber.cpp
+++ b/src/HealthGPS/event_subscriber.cpp
@@ -16,5 +16,5 @@ void EventSubscriberHandler::unsubscribe() const {
         event_hub_->unsubscribe(*this);
     }
 }
-const EventHandlerIdentifier EventSubscriberHandler::id() const noexcept { return identifier_; }
+EventHandlerIdentifier EventSubscriberHandler::id() const noexcept { return identifier_; }
 } // namespace hgps

--- a/src/HealthGPS/event_subscriber.h
+++ b/src/HealthGPS/event_subscriber.h
@@ -24,7 +24,7 @@ class EventSubscriberHandler final : public EventSubscriber {
 
     void unsubscribe() const override;
 
-    [[nodiscard]] const EventHandlerIdentifier id() const noexcept override;
+    [[nodiscard]] EventHandlerIdentifier id() const noexcept override;
 
   private:
     EventHandlerIdentifier identifier_;

--- a/src/HealthGPS/fiscal_scenario.cpp
+++ b/src/HealthGPS/fiscal_scenario.cpp
@@ -7,8 +7,7 @@
 namespace hgps {
 FiscalPolicyScenario::FiscalPolicyScenario(SyncChannel &data_sync,
                                            FiscalPolicyDefinition &&definition)
-    : channel_{data_sync}, definition_{std::move(definition)}, factor_impact_{},
-      interventions_book_{} {
+    : channel_{data_sync}, definition_{std::move(definition)} {
 
     if (definition_.impacts.size() != 3) {
         throw std::invalid_argument("Number of impact levels mismatch, must be 3.");
@@ -88,11 +87,12 @@ double FiscalPolicyScenario::apply([[maybe_unused]] Random &generator, Person &e
                 interventions_book_.at(entity.id()) = age;
                 auto effect = adult_effect.value - teen_effect.value;
                 return value + (factor_value * effect);
-            } else if (definition_.impact_type == FiscalImpactType::optimist) {
-                return value;
-            } else {
-                throw std::logic_error("Fiscal intervention impact type not implemented.");
             }
+            if (definition_.impact_type == FiscalImpactType::optimist) {
+                return value;
+            }
+
+            throw std::logic_error("Fiscal intervention impact type not implemented.");
         }
 
         return value;
@@ -113,7 +113,8 @@ const std::vector<PolicyImpact> &FiscalPolicyScenario::impacts() const noexcept 
 FiscalImpactType parse_fiscal_impact_type(std::string impact_type) {
     if (core::case_insensitive::equals(impact_type, "pessimist")) {
         return FiscalImpactType::pessimist;
-    } else if (core::case_insensitive::equals(impact_type, "optimist")) {
+    }
+    if (core::case_insensitive::equals(impact_type, "optimist")) {
         return FiscalImpactType::optimist;
     }
 

--- a/src/HealthGPS/food_labelling_scenario.cpp
+++ b/src/HealthGPS/food_labelling_scenario.cpp
@@ -6,9 +6,8 @@ inline constexpr int FOP_NO_EFFECT = -2;
 
 FoodLabellingScenario::FoodLabellingScenario(SyncChannel &data_sync,
                                              FoodLabellingDefinition &&definition)
-    : channel_{data_sync}, definition_{std::move(definition)}, factor_impact_{},
-      interventions_book_{} {
-    if (definition_.impacts.size() < 1) {
+    : channel_{data_sync}, definition_{std::move(definition)} {
+    if (definition_.impacts.empty()) {
         throw std::invalid_argument("Number of impact levels mismatch, must be greater than 1.");
     }
 

--- a/src/HealthGPS/healthgps.h
+++ b/src/HealthGPS/healthgps.h
@@ -84,6 +84,6 @@ class HealthGPS : public Simulation {
     hgps::IntegerAgeGenderTable create_net_migration();
     std::map<std::string, core::UnivariateSummary> create_input_data_summary() const;
 
-    Person partial_clone_entity(const Person &source) const noexcept;
+    static Person partial_clone_entity(const Person &source) noexcept;
 };
 } // namespace hgps

--- a/src/HealthGPS/info_message.cpp
+++ b/src/HealthGPS/info_message.cpp
@@ -30,7 +30,7 @@ void InfoEventMessage::accept(EventMessageVisitor &visitor) const { visitor.visi
 
 namespace detail {
 
-std::string model_action_str(const ModelAction action) {
+std::string model_action_str(ModelAction action) {
     switch (action) {
     case ModelAction::update:
         return "update";

--- a/src/HealthGPS/info_message.cpp
+++ b/src/HealthGPS/info_message.cpp
@@ -30,7 +30,7 @@ void InfoEventMessage::accept(EventMessageVisitor &visitor) const { visitor.visi
 
 namespace detail {
 
-const std::string model_action_str(const ModelAction action) {
+std::string model_action_str(const ModelAction action) {
     switch (action) {
     case ModelAction::update:
         return "update";

--- a/src/HealthGPS/info_message.h
+++ b/src/HealthGPS/info_message.h
@@ -54,6 +54,6 @@ struct InfoEventMessage final : public EventMessage {
 
 namespace detail {
 /// @brief Converts enumeration to string, not pretty but no support in C++
-std::string model_action_str(const ModelAction action);
+std::string model_action_str(ModelAction action);
 } // namespace detail
 } // namespace hgps

--- a/src/HealthGPS/info_message.h
+++ b/src/HealthGPS/info_message.h
@@ -54,6 +54,6 @@ struct InfoEventMessage final : public EventMessage {
 
 namespace detail {
 /// @brief Converts enumeration to string, not pretty but no support in C++
-const std::string model_action_str(const ModelAction action);
+std::string model_action_str(const ModelAction action);
 } // namespace detail
 } // namespace hgps

--- a/src/HealthGPS/life_table.cpp
+++ b/src/HealthGPS/life_table.cpp
@@ -5,15 +5,15 @@
 namespace hgps {
 LifeTable::LifeTable(std::map<int, Birth> &&births,
                      std::map<int, std::map<int, Mortality>> &&deaths)
-    : birth_table_{std::move(births)}, death_table_{std::move(deaths)}, time_range_{},
-      age_range_{} {
+    : birth_table_{std::move(births)}, death_table_{std::move(deaths)} {
     if (birth_table_.empty()) {
         if (!death_table_.empty()) {
             throw std::invalid_argument("empty births and deaths content mismatch");
         }
 
         return;
-    } else if (death_table_.empty()) {
+    }
+    if (death_table_.empty()) {
         throw std::invalid_argument("births and empty deaths content mismatch");
     }
 

--- a/src/HealthGPS/lms_model.cpp
+++ b/src/HealthGPS/lms_model.cpp
@@ -46,7 +46,7 @@ double hgps::LmsModel::adjust_risk_factor_value(const Person &entity,
 
 WeightCategory LmsModel::classify_weight_bmi(const Person &entity, double bmi) const {
     if (entity.age <= child_cutoff_age_) {
-        auto &params = definition_.get().at(entity.age, entity.gender);
+        const auto &params = definition_.get().at(entity.age, entity.gender);
 
         auto zscore = 0.0;
         if (params.lambda == 0.0) {
@@ -58,13 +58,15 @@ WeightCategory LmsModel::classify_weight_bmi(const Person &entity, double bmi) c
 
         if (zscore > 2.0) {
             return WeightCategory::obese;
-        } else if (zscore > 1.0) {
+        }
+        if (zscore > 1.0) {
             return WeightCategory::overweight;
         }
     } else {
         if (bmi >= 30.0) {
             return WeightCategory::obese;
-        } else if (bmi >= 25.0) {
+        }
+        if (bmi >= 25.0) {
             return WeightCategory::overweight;
         }
     }

--- a/src/HealthGPS/marketing_dynamic_scenario.cpp
+++ b/src/HealthGPS/marketing_dynamic_scenario.cpp
@@ -9,9 +9,8 @@ inline constexpr int MARKETING_FORMER = -2;
 
 hgps::MarketingDynamicScenario::MarketingDynamicScenario(SyncChannel &data_sync,
                                                          MarketingDynamicDefinition &&definition)
-    : channel_{data_sync}, definition_{std::move(definition)}, factor_impact_{},
-      interventions_book_{} {
-    if (definition_.impacts.size() < 1) {
+    : channel_{data_sync}, definition_{std::move(definition)} {
+    if (definition_.impacts.empty()) {
         throw std::invalid_argument("Number of impact levels mismatch, must be greater than 1.");
     }
 

--- a/src/HealthGPS/marketing_scenario.cpp
+++ b/src/HealthGPS/marketing_scenario.cpp
@@ -3,8 +3,7 @@
 namespace hgps {
 MarketingPolicyScenario::MarketingPolicyScenario(SyncChannel &data_sync,
                                                  MarketingPolicyDefinition &&definition)
-    : channel_{data_sync}, definition_{std::move(definition)}, factor_impact_{},
-      interventions_book_{} {
+    : channel_{data_sync}, definition_{std::move(definition)} {
 
     if (definition_.impacts.size() != 3) {
         throw std::invalid_argument("Number of impact levels mismatch, must be 3.");

--- a/src/HealthGPS/model_result.cpp
+++ b/src/HealthGPS/model_result.cpp
@@ -21,13 +21,13 @@ std::string ModelResult::to_string() const noexcept {
                       indicators.disability_adjusted_life_years);
 
     ss << fmt::format("{:{}}  : {:>14} : {:>14}\n", "#Risk factors average", pad, "Male", "Female");
-    for (auto &item : risk_ractor_average) {
+    for (const auto &item : risk_ractor_average) {
         ss << fmt::format(" {:{}} : {:>14.5f} : {:>14.5f}\n", item.first, pad, item.second.male,
                           item.second.female);
     }
 
     ss << fmt::format("{:{}}  : {:>14} : {:>14}\n", "#Prevalence", pad, "Male", "Female");
-    for (auto &item : disease_prevalence) {
+    for (const auto &item : disease_prevalence) {
         ss << fmt::format(" {:{}} : {:>14.5f} : {:>14.5f}\n", item.first, pad, item.second.male,
                           item.second.female);
     }

--- a/src/HealthGPS/modelrunner.cpp
+++ b/src/HealthGPS/modelrunner.cpp
@@ -12,14 +12,15 @@ using ElapsedTime = std::chrono::duration<double, std::milli>;
 
 ModelRunner::ModelRunner(EventAggregator &bus,
                          std::unique_ptr<RandomBitGenerator> generator) noexcept
-    : running_{false}, event_bus_{bus}, rnd_{std::move(generator)}, source_{} {}
+    : running_{false}, event_bus_{bus}, rnd_{std::move(generator)} {}
 
 double ModelRunner::run(Simulation &baseline, const unsigned int trial_runs) {
     if (trial_runs < 1) {
         throw std::invalid_argument("The number of trial runs must not be less than one");
-    } else if (baseline.type() != ScenarioType::baseline) {
+    }
+    if (baseline.type() != ScenarioType::baseline) {
         throw std::invalid_argument(
-            fmt::format("Simulation: '{}' can not be evaluated alone", baseline.name()));
+            fmt::format("Simulation: '{}' cannot be evaluated alone", baseline.name()));
     }
 
     if (running_.load()) {
@@ -62,10 +63,12 @@ double ModelRunner::run(Simulation &baseline, Simulation &intervention,
                         const unsigned int trial_runs) {
     if (trial_runs < 1) {
         throw std::invalid_argument("The number of trial runs must not be less than one.");
-    } else if (baseline.type() != ScenarioType::baseline) {
+    }
+    if (baseline.type() != ScenarioType::baseline) {
         throw std::invalid_argument(
             fmt::format("Baseline simulation: {} type mismatch.", baseline.name()));
-    } else if (intervention.type() != ScenarioType::intervention) {
+    }
+    if (intervention.type() != ScenarioType::intervention) {
         throw std::invalid_argument(
             fmt::format("Intervention simulation: {} type mismatch.", intervention.name()));
     }

--- a/src/HealthGPS/physical_activity_scenario.cpp
+++ b/src/HealthGPS/physical_activity_scenario.cpp
@@ -9,8 +9,7 @@ inline constexpr int PA_NO_EFFECT = -2;
 
 PhysicalActivityScenario::PhysicalActivityScenario(SyncChannel &data_sync,
                                                    PhysicalActivityDefinition &&definition)
-    : channel_{data_sync}, definition_{std::move(definition)}, factor_impact_{},
-      interventions_book_{} {
+    : channel_{data_sync}, definition_{std::move(definition)} {
     if (definition_.impacts.size() < 2) {
         throw std::invalid_argument("Number of impact levels mismatch, must be greater than 2.");
     }

--- a/src/HealthGPS/population.cpp
+++ b/src/HealthGPS/population.cpp
@@ -23,21 +23,21 @@ Person &Population::at(std::size_t index) { return people_.at(index); }
 
 const Person &Population::at(std::size_t index) const { return people_.at(index); }
 
-void Population::add(Person &&entity, unsigned int time) noexcept {
+void Population::add(Person &&person, unsigned int time) noexcept {
     auto recycle = find_index_of_recyclables(time, 1);
-    if (recycle.size() > 0) {
-        people_.at(recycle.at(0)) = entity;
+    if (!recycle.empty()) {
+        people_.at(recycle.at(0)) = person;
         return;
     }
 
-    people_.emplace_back(entity);
+    people_.emplace_back(person);
 }
 
 void Population::add_newborn_babies(std::size_t number, core::Gender gender,
                                     unsigned int time) noexcept {
     auto recycle = find_index_of_recyclables(time, number);
     auto remaining = number;
-    if (recycle.size() > 0) {
+    if (!recycle.empty()) {
         auto replacebles = std::min(number, recycle.size());
         for (auto index = std::size_t{0}; index < replacebles; index++) {
             people_.at(recycle.at(index)) = Person{gender};
@@ -54,7 +54,7 @@ std::vector<int> Population::find_index_of_recyclables(unsigned int time,
                                                        std::size_t top) const noexcept {
     auto indices = std::vector<int>{};
     indices.reserve(top);
-    for (auto index = 0; auto &entity : people_) {
+    for (auto index = 0; const auto &entity : people_) {
         if (!entity.is_active() && entity.time_of_death() < time &&
             entity.time_of_migration() < time) {
             indices.emplace_back(index);

--- a/src/HealthGPS/relative_risk.cpp
+++ b/src/HealthGPS/relative_risk.cpp
@@ -5,7 +5,7 @@ namespace hgps {
 RelativeRiskLookup::RelativeRiskLookup(const MonotonicVector<int> &rows,
                                        const MonotonicVector<float> &cols,
                                        core::FloatArray2D &&values)
-    : table_{std::move(values)}, rows_index_{}, cols_index_{} {
+    : table_{std::move(values)} {
     if (rows.size() != table_.rows() || cols.size() != table_.columns()) {
         throw std::out_of_range("Lookup breakpoints and values size mismatch.");
     }

--- a/src/HealthGPS/repository.cpp
+++ b/src/HealthGPS/repository.cpp
@@ -6,9 +6,7 @@
 
 namespace hgps {
 
-CachedRepository::CachedRepository(core::Datastore &manager)
-    : mutex_{}, data_manager_{manager}, rf_model_definition_{}, baseline_adjustments_{},
-      diseases_info_{}, diseases_{}, lms_parameters_{} {}
+CachedRepository::CachedRepository(core::Datastore &manager) : data_manager_{manager} {}
 
 void CachedRepository::register_risk_factor_model_definition(
     const HierarchicalModelType &model_type,
@@ -50,7 +48,7 @@ const std::vector<core::DiseaseInfo> &CachedRepository::get_diseases() {
 }
 
 std::optional<core::DiseaseInfo> CachedRepository::get_disease_info(core::Identifier code) {
-    auto &all_diseases = get_diseases();
+    const auto &all_diseases = get_diseases();
     auto it = std::find_if(all_diseases.cbegin(), all_diseases.cend(),
                            [&code](const core::DiseaseInfo &other) { return other.code == code; });
 

--- a/src/HealthGPS/riskfactor.cpp
+++ b/src/HealthGPS/riskfactor.cpp
@@ -14,14 +14,15 @@ RiskFactorModule::RiskFactorModule(
 
     if (!models_.contains(HierarchicalModelType::Static)) {
         throw std::invalid_argument("Missing required hierarchical model of type = static.");
-    } else if (models_.at(HierarchicalModelType::Static)->type() != HierarchicalModelType::Static) {
+    }
+    if (models_.at(HierarchicalModelType::Static)->type() != HierarchicalModelType::Static) {
         throw std::out_of_range("Model type mismatch in 'static' hierarchical model entry.");
     }
 
     if (!models_.contains(HierarchicalModelType::Dynamic)) {
         throw std::invalid_argument("Missing required hierarchical model of type = dynamic.");
-    } else if (models_.at(HierarchicalModelType::Dynamic)->type() !=
-               HierarchicalModelType::Dynamic) {
+    }
+    if (models_.at(HierarchicalModelType::Dynamic)->type() != HierarchicalModelType::Dynamic) {
         throw std::out_of_range("Model type mismatch in 'dynamic' hierarchical model entry.");
     }
 }

--- a/src/HealthGPS/riskfactor.h
+++ b/src/HealthGPS/riskfactor.h
@@ -28,7 +28,7 @@ class RiskFactorModule final : public RiskFactorHostModule {
 
     std::size_t size() const noexcept override;
 
-    bool contains(const HierarchicalModelType &modelType) const noexcept override;
+    bool contains(const HierarchicalModelType &model_type) const noexcept override;
 
     HierarchicalLinearModel &at(const HierarchicalModelType &model_type) const;
 

--- a/src/HealthGPS/riskfactor_adjustment.h
+++ b/src/HealthGPS/riskfactor_adjustment.h
@@ -24,8 +24,8 @@ class RiskfactorAdjustmentModel {
   private:
     std::reference_wrapper<BaselineAdjustment> adjustments_;
 
-    FactorAdjustmentTable calculate_simulated_mean(Population &population,
-                                                   const core::IntegerInterval &age_range) const;
+    static FactorAdjustmentTable calculate_simulated_mean(Population &population,
+                                                          const core::IntegerInterval &age_range);
 
     FactorAdjustmentTable calculate_adjustment_coefficients(RuntimeContext &context) const;
 

--- a/src/HealthGPS/runtime_context.cpp
+++ b/src/HealthGPS/runtime_context.cpp
@@ -35,9 +35,7 @@ const core::IntegerInterval &RuntimeContext::age_range() const noexcept {
     return definition_.get().inputs().settings().age_range();
 }
 
-const std::string RuntimeContext::identifier() const noexcept {
-    return definition_.get().identifier();
-}
+std::string RuntimeContext::identifier() const noexcept { return definition_.get().identifier(); }
 
 void RuntimeContext::set_current_time(const int time_now) noexcept { time_now_ = time_now; }
 

--- a/src/HealthGPS/runtime_context.h
+++ b/src/HealthGPS/runtime_context.h
@@ -72,7 +72,7 @@ class RuntimeContext {
 
     /// @brief Gets the simulation identifier for outside world messages
     /// @return Simulation identifier
-    const std::string identifier() const noexcept;
+    std::string identifier() const noexcept;
 
     /// @brief Sets the current simulation time value
     /// @param time_now The new simulation time

--- a/src/HealthGPS/ses_noise_module.cpp
+++ b/src/HealthGPS/ses_noise_module.cpp
@@ -37,12 +37,12 @@ void SESNoiseModule::initialise_population(RuntimeContext &context) {
 void SESNoiseModule::update_population(RuntimeContext &context) {
     auto newborn_age = 0u;
     auto &pop = context.population();
-    auto indeces = core::find_index_of_all(core::execution_policy, pop, [&](const Person &entity) {
+    auto indices = core::find_index_of_all(core::execution_policy, pop, [&](const Person &entity) {
         return entity.age == newborn_age;
     });
 
-    std::sort(indeces.begin(), indeces.end());
-    for (auto &index : indeces) {
+    std::sort(indices.begin(), indices.end());
+    for (auto &index : indices) {
         pop[index].ses = context.random().next_normal(parameters_[0], parameters_[1]);
     }
 }

--- a/src/HealthGPS/simple_policy_scenario.cpp
+++ b/src/HealthGPS/simple_policy_scenario.cpp
@@ -5,7 +5,7 @@ namespace hgps {
 
 SimplePolicyScenario::SimplePolicyScenario(SyncChannel &data_sync,
                                            SimplePolicyDefinition &&definition)
-    : channel_{data_sync}, definition_{std::move(definition)}, factor_impact_{} {
+    : channel_{data_sync}, definition_{std::move(definition)} {
     for (const auto &factor : definition_.impacts) {
         factor_impact_.emplace(factor.risk_factor, factor);
     }


### PR DESCRIPTION
This PR enables a bunch of `clang-tidy`'s `readability` checks and fixes associated warnings.

Probably the most common change you'll see in the diff is the adding of `const`s to various `auto`-typed variables. Note that this change won't make non-`const` variables `const`. These are variables that already have `const` types, it's just that they're hidden in the `auto`, so it's better style to just make it `const auto`.

There are lots of other small changes (such as making member functions which don't use `this` `static`) which also shouldn't introduce any functional changes to the code.

The `readability-function-cognitive-complexity` check flagged up three different functions which are massive and complicated. For now, I haven't fixed them up and I've suppressed just these warnings in place. I'll open issues for each to be tackled separately. 

Closes #178.