### PR TITLE
Add yet more clang tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,6 +8,7 @@ Checks: >
     modernize-*,
     performance-*,
     misc-*,
+    cppcoreguidelines-*,
 
     # Checks to exclude
     -*,
@@ -25,6 +26,15 @@ Checks: >
     -misc-const-correctness,
     -misc-no-recursion,
     -misc-non-private-member-variables-in-classes,
+    -cppcoreguidelines-avoid-magic-numbers,
+    -cppcoreguidelines-narrowing-conversions,
+    -cppcoreguidelines-init-variables,
+    -cppcoreguidelines-non-private-member-variables-in-classes,
+    -cppcoreguidelines-avoid-non-const-global-variables,
+    -cppcoreguidelines-avoid-c-arrays,
+    -cppcoreguidelines-pro-bounds-constant-array-index,
+    -cppcoreguidelines-special-member-functions,
+    -cppcoreguidelines-macro-usage,
 CheckOptions:
     - key: readability-function-cognitive-complexity.IgnoreMacros
       value: true

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -33,6 +33,7 @@ Checks: >
     -cppcoreguidelines-non-private-member-variables-in-classes,
     -cppcoreguidelines-avoid-non-const-global-variables,
     -cppcoreguidelines-avoid-c-arrays,
+    -cppcoreguidelines-avoid-do-while,
     -cppcoreguidelines-pro-bounds-constant-array-index,
     -cppcoreguidelines-special-member-functions,
     -cppcoreguidelines-macro-usage,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,6 +18,7 @@ Checks: >
     -bugprone-easily-swappable-parameters,
     -bugprone-narrowing-conversions,
     -modernize-use-trailing-return-type,
+    -modernize-use-nodiscard,
     -readability-identifier-length,
     -readability-implicit-bool-conversion,
     -readability-uppercase-literal-suffix,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@ Checks: >
     clang-analyzer-*,
     bugprone-*,
     readability-*,
+    modernize-*,
 
     # Checks to exclude
     -*,
@@ -13,6 +14,7 @@ Checks: >
     -clang-analyzer-optin.osx.*,
     -bugprone-easily-swappable-parameters,
     -bugprone-narrowing-conversions,
+    -modernize-use-trailing-return-type,
     -readability-identifier-length,
     -readability-implicit-bool-conversion,
     -readability-uppercase-literal-suffix,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,7 @@ Checks: >
     bugprone-*,
     readability-*,
     modernize-*,
+    performance-*,
 
     # Checks to exclude
     -*,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,6 +7,7 @@ Checks: >
     readability-*,
     modernize-*,
     performance-*,
+    misc-*,
 
     # Checks to exclude
     -*,
@@ -21,6 +22,9 @@ Checks: >
     -readability-uppercase-literal-suffix,
     -readability-magic-numbers,
     -readability-isolate-declaration,
+    -misc-const-correctness,
+    -misc-no-recursion,
+    -misc-non-private-member-variables-in-classes,
 CheckOptions:
     - key: readability-function-cognitive-complexity.IgnoreMacros
       value: true

--- a/src/HealthGPS.Console/command_options.cpp
+++ b/src/HealthGPS.Console/command_options.cpp
@@ -19,6 +19,7 @@ cxxopts::Options create_options() {
     return options;
 }
 
+// NOLINTNEXTLINE(modernize-avoid-c-arrays)
 CommandOptions parse_arguments(cxxopts::Options &options, int &argc, char *argv[]) {
     namespace fs = std::filesystem;
 

--- a/src/HealthGPS.Console/configuration.cpp
+++ b/src/HealthGPS.Console/configuration.cpp
@@ -39,7 +39,6 @@ ConfigurationError::ConfigurationError(const std::string &msg) : std::runtime_er
 
 Configuration get_configuration(CommandOptions &options) {
     MEASURE_FUNCTION();
-    namespace fs = std::filesystem;
     using namespace host::poco;
 
     bool success = true;

--- a/src/HealthGPS.Console/configuration.cpp
+++ b/src/HealthGPS.Console/configuration.cpp
@@ -158,8 +158,8 @@ ModelInput create_model_input(core::DataTable &input_table, core::Country countr
         mapping.emplace_back(item.name, item.level, item.range);
     }
 
-    return ModelInput(input_table, settings, run_info, ses_mapping,
-                      HierarchicalMapping(std::move(mapping)), diseases);
+    return {input_table, settings, run_info, ses_mapping, HierarchicalMapping(std::move(mapping)),
+            diseases};
 }
 
 std::string create_output_file_name(const poco::OutputInfo &info, int job_id) {

--- a/src/HealthGPS.Console/configuration.h
+++ b/src/HealthGPS.Console/configuration.h
@@ -104,7 +104,7 @@ std::vector<hgps::core::DiseaseInfo> get_diseases_info(hgps::core::Datastore &da
 /// @param diseases Selected diseases for experiment
 /// @return The respective model input instance
 hgps::ModelInput create_model_input(hgps::core::DataTable &input_table, hgps::core::Country country,
-                                    Configuration &config,
+                                    const Configuration &config,
                                     std::vector<hgps::core::DiseaseInfo> diseases);
 
 /// @brief Creates the full output file name from user input configuration

--- a/src/HealthGPS.Console/event_monitor.cpp
+++ b/src/HealthGPS.Console/event_monitor.cpp
@@ -58,19 +58,19 @@ void EventMonitor::visit(const hgps::ErrorEventMessage &message) {
 void EventMonitor::visit(const hgps::ResultEventMessage &message) { result_writer_.write(message); }
 
 void EventMonitor::info_event_handler(std::shared_ptr<hgps::EventMessage> message) {
-    info_queue_.push(message);
+    info_queue_.emplace(std::move(message));
 }
 
-void EventMonitor::error_event_handler(std::shared_ptr<hgps::EventMessage> message) {
+void EventMonitor::error_event_handler(const std::shared_ptr<hgps::EventMessage> &message) {
     // handle error synchronous, no delay!
     message->accept(*this);
 }
 
 void EventMonitor::result_event_handler(std::shared_ptr<hgps::EventMessage> message) {
-    results_queue_.push(message);
+    results_queue_.emplace(std::move(message));
 }
 
-void EventMonitor::info_dispatch_thread(std::stop_token token) {
+void EventMonitor::info_dispatch_thread(const std::stop_token &token) {
     fmt::print(fg(fmt::color::light_blue), "Info event thread started...\n");
     while (!token.stop_requested()) {
         std::shared_ptr<hgps::EventMessage> m;
@@ -84,7 +84,7 @@ void EventMonitor::info_dispatch_thread(std::stop_token token) {
     fmt::print(fg(fmt::color::light_blue), "Info event thread exited.\n");
 }
 
-void EventMonitor::result_dispatch_thread(std::stop_token token) {
+void EventMonitor::result_dispatch_thread(const std::stop_token &token) {
     fmt::print(fg(fmt::color::gray), "Result event thread started...\n");
     while (!token.stop_requested()) {
         std::shared_ptr<hgps::EventMessage> m;

--- a/src/HealthGPS.Console/event_monitor.cpp
+++ b/src/HealthGPS.Console/event_monitor.cpp
@@ -10,26 +10,24 @@
 namespace host {
 EventMonitor::EventMonitor(hgps::EventAggregator &event_bus, ResultWriter &result_writer)
     : result_writer_{result_writer} {
-    handlers_.emplace_back(
-        event_bus.subscribe(hgps::EventType::runner, std::bind(&EventMonitor::info_event_handler,
-                                                               this, std::placeholders::_1)));
+    handlers_.emplace_back(event_bus.subscribe(hgps::EventType::runner, [this](auto &&PH1) {
+        info_event_handler(std::forward<decltype(PH1)>(PH1));
+    }));
 
-    handlers_.emplace_back(
-        event_bus.subscribe(hgps::EventType::info, std::bind(&EventMonitor::info_event_handler,
-                                                             this, std::placeholders::_1)));
+    handlers_.emplace_back(event_bus.subscribe(hgps::EventType::info, [this](auto &&PH1) {
+        info_event_handler(std::forward<decltype(PH1)>(PH1));
+    }));
 
-    handlers_.emplace_back(
-        event_bus.subscribe(hgps::EventType::result, std::bind(&EventMonitor::result_event_handler,
-                                                               this, std::placeholders::_1)));
+    handlers_.emplace_back(event_bus.subscribe(hgps::EventType::result, [this](auto &&PH1) {
+        result_event_handler(std::forward<decltype(PH1)>(PH1));
+    }));
 
-    handlers_.emplace_back(
-        event_bus.subscribe(hgps::EventType::error, std::bind(&EventMonitor::error_event_handler,
-                                                              this, std::placeholders::_1)));
+    handlers_.emplace_back(event_bus.subscribe(hgps::EventType::error, [this](auto &&PH1) {
+        error_event_handler(std::forward<decltype(PH1)>(PH1));
+    }));
 
-    threads_.emplace_back(
-        std::jthread(&EventMonitor::info_dispatch_thread, this, cancel_source_.get_token()));
-    threads_.emplace_back(
-        std::jthread(&EventMonitor::result_dispatch_thread, this, cancel_source_.get_token()));
+    threads_.emplace_back(&EventMonitor::info_dispatch_thread, this, cancel_source_.get_token());
+    threads_.emplace_back(&EventMonitor::result_dispatch_thread, this, cancel_source_.get_token());
 }
 
 EventMonitor::~EventMonitor() noexcept {

--- a/src/HealthGPS.Console/event_monitor.h
+++ b/src/HealthGPS.Console/event_monitor.h
@@ -41,10 +41,10 @@ class EventMonitor final : public hgps::EventMessageVisitor {
     std::stop_source cancel_source_;
 
     void info_event_handler(std::shared_ptr<hgps::EventMessage> message);
-    void error_event_handler(std::shared_ptr<hgps::EventMessage> message);
+    void error_event_handler(const std::shared_ptr<hgps::EventMessage> &message);
     void result_event_handler(std::shared_ptr<hgps::EventMessage> message);
 
-    void info_dispatch_thread(std::stop_token token);
-    void result_dispatch_thread(std::stop_token token);
+    void info_dispatch_thread(const std::stop_token &token);
+    void result_dispatch_thread(const std::stop_token &token);
 };
 } // namespace host

--- a/src/HealthGPS.Console/program.cpp
+++ b/src/HealthGPS.Console/program.cpp
@@ -115,7 +115,8 @@ int main(int argc, char *argv[]) { // NOLINT(bugprone-exception-escape)
         std::cout << input_table;
 
         // Create complete model input from configuration
-        auto model_input = create_model_input(input_table, country, config, diseases);
+        auto model_input =
+            create_model_input(input_table, std::move(country), config, std::move(diseases));
 
         // Create event bus and event monitor with a results file writer
         auto event_bus = DefaultEventBus();

--- a/src/HealthGPS.Console/program.cpp
+++ b/src/HealthGPS.Console/program.cpp
@@ -191,8 +191,10 @@ int main(int argc, char *argv[]) { // NOLINT(bugprone-exception-escape)
     return exit_application(EXIT_SUCCESS);
 }
 
+// NOLINTBEGIN(modernize-concat-nested-namespaces)
 /// @brief Top-level namespace for Health-GPS Console host application
 namespace host {
 /// @brief Internal details namespace for private data types and functions
 namespace detail {}
 } // namespace host
+// NOLINTEND(modernize-concat-nested-namespaces)

--- a/src/HealthGPS.Console/result_file_writer.cpp
+++ b/src/HealthGPS.Console/result_file_writer.cpp
@@ -8,10 +8,11 @@
 #include <fmt/core.h>
 #include <nlohmann/json.hpp>
 #include <sstream>
+#include <utility>
 
 namespace host {
-ResultFileWriter::ResultFileWriter(const std::filesystem::path file_name, const ExperimentInfo info)
-    : info_{info} {
+ResultFileWriter::ResultFileWriter(const std::filesystem::path &file_name, ExperimentInfo info)
+    : info_{std::move(info)} {
     stream_.open(file_name, std::ofstream::out | std::ofstream::app);
     if (stream_.fail() || !stream_.is_open()) {
         throw std::invalid_argument(fmt::format("Cannot open output file: {}", file_name.string()));
@@ -75,7 +76,7 @@ void ResultFileWriter::write(const hgps::ResultEventMessage &message) {
     write_csv_channels(message);
 }
 
-void ResultFileWriter::write_json_begin(const std::filesystem::path output) {
+void ResultFileWriter::write_json_begin(const std::filesystem::path &output) {
     using json = nlohmann::ordered_json;
 
     auto tp = std::chrono::system_clock::now();
@@ -91,7 +92,7 @@ void ResultFileWriter::write_json_begin(const std::filesystem::path output) {
         {"result", {1, 2}}};
 
     auto json_header = msg.dump();
-    auto array_start = json_header.find_last_of("[");
+    auto array_start = json_header.find_last_of('[');
     stream_ << json_header.substr(0, array_start + 1);
     stream_.flush();
 }

--- a/src/HealthGPS.Console/result_file_writer.cpp
+++ b/src/HealthGPS.Console/result_file_writer.cpp
@@ -29,15 +29,9 @@ ResultFileWriter::ResultFileWriter(const std::filesystem::path &file_name, Exper
     write_json_begin(output_filename);
 }
 
-ResultFileWriter::ResultFileWriter(ResultFileWriter &&other) noexcept {
-    stream_.close();
-    stream_ = std::move(other.stream_);
-
-    csvstream_.close();
-    csvstream_ = std::move(other.csvstream_);
-
-    info_ = std::move(other.info_);
-}
+ResultFileWriter::ResultFileWriter(ResultFileWriter &&other) noexcept
+    : stream_{std::move(other.stream_)}, csvstream_{std::move(other.csvstream_)},
+      info_{std::move(other.info_)} {}
 
 ResultFileWriter &ResultFileWriter::operator=(ResultFileWriter &&other) noexcept {
     stream_.close();

--- a/src/HealthGPS.Console/result_file_writer.h
+++ b/src/HealthGPS.Console/result_file_writer.h
@@ -20,7 +20,7 @@ class ResultFileWriter final : public ResultWriter {
     /// @brief Initialises an instance of the host::ResultFileWriter class.
     /// @param file_name The JSON output file full name
     /// @param info The associated experiment information
-    ResultFileWriter(const std::filesystem::path file_name, const ExperimentInfo info);
+    ResultFileWriter(const std::filesystem::path &file_name, ExperimentInfo info);
 
     ResultFileWriter(const ResultFileWriter &) = delete;
     ResultFileWriter &operator=(const ResultFileWriter &) = delete;
@@ -38,7 +38,7 @@ class ResultFileWriter final : public ResultWriter {
     std::atomic<bool> first_row_{true};
     ExperimentInfo info_;
 
-    void write_json_begin(const std::filesystem::path output);
+    void write_json_begin(const std::filesystem::path &output);
     void write_json_end();
 
     static std::string to_json_string(const hgps::ResultEventMessage &message);

--- a/src/HealthGPS.Core/datastore.h
+++ b/src/HealthGPS.Core/datastore.h
@@ -29,7 +29,7 @@ class Datastore {
     /// @return The resulting list of population trend items
     virtual std::vector<PopulationItem>
     get_population(const Country &country,
-                   const std::function<bool(const unsigned int &)> time_filter) const = 0;
+                   const std::function<bool(unsigned int)> time_filter) const = 0;
 
     /// @brief Gets the population mortality trend for a country filtered by time
     /// @param country The target country definition
@@ -37,7 +37,7 @@ class Datastore {
     /// @return The resulting list of mortality trend items
     virtual std::vector<MortalityItem>
     get_mortality(const Country &country,
-                  const std::function<bool(const unsigned int &)> time_filter) const = 0;
+                  const std::function<bool(unsigned int)> time_filter) const = 0;
 
     /// @brief Gets the collection of diseases information in the store
     /// @return The list of diseases defined
@@ -88,7 +88,7 @@ class Datastore {
     /// @return The resulting list of birth indicator items
     virtual std::vector<BirthItem>
     get_birth_indicators(const Country country,
-                         const std::function<bool(const unsigned int &)> time_filter) const = 0;
+                         const std::function<bool(unsigned int)> time_filter) const = 0;
 
     /// @brief Gets the LMS (lambda-mu-sigma) parameters for childhood growth charts
     /// @return The parameters for the LMS model

--- a/src/HealthGPS.Core/datastore.h
+++ b/src/HealthGPS.Core/datastore.h
@@ -29,7 +29,7 @@ class Datastore {
     /// @return The resulting list of population trend items
     virtual std::vector<PopulationItem>
     get_population(const Country &country,
-                   const std::function<bool(unsigned int)> time_filter) const = 0;
+                   const std::function<bool(unsigned int)> &time_filter) const = 0;
 
     /// @brief Gets the population mortality trend for a country filtered by time
     /// @param country The target country definition
@@ -37,7 +37,7 @@ class Datastore {
     /// @return The resulting list of mortality trend items
     virtual std::vector<MortalityItem>
     get_mortality(const Country &country,
-                  const std::function<bool(unsigned int)> time_filter) const = 0;
+                  const std::function<bool(unsigned int)> &time_filter) const = 0;
 
     /// @brief Gets the collection of diseases information in the store
     /// @return The list of diseases defined
@@ -52,14 +52,14 @@ class Datastore {
     /// @param info The target disease information
     /// @param country The target country definition
     /// @return The disease definition, check empty() = true for missing data.
-    virtual DiseaseEntity get_disease(DiseaseInfo info, Country country) const = 0;
+    virtual DiseaseEntity get_disease(const DiseaseInfo &info, const Country &country) const = 0;
 
     /// @brief Gets the relative risk effects for disease to disease interactions
     /// @param source The source disease information
     /// @param target The target disease information
     /// @return The disease-disease effects, check empty() = true for missing data.
-    virtual RelativeRiskEntity get_relative_risk_to_disease(DiseaseInfo source,
-                                                            DiseaseInfo target) const = 0;
+    virtual RelativeRiskEntity get_relative_risk_to_disease(const DiseaseInfo &source,
+                                                            const DiseaseInfo &target) const = 0;
 
     /// @brief Gets the relative risk effects for risk factor to disease interactions
     /// @param source The disease information
@@ -67,28 +67,28 @@ class Datastore {
     /// @param risk_factor_key The risk factor identifier
     /// @return The risk factor-disease effects, check empty() = true for missing data.
     virtual RelativeRiskEntity
-    get_relative_risk_to_risk_factor(DiseaseInfo source, Gender gender,
-                                     Identifier risk_factor_key) const = 0;
+    get_relative_risk_to_risk_factor(const DiseaseInfo &source, Gender gender,
+                                     const Identifier &risk_factor_key) const = 0;
 
     /// @brief Gets the parameters required by cancer type diseases for a country
     /// @param info The disease of type cancer information
     /// @param country The target country definition
     /// @return The cancer parameters, check empty() = true for missing data.
-    virtual CancerParameterEntity get_disease_parameter(DiseaseInfo info,
-                                                        Country country) const = 0;
+    virtual CancerParameterEntity get_disease_parameter(const DiseaseInfo &info,
+                                                        const Country &country) const = 0;
 
     /// @brief Gets the Burden of Diseases (BoD) analysis dataset for a country
     /// @param country The target country definition
     /// @return The BoD analysis data, check empty() = true for missing data.
-    virtual DiseaseAnalysisEntity get_disease_analysis(const Country country) const = 0;
+    virtual DiseaseAnalysisEntity get_disease_analysis(const Country &country) const = 0;
 
     /// @brief Gets the population birth indicators for a country filtered by time
     /// @param country The target country definition
     /// @param time_filter The time filter predicate, e.g. years range
     /// @return The resulting list of birth indicator items
     virtual std::vector<BirthItem>
-    get_birth_indicators(const Country country,
-                         const std::function<bool(unsigned int)> time_filter) const = 0;
+    get_birth_indicators(const Country &country,
+                         const std::function<bool(unsigned int)> &time_filter) const = 0;
 
     /// @brief Gets the LMS (lambda-mu-sigma) parameters for childhood growth charts
     /// @return The parameters for the LMS model

--- a/src/HealthGPS.Core/datastore.h
+++ b/src/HealthGPS.Core/datastore.h
@@ -28,7 +28,7 @@ class Datastore {
     /// @param time_filter The time filter predicate, e.g., years range
     /// @return The resulting list of population trend items
     virtual std::vector<PopulationItem>
-    get_population(Country country,
+    get_population(const Country &country,
                    const std::function<bool(const unsigned int &)> time_filter) const = 0;
 
     /// @brief Gets the population mortality trend for a country filtered by time
@@ -36,7 +36,7 @@ class Datastore {
     /// @param time_filter The time filter predicate, e.g., years range
     /// @return The resulting list of mortality trend items
     virtual std::vector<MortalityItem>
-    get_mortality(Country country,
+    get_mortality(const Country &country,
                   const std::function<bool(const unsigned int &)> time_filter) const = 0;
 
     /// @brief Gets the collection of diseases information in the store

--- a/src/HealthGPS.Core/datastore.h
+++ b/src/HealthGPS.Core/datastore.h
@@ -28,16 +28,14 @@ class Datastore {
     /// @param time_filter The time filter predicate, e.g., years range
     /// @return The resulting list of population trend items
     virtual std::vector<PopulationItem>
-    get_population(const Country &country,
-                   const std::function<bool(unsigned int)> &time_filter) const = 0;
+    get_population(const Country &country, std::function<bool(unsigned int)> time_filter) const = 0;
 
     /// @brief Gets the population mortality trend for a country filtered by time
     /// @param country The target country definition
     /// @param time_filter The time filter predicate, e.g., years range
     /// @return The resulting list of mortality trend items
     virtual std::vector<MortalityItem>
-    get_mortality(const Country &country,
-                  const std::function<bool(unsigned int)> &time_filter) const = 0;
+    get_mortality(const Country &country, std::function<bool(unsigned int)> time_filter) const = 0;
 
     /// @brief Gets the collection of diseases information in the store
     /// @return The list of diseases defined
@@ -88,7 +86,7 @@ class Datastore {
     /// @return The resulting list of birth indicator items
     virtual std::vector<BirthItem>
     get_birth_indicators(const Country &country,
-                         const std::function<bool(unsigned int)> &time_filter) const = 0;
+                         std::function<bool(unsigned int)> time_filter) const = 0;
 
     /// @brief Gets the LMS (lambda-mu-sigma) parameters for childhood growth charts
     /// @return The parameters for the LMS model

--- a/src/HealthGPS.Core/identifier.cpp
+++ b/src/HealthGPS.Core/identifier.cpp
@@ -10,7 +10,7 @@ Identifier Identifier::empty() {
     return instance;
 }
 
-Identifier::Identifier(std::string value) : value_{to_lower(value)} {
+Identifier::Identifier(const std::string &value) : value_{to_lower(value)} {
     if (!value_.empty()) {
         validate_identifier();
     }

--- a/src/HealthGPS.Core/identifier.h
+++ b/src/HealthGPS.Core/identifier.h
@@ -30,7 +30,7 @@ struct Identifier final {
     /// @param value The string identifier
     /// @throws std::invalid_argument for value starting with a number or containing invalid
     /// characters.
-    Identifier(std::string value);
+    Identifier(const std::string &value);
 
     /// @brief Checks whether this is an empty identifier
     /// @return true if the identifier is empty; otherwise, false.

--- a/src/HealthGPS.Core/univariate_summary.cpp
+++ b/src/HealthGPS.Core/univariate_summary.cpp
@@ -3,20 +3,21 @@
 #include <cmath>
 #include <fmt/format.h>
 #include <sstream>
+#include <utility>
 
 namespace hgps::core {
 UnivariateSummary::UnivariateSummary()
     : name_{"Untitled"}, min_{std::nan("")}, max_{std::nan("")} {}
 
-UnivariateSummary::UnivariateSummary(const std::string name)
-    : name_{name}, min_{std::nan("")}, max_{std::nan("")} {}
+UnivariateSummary::UnivariateSummary(std::string name)
+    : name_{std::move(name)}, min_{std::nan("")}, max_{std::nan("")} {}
 
-UnivariateSummary::UnivariateSummary(const std::vector<double> values) : UnivariateSummary() {
+UnivariateSummary::UnivariateSummary(const std::vector<double> &values) : UnivariateSummary() {
     append(values);
 }
 
-UnivariateSummary::UnivariateSummary(const std::string name, const std::vector<double> values)
-    : UnivariateSummary(name) {
+UnivariateSummary::UnivariateSummary(std::string name, const std::vector<double> &values)
+    : UnivariateSummary(std::move(name)) {
     append(values);
 }
 

--- a/src/HealthGPS.Core/univariate_summary.h
+++ b/src/HealthGPS.Core/univariate_summary.h
@@ -18,16 +18,16 @@ class UnivariateSummary {
 
     /// @brief Initialises a new instance of the UnivariateSummary class.
     /// @param name The factor or variable name
-    UnivariateSummary(const std::string name);
+    UnivariateSummary(std::string name);
 
     /// @brief Initialises a new instance of the UnivariateSummary class.
     /// @param values The values to summary
-    UnivariateSummary(const std::vector<double> values);
+    UnivariateSummary(const std::vector<double> &values);
 
     /// @brief Initialises a new instance of the UnivariateSummary class.
     /// @param name The factor or variable name
     /// @param values The values to summary
-    UnivariateSummary(const std::string name, const std::vector<double> values);
+    UnivariateSummary(std::string name, const std::vector<double> &values);
 
     /// @brief Gets the factor or variable name
     /// @return The name identification

--- a/src/HealthGPS.Datastore/datamanager.cpp
+++ b/src/HealthGPS.Datastore/datamanager.cpp
@@ -81,7 +81,7 @@ std::vector<PopulationItem> DataManager::get_population(const Country &country) 
 
 std::vector<PopulationItem>
 DataManager::get_population(const Country &country,
-                            const std::function<bool(unsigned int)> time_filter) const {
+                            const std::function<bool(unsigned int)> &time_filter) const {
     auto results = std::vector<PopulationItem>();
 
     if (index_.contains("demographic")) {
@@ -132,7 +132,7 @@ std::vector<MortalityItem> DataManager::get_mortality(const Country &country) co
 
 std::vector<MortalityItem>
 DataManager::get_mortality(const Country &country,
-                           const std::function<bool(unsigned int)> time_filter) const {
+                           const std::function<bool(unsigned int)> &time_filter) const {
     auto results = std::vector<MortalityItem>();
     if (index_.contains("demographic")) {
         auto nodepath = index_["demographic"]["path"].get<std::string>();
@@ -231,7 +231,7 @@ DiseaseInfo DataManager::get_disease_info(const core::Identifier &code) const {
     throw std::runtime_error("Index has no 'diseases' entry.");
 }
 
-DiseaseEntity DataManager::get_disease(DiseaseInfo info, Country country) const {
+DiseaseEntity DataManager::get_disease(const DiseaseInfo &info, const Country &country) const {
     DiseaseEntity result;
     result.info = info;
     result.country = country;
@@ -294,8 +294,8 @@ DiseaseEntity DataManager::get_disease(DiseaseInfo info, Country country) const 
     return result;
 }
 
-RelativeRiskEntity DataManager::get_relative_risk_to_disease(DiseaseInfo source,
-                                                             DiseaseInfo target) const {
+RelativeRiskEntity DataManager::get_relative_risk_to_disease(const DiseaseInfo &source,
+                                                             const DiseaseInfo &target) const {
     if (index_.contains("diseases")) {
         auto diseases_path = index_["diseases"]["path"].get<std::string>();
         auto disease_folder = index_["diseases"]["disease"]["path"].get<std::string>();
@@ -362,8 +362,8 @@ RelativeRiskEntity DataManager::get_relative_risk_to_disease(DiseaseInfo source,
 }
 
 RelativeRiskEntity
-DataManager::get_relative_risk_to_risk_factor(DiseaseInfo source, Gender gender,
-                                              core::Identifier risk_factor_key) const {
+DataManager::get_relative_risk_to_risk_factor(const DiseaseInfo &source, Gender gender,
+                                              const core::Identifier &risk_factor_key) const {
     auto table = RelativeRiskEntity();
     if (!index_.contains("diseases")) {
         notify_warning("index has no 'diseases' entry.");
@@ -416,7 +416,8 @@ DataManager::get_relative_risk_to_risk_factor(DiseaseInfo source, Gender gender,
     return table;
 }
 
-CancerParameterEntity DataManager::get_disease_parameter(DiseaseInfo info, Country country) const {
+CancerParameterEntity DataManager::get_disease_parameter(const DiseaseInfo &info,
+                                                         const Country &country) const {
     auto table = CancerParameterEntity();
     if (!index_.contains("diseases")) {
         notify_warning("index has no 'diseases' entry.");
@@ -487,8 +488,8 @@ std::vector<BirthItem> DataManager::get_birth_indicators(const Country &country)
 }
 
 std::vector<BirthItem>
-DataManager::get_birth_indicators(const Country country,
-                                  const std::function<bool(unsigned int)> time_filter) const {
+DataManager::get_birth_indicators(const Country &country,
+                                  const std::function<bool(unsigned int)> &time_filter) const {
     std::vector<BirthItem> result;
     if (index_.contains("demographic")) {
         auto nodepath = index_["demographic"]["path"].get<std::string>();
@@ -560,7 +561,7 @@ std::vector<LmsDataRow> DataManager::get_lms_parameters() const {
     return parameters;
 }
 
-DiseaseAnalysisEntity DataManager::get_disease_analysis(const Country country) const {
+DiseaseAnalysisEntity DataManager::get_disease_analysis(const Country &country) const {
     DiseaseAnalysisEntity entity;
     if (!index_.contains("analysis")) {
         notify_warning("index has no 'analysis' entry.");
@@ -589,7 +590,7 @@ DiseaseAnalysisEntity DataManager::get_disease_analysis(const Country country) c
         entity.disability_weights.emplace(row[0], std::stof(row[1]));
     }
 
-    entity.cost_of_diseases = load_cost_of_diseases(country, cost_node, local_root_path.string());
+    entity.cost_of_diseases = load_cost_of_diseases(country, cost_node, local_root_path);
     entity.life_expectancy = load_life_expectancy(country);
     return entity;
 }
@@ -616,7 +617,7 @@ RelativeRiskEntity DataManager::generate_default_relative_risk_to_disease() cons
 }
 
 std::map<int, std::map<Gender, double>>
-DataManager::load_cost_of_diseases(Country country, nlohmann::json node,
+DataManager::load_cost_of_diseases(const Country &country, const nlohmann::json &node,
                                    const std::filesystem::path &parent_path) const {
     std::map<int, std::map<Gender, double>> result;
     auto cost_path = node["path"].get<std::string>();
@@ -718,7 +719,7 @@ DataManager::create_fields_index_mapping(const std::vector<std::string> &column_
     return mapping;
 }
 
-void DataManager::notify_warning(const std::string_view message) const {
+void DataManager::notify_warning(std::string_view message) const {
     if (verbosity_ == VerboseMode::none) {
         return;
     }

--- a/src/HealthGPS.Datastore/datamanager.cpp
+++ b/src/HealthGPS.Datastore/datamanager.cpp
@@ -76,12 +76,12 @@ Country DataManager::get_country(const std::string &alpha) const {
 }
 
 std::vector<PopulationItem> DataManager::get_population(const Country &country) const {
-    return DataManager::get_population(country, [](const unsigned int &) { return true; });
+    return DataManager::get_population(country, [](unsigned int) { return true; });
 }
 
 std::vector<PopulationItem>
 DataManager::get_population(const Country &country,
-                            const std::function<bool(const unsigned int &)> time_filter) const {
+                            const std::function<bool(unsigned int)> time_filter) const {
     auto results = std::vector<PopulationItem>();
 
     if (index_.contains("demographic")) {
@@ -127,12 +127,12 @@ DataManager::get_population(const Country &country,
 }
 
 std::vector<MortalityItem> DataManager::get_mortality(const Country &country) const {
-    return DataManager::get_mortality(country, [](const unsigned int &) { return true; });
+    return DataManager::get_mortality(country, [](unsigned int) { return true; });
 }
 
 std::vector<MortalityItem>
 DataManager::get_mortality(const Country &country,
-                           const std::function<bool(const unsigned int &)> time_filter) const {
+                           const std::function<bool(unsigned int)> time_filter) const {
     auto results = std::vector<MortalityItem>();
     if (index_.contains("demographic")) {
         auto nodepath = index_["demographic"]["path"].get<std::string>();
@@ -483,11 +483,12 @@ CancerParameterEntity DataManager::get_disease_parameter(DiseaseInfo info, Count
 }
 
 std::vector<BirthItem> DataManager::get_birth_indicators(const Country &country) const {
-    return DataManager::get_birth_indicators(country, [](const unsigned int &) { return true; });
+    return DataManager::get_birth_indicators(country, [](unsigned int) { return true; });
 }
 
-std::vector<BirthItem> DataManager::get_birth_indicators(
-    const Country country, const std::function<bool(const unsigned int &)> time_filter) const {
+std::vector<BirthItem>
+DataManager::get_birth_indicators(const Country country,
+                                  const std::function<bool(unsigned int)> time_filter) const {
     std::vector<BirthItem> result;
     if (index_.contains("demographic")) {
         auto nodepath = index_["demographic"]["path"].get<std::string>();

--- a/src/HealthGPS.Datastore/datamanager.cpp
+++ b/src/HealthGPS.Datastore/datamanager.cpp
@@ -356,7 +356,7 @@ RelativeRiskEntity DataManager::get_relative_risk_to_disease(DiseaseInfo source,
 
     notify_warning("index has no 'diseases' entry.");
 
-    return RelativeRiskEntity();
+    return {};
 }
 
 RelativeRiskEntity
@@ -609,7 +609,7 @@ RelativeRiskEntity DataManager::generate_default_relative_risk_to_disease() cons
     }
     notify_warning("index has no 'diseases' entry.");
 
-    return RelativeRiskEntity();
+    return {};
 }
 
 std::map<int, std::map<Gender, double>>

--- a/src/HealthGPS.Datastore/datamanager.cpp
+++ b/src/HealthGPS.Datastore/datamanager.cpp
@@ -81,7 +81,7 @@ std::vector<PopulationItem> DataManager::get_population(const Country &country) 
 
 std::vector<PopulationItem>
 DataManager::get_population(const Country &country,
-                            const std::function<bool(unsigned int)> &time_filter) const {
+                            std::function<bool(unsigned int)> time_filter) const {
     auto results = std::vector<PopulationItem>();
 
     if (index_.contains("demographic")) {
@@ -132,7 +132,7 @@ std::vector<MortalityItem> DataManager::get_mortality(const Country &country) co
 
 std::vector<MortalityItem>
 DataManager::get_mortality(const Country &country,
-                           const std::function<bool(unsigned int)> &time_filter) const {
+                           std::function<bool(unsigned int)> time_filter) const {
     auto results = std::vector<MortalityItem>();
     if (index_.contains("demographic")) {
         auto nodepath = index_["demographic"]["path"].get<std::string>();
@@ -489,7 +489,7 @@ std::vector<BirthItem> DataManager::get_birth_indicators(const Country &country)
 
 std::vector<BirthItem>
 DataManager::get_birth_indicators(const Country &country,
-                                  const std::function<bool(unsigned int)> &time_filter) const {
+                                  std::function<bool(unsigned int)> time_filter) const {
     std::vector<BirthItem> result;
     if (index_.contains("demographic")) {
         auto nodepath = index_["demographic"]["path"].get<std::string>();

--- a/src/HealthGPS.Datastore/datamanager.h
+++ b/src/HealthGPS.Datastore/datamanager.h
@@ -41,38 +41,39 @@ class DataManager : public Datastore {
 
     std::vector<PopulationItem>
     get_population(const Country &country,
-                   const std::function<bool(unsigned int)> time_filter) const override;
+                   const std::function<bool(unsigned int)> &time_filter) const override;
 
     std::vector<MortalityItem> get_mortality(const Country &country) const;
 
     std::vector<MortalityItem>
     get_mortality(const Country &country,
-                  const std::function<bool(unsigned int)> time_filter) const override;
+                  const std::function<bool(unsigned int)> &time_filter) const override;
 
     std::vector<DiseaseInfo> get_diseases() const override;
 
     DiseaseInfo get_disease_info(const core::Identifier &code) const override;
 
-    DiseaseEntity get_disease(DiseaseInfo info, Country country) const override;
+    DiseaseEntity get_disease(const DiseaseInfo &info, const Country &country) const override;
 
-    RelativeRiskEntity get_relative_risk_to_disease(DiseaseInfo source,
-                                                    DiseaseInfo target) const override;
+    RelativeRiskEntity get_relative_risk_to_disease(const DiseaseInfo &source,
+                                                    const DiseaseInfo &target) const override;
 
     RelativeRiskEntity
-    get_relative_risk_to_risk_factor(DiseaseInfo source, Gender gender,
-                                     core::Identifier risk_factor_key) const override;
+    get_relative_risk_to_risk_factor(const DiseaseInfo &source, Gender gender,
+                                     const core::Identifier &risk_factor_key) const override;
 
     /// @copydoc core::Datastore::get_disease_parameter
     /// @throws std::out_of_range for unknown disease parameter file type.
-    CancerParameterEntity get_disease_parameter(DiseaseInfo info, Country country) const override;
+    CancerParameterEntity get_disease_parameter(const DiseaseInfo &info,
+                                                const Country &country) const override;
 
-    DiseaseAnalysisEntity get_disease_analysis(const Country country) const override;
+    DiseaseAnalysisEntity get_disease_analysis(const Country &country) const override;
 
     std::vector<BirthItem> get_birth_indicators(const Country &country) const;
 
     std::vector<BirthItem>
-    get_birth_indicators(const Country country,
-                         const std::function<bool(unsigned int)> time_filter) const override;
+    get_birth_indicators(const Country &country,
+                         const std::function<bool(unsigned int)> &time_filter) const override;
 
     std::vector<LmsDataRow> get_lms_parameters() const override;
 
@@ -84,7 +85,7 @@ class DataManager : public Datastore {
     RelativeRiskEntity generate_default_relative_risk_to_disease() const;
 
     std::map<int, std::map<Gender, double>>
-    load_cost_of_diseases(Country country, nlohmann::json node,
+    load_cost_of_diseases(const Country &country, const nlohmann::json &node,
                           const std::filesystem::path &parent_path) const;
 
     std::vector<LifeExpectancyItem> load_life_expectancy(const Country &country) const;
@@ -96,7 +97,7 @@ class DataManager : public Datastore {
     create_fields_index_mapping(const std::vector<std::string> &column_names,
                                 const std::vector<std::string> &fields);
 
-    void notify_warning(const std::string_view message) const;
+    void notify_warning(std::string_view message) const;
 };
 
 } // namespace hgps::data

--- a/src/HealthGPS.Datastore/datamanager.h
+++ b/src/HealthGPS.Datastore/datamanager.h
@@ -30,23 +30,23 @@ class DataManager : public Datastore {
     /// @param verbosity The terminal logging verbosity mode to use.
     /// @throws std::invalid_argument if the root directory or index.json is missing.
     /// @throws std::runtime_error for invalid or unsupported index.json file schema version.
-    explicit DataManager(const std::filesystem::path root_directory,
+    explicit DataManager(std::filesystem::path root_directory,
                          VerboseMode verbosity = VerboseMode::none);
 
     std::vector<Country> get_countries() const override;
 
     Country get_country(const std::string &alpha) const override;
 
-    std::vector<PopulationItem> get_population(Country country) const;
+    std::vector<PopulationItem> get_population(const Country &country) const;
 
     std::vector<PopulationItem>
-    get_population(Country country,
+    get_population(const Country &country,
                    const std::function<bool(const unsigned int &)> time_filter) const override;
 
-    std::vector<MortalityItem> get_mortality(Country country) const;
+    std::vector<MortalityItem> get_mortality(const Country &country) const;
 
     std::vector<MortalityItem>
-    get_mortality(Country country,
+    get_mortality(const Country &country,
                   const std::function<bool(const unsigned int &)> time_filter) const override;
 
     std::vector<DiseaseInfo> get_diseases() const override;
@@ -68,7 +68,7 @@ class DataManager : public Datastore {
 
     DiseaseAnalysisEntity get_disease_analysis(const Country country) const override;
 
-    std::vector<BirthItem> get_birth_indicators(const Country country) const;
+    std::vector<BirthItem> get_birth_indicators(const Country &country) const;
 
     std::vector<BirthItem> get_birth_indicators(
         const Country country,
@@ -85,11 +85,12 @@ class DataManager : public Datastore {
 
     std::map<int, std::map<Gender, double>>
     load_cost_of_diseases(Country country, nlohmann::json node,
-                          std::filesystem::path parent_path) const;
+                          const std::filesystem::path &parent_path) const;
 
     std::vector<LifeExpectancyItem> load_life_expectancy(const Country &country) const;
 
-    static std::string replace_string_tokens(std::string source, std::vector<std::string> tokens);
+    static std::string replace_string_tokens(const std::string &source,
+                                             const std::vector<std::string> &tokens);
 
     static std::map<std::string, std::size_t>
     create_fields_index_mapping(const std::vector<std::string> &column_names,

--- a/src/HealthGPS.Datastore/datamanager.h
+++ b/src/HealthGPS.Datastore/datamanager.h
@@ -41,13 +41,13 @@ class DataManager : public Datastore {
 
     std::vector<PopulationItem>
     get_population(const Country &country,
-                   const std::function<bool(unsigned int)> &time_filter) const override;
+                   std::function<bool(unsigned int)> time_filter) const override;
 
     std::vector<MortalityItem> get_mortality(const Country &country) const;
 
     std::vector<MortalityItem>
     get_mortality(const Country &country,
-                  const std::function<bool(unsigned int)> &time_filter) const override;
+                  std::function<bool(unsigned int)> time_filter) const override;
 
     std::vector<DiseaseInfo> get_diseases() const override;
 
@@ -73,7 +73,7 @@ class DataManager : public Datastore {
 
     std::vector<BirthItem>
     get_birth_indicators(const Country &country,
-                         const std::function<bool(unsigned int)> &time_filter) const override;
+                         std::function<bool(unsigned int)> time_filter) const override;
 
     std::vector<LmsDataRow> get_lms_parameters() const override;
 

--- a/src/HealthGPS.Datastore/datamanager.h
+++ b/src/HealthGPS.Datastore/datamanager.h
@@ -41,13 +41,13 @@ class DataManager : public Datastore {
 
     std::vector<PopulationItem>
     get_population(const Country &country,
-                   const std::function<bool(const unsigned int &)> time_filter) const override;
+                   const std::function<bool(unsigned int)> time_filter) const override;
 
     std::vector<MortalityItem> get_mortality(const Country &country) const;
 
     std::vector<MortalityItem>
     get_mortality(const Country &country,
-                  const std::function<bool(const unsigned int &)> time_filter) const override;
+                  const std::function<bool(unsigned int)> time_filter) const override;
 
     std::vector<DiseaseInfo> get_diseases() const override;
 
@@ -70,9 +70,9 @@ class DataManager : public Datastore {
 
     std::vector<BirthItem> get_birth_indicators(const Country &country) const;
 
-    std::vector<BirthItem> get_birth_indicators(
-        const Country country,
-        const std::function<bool(const unsigned int &)> time_filter) const override;
+    std::vector<BirthItem>
+    get_birth_indicators(const Country country,
+                         const std::function<bool(unsigned int)> time_filter) const override;
 
     std::vector<LmsDataRow> get_lms_parameters() const override;
 

--- a/src/HealthGPS.Tests/Channel.Test.cpp
+++ b/src/HealthGPS.Tests/Channel.Test.cpp
@@ -209,6 +209,8 @@ TEST(ChannelTest, MultipleConsumers) {
 
     // Create multiple consumers
     std::vector<std::jthread> threads;
+    threads.reserve(number_of_consumers);
+
     for (auto i = 0; i < number_of_consumers; ++i) {
         threads.emplace_back(consumer);
     }

--- a/src/HealthGPS.Tests/Channel.Test.cpp
+++ b/src/HealthGPS.Tests/Channel.Test.cpp
@@ -210,7 +210,7 @@ TEST(ChannelTest, MultipleConsumers) {
     // Create multiple consumers
     std::vector<std::jthread> threads;
     for (auto i = 0; i < number_of_consumers; ++i) {
-        threads.emplace_back(std::jthread{consumer});
+        threads.emplace_back(consumer);
     }
 
     // Producer

--- a/src/HealthGPS.Tests/Core.Array2DTest.cpp
+++ b/src/HealthGPS.Tests/Core.Array2DTest.cpp
@@ -193,7 +193,7 @@ TEST(TestCore_Array2D, PrintDataToString) {
 
     ASSERT_TRUE(i3str.size() > 10);
     EXPECT_EQ(0, i3str.find_first_of("Array"));
-    EXPECT_TRUE(i3str.find_first_of(":") > 0);
+    EXPECT_TRUE(i3str.find_first_of(':') > 0);
     EXPECT_EQ('\n', i3str.back());
 }
 

--- a/src/HealthGPS.Tests/Core.Test.cpp
+++ b/src/HealthGPS.Tests/Core.Test.cpp
@@ -173,7 +173,7 @@ TEST(TestCore, CreateDataTable) {
 
     // Casting to columns type
     const auto &col = table.column("Integer");
-    const auto &int_col = static_cast<const IntegerDataTableColumn &>(col);
+    const auto &int_col = dynamic_cast<const IntegerDataTableColumn &>(col);
 
     auto slow_value = std::any_cast<int>(col.value(1));
     auto safe_value = int_col.value_safe(1);

--- a/src/HealthGPS.Tests/Datastore.Test.cpp
+++ b/src/HealthGPS.Tests/Datastore.Test.cpp
@@ -44,9 +44,8 @@ TEST_F(DatastoreTest, CountryPopulation) {
     auto uk_pop_min = uk_pop.front().at_time;
     auto uk_pop_max = uk_pop.back().at_time;
     auto mid_year = std::midpoint(uk_pop_min, uk_pop_max);
-    auto uk_pop_flt = manager.get_population(uk, [&mid_year](const int &value) {
-        return value >= (mid_year - 1) && value <= (mid_year + 1);
-    });
+    auto uk_pop_flt = manager.get_population(
+        uk, [&mid_year](int value) { return value >= (mid_year - 1) && value <= (mid_year + 1); });
 
     ASSERT_GT(uk_pop.size(), 0);
     ASSERT_GT(uk_pop_flt.size(), 0);
@@ -87,9 +86,8 @@ TEST_F(DatastoreTest, CountryMortality) {
     auto uk_deaths_min = uk_deaths.front().at_time;
     auto uk_deaths_max = uk_deaths.back().at_time;
     auto mid_year = std::midpoint(uk_deaths_min, uk_deaths_max);
-    auto uk_deaths_flt = manager.get_mortality(uk, [&mid_year](const int &value) {
-        return value >= (mid_year - 1) && value <= (mid_year + 1);
-    });
+    auto uk_deaths_flt = manager.get_mortality(
+        uk, [&mid_year](int value) { return value >= (mid_year - 1) && value <= (mid_year + 1); });
 
     ASSERT_GT(uk_deaths.size(), 0);
     ASSERT_GT(uk_deaths_flt.size(), 0);
@@ -264,9 +262,8 @@ TEST_F(DatastoreTest, RetrieveBirthIndicators) {
     auto uk_births_min = uk_births.front().at_time;
     auto uk_births_max = uk_births.back().at_time;
     auto mid_year = std::midpoint(uk_births_min, uk_births_max);
-    auto uk_births_flt = manager.get_birth_indicators(uk, [&mid_year](const int &value) {
-        return value >= (mid_year - 1) && value <= (mid_year + 1);
-    });
+    auto uk_births_flt = manager.get_birth_indicators(
+        uk, [&mid_year](int value) { return value >= (mid_year - 1) && value <= (mid_year + 1); });
 
     ASSERT_FALSE(uk_births.empty());
     ASSERT_GT(uk_births.size(), 0);

--- a/src/HealthGPS.Tests/Datastore.Test.cpp
+++ b/src/HealthGPS.Tests/Datastore.Test.cpp
@@ -3,8 +3,6 @@
 
 #include "HealthGPS.Datastore/api.h"
 
-namespace fs = std::filesystem;
-
 // The fixture for testing class Foo.
 class DatastoreTest : public ::testing::Test {
   protected:

--- a/src/HealthGPS.Tests/EventAggregator.Test.cpp
+++ b/src/HealthGPS.Tests/EventAggregator.Test.cpp
@@ -64,7 +64,9 @@ TEST(TestHealthGPS_EventBus, AddEventSubscribers) {
 
     // auto counter = 0;
     auto handler = TestHandler{};
-    auto member_callback = std::bind(&TestHandler::handler_event, &handler, _1);
+    auto member_callback = [ObjectPtr = &handler](auto &&PH1) {
+        ObjectPtr->handler_event(std::forward<decltype(PH1)>(PH1));
+    };
 
     auto hub = DefaultEventBus{};
     auto free_sub = hub.subscribe(EventType::info, free_handler_event);
@@ -90,7 +92,9 @@ TEST(TestHealthGPS_EventBus, HandlerAutoUnsubscribe) {
 
     auto counter = 0;
     auto handler = TestHandler{};
-    auto member_callback = std::bind(&TestHandler::handler_event, &handler, _1);
+    auto member_callback = [ObjectPtr = &handler](auto &&PH1) {
+        ObjectPtr->handler_event(std::forward<decltype(PH1)>(PH1));
+    };
 
     auto hub = DefaultEventBus{};
     {
@@ -114,7 +118,9 @@ TEST(TestHealthGPS_EventBus, ContainerAutoUnsubscribe) {
 
     auto counter = 0;
     auto handler = TestHandler{};
-    auto member_callback = std::bind(&TestHandler::handler_event, &handler, _1);
+    auto member_callback = [ObjectPtr = &handler](auto &&PH1) {
+        ObjectPtr->handler_event(std::forward<decltype(PH1)>(PH1));
+    };
 
     std::vector<std::unique_ptr<EventSubscriber>> subscribers;
 
@@ -141,7 +147,9 @@ TEST(TestHealthGPS_EventBus, ClearUnsubscribes) {
 
     auto counter = 0;
     auto handler = TestHandler{};
-    auto member_callback = std::bind(&TestHandler::handler_event, &handler, _1);
+    auto member_callback = [ObjectPtr = &handler](auto &&PH1) {
+        ObjectPtr->handler_event(std::forward<decltype(PH1)>(PH1));
+    };
 
     auto hub = DefaultEventBus{};
     auto free_sub = hub.subscribe(EventType::info, free_handler_event);
@@ -161,7 +169,9 @@ TEST(TestHealthGPS_EventBus, PublishToSubscribers) {
     auto counter = 0;
     auto expected = 2;
     auto handler = TestHandler{};
-    auto callback = std::bind(&TestHandler::handler_event, &handler, _1);
+    auto callback = [ObjectPtr = &handler](auto &&PH1) {
+        ObjectPtr->handler_event(std::forward<decltype(PH1)>(PH1));
+    };
 
     auto hub = DefaultEventBus{};
     auto fun_sub = hub.subscribe(EventType::info, callback);
@@ -186,7 +196,9 @@ TEST(TestHealthGPS_EventBus, PublishToFilteredSubscribers) {
     auto count_expected = 2;
 
     auto info_handler = TestHandler{};
-    auto info_callback = std::bind(&TestHandler::handler_event, &info_handler, _1);
+    auto info_callback = [ObjectPtr = &info_handler](auto &&PH1) {
+        ObjectPtr->handler_event(std::forward<decltype(PH1)>(PH1));
+    };
 
     auto hub = DefaultEventBus{};
     auto info_sub = hub.subscribe(EventType::info, info_callback);

--- a/src/HealthGPS.Tests/EventAggregator.Test.cpp
+++ b/src/HealthGPS.Tests/EventAggregator.Test.cpp
@@ -12,10 +12,7 @@ struct TestHandler {
     int counter{};
 };
 
-static int global_counter = 0;
-static void free_handler_event(const std::shared_ptr<hgps::EventMessage> & /*unused*/) {
-    global_counter++;
-}
+const auto event_noop = [](const std::shared_ptr<hgps::EventMessage> & /*unused*/) {};
 
 TEST(TestHealthGPS_EventBus, CreateHandlerIdentifier) {
     using namespace hgps;
@@ -71,7 +68,7 @@ TEST(TestHealthGPS_EventBus, AddEventSubscribers) {
     };
 
     auto hub = DefaultEventBus{};
-    auto free_sub = hub.subscribe(EventType::info, free_handler_event);
+    auto free_sub = hub.subscribe(EventType::info, event_noop);
     auto fun_sub = hub.subscribe(EventType::info, member_callback);
     // GCC lambda optimization bug, optimized out.
     // auto lam_sub = hub.subscribe(EventType::info,
@@ -100,7 +97,7 @@ TEST(TestHealthGPS_EventBus, HandlerAutoUnsubscribe) {
 
     auto hub = DefaultEventBus{};
     {
-        auto free_sub = hub.subscribe(EventType::info, free_handler_event);
+        auto free_sub = hub.subscribe(EventType::info, event_noop);
         auto fun_sub = hub.subscribe(EventType::info, member_callback);
         auto lam_sub =
             hub.subscribe(EventType::info,
@@ -128,7 +125,7 @@ TEST(TestHealthGPS_EventBus, ContainerAutoUnsubscribe) {
     std::vector<std::unique_ptr<EventSubscriber>> subscribers;
 
     auto hub = DefaultEventBus{};
-    subscribers.push_back(hub.subscribe(EventType::info, free_handler_event));
+    subscribers.push_back(hub.subscribe(EventType::info, event_noop));
     subscribers.push_back(hub.subscribe(EventType::info, member_callback));
     subscribers.push_back(hub.subscribe(
         EventType::info, [&counter](const std::shared_ptr<hgps::EventMessage> &) { counter++; }));
@@ -155,7 +152,7 @@ TEST(TestHealthGPS_EventBus, ClearUnsubscribes) {
     };
 
     auto hub = DefaultEventBus{};
-    auto free_sub = hub.subscribe(EventType::info, free_handler_event);
+    auto free_sub = hub.subscribe(EventType::info, event_noop);
     auto fun_sub = hub.subscribe(EventType::info, member_callback);
     auto lam_sub = hub.subscribe(
         EventType::info, [&counter](const std::shared_ptr<hgps::EventMessage> &) { counter++; });

--- a/src/HealthGPS.Tests/EventAggregator.Test.cpp
+++ b/src/HealthGPS.Tests/EventAggregator.Test.cpp
@@ -7,13 +7,15 @@
 #include "HealthGPS/runner_message.h"
 
 struct TestHandler {
-    void handler_event(std::shared_ptr<hgps::EventMessage> /*unused*/) { counter++; }
+    void handler_event(const std::shared_ptr<hgps::EventMessage> & /*unused*/) { counter++; }
 
     int counter{};
 };
 
 static int global_counter = 0;
-static void free_handler_event(std::shared_ptr<hgps::EventMessage> /*unused*/) { global_counter++; }
+static void free_handler_event(const std::shared_ptr<hgps::EventMessage> & /*unused*/) {
+    global_counter++;
+}
 
 TEST(TestHealthGPS_EventBus, CreateHandlerIdentifier) {
     using namespace hgps;
@@ -100,8 +102,9 @@ TEST(TestHealthGPS_EventBus, HandlerAutoUnsubscribe) {
     {
         auto free_sub = hub.subscribe(EventType::info, free_handler_event);
         auto fun_sub = hub.subscribe(EventType::info, member_callback);
-        auto lam_sub = hub.subscribe(
-            EventType::info, [&counter](std::shared_ptr<hgps::EventMessage>) { counter++; });
+        auto lam_sub =
+            hub.subscribe(EventType::info,
+                          [&counter](const std::shared_ptr<hgps::EventMessage> &) { counter++; });
 
         ASSERT_EQ(expected, hub.count());
     }
@@ -128,7 +131,7 @@ TEST(TestHealthGPS_EventBus, ContainerAutoUnsubscribe) {
     subscribers.push_back(hub.subscribe(EventType::info, free_handler_event));
     subscribers.push_back(hub.subscribe(EventType::info, member_callback));
     subscribers.push_back(hub.subscribe(
-        EventType::info, [&counter](std::shared_ptr<hgps::EventMessage>) { counter++; }));
+        EventType::info, [&counter](const std::shared_ptr<hgps::EventMessage> &) { counter++; }));
 
     ASSERT_EQ(expected, hub.count());
     ASSERT_EQ(expected, subscribers.size());
@@ -154,8 +157,8 @@ TEST(TestHealthGPS_EventBus, ClearUnsubscribes) {
     auto hub = DefaultEventBus{};
     auto free_sub = hub.subscribe(EventType::info, free_handler_event);
     auto fun_sub = hub.subscribe(EventType::info, member_callback);
-    auto lam_sub = hub.subscribe(EventType::info,
-                                 [&counter](std::shared_ptr<hgps::EventMessage>) { counter++; });
+    auto lam_sub = hub.subscribe(
+        EventType::info, [&counter](const std::shared_ptr<hgps::EventMessage> &) { counter++; });
 
     ASSERT_EQ(expected, hub.count());
     hub.clear();
@@ -175,8 +178,8 @@ TEST(TestHealthGPS_EventBus, PublishToSubscribers) {
 
     auto hub = DefaultEventBus{};
     auto fun_sub = hub.subscribe(EventType::info, callback);
-    auto lam_sub = hub.subscribe(EventType::info,
-                                 [&counter](std::shared_ptr<hgps::EventMessage>) { counter++; });
+    auto lam_sub = hub.subscribe(
+        EventType::info, [&counter](const std::shared_ptr<hgps::EventMessage> &) { counter++; });
     hub.publish(std::make_unique<InfoEventMessage>("UnitTest", ModelAction::start, 1, 2010));
     hub.publish_async(std::make_unique<InfoEventMessage>("UnitTest", ModelAction::start, 2, 2010));
 
@@ -202,14 +205,15 @@ TEST(TestHealthGPS_EventBus, PublishToFilteredSubscribers) {
 
     auto hub = DefaultEventBus{};
     auto info_sub = hub.subscribe(EventType::info, info_callback);
-    auto run_sub =
-        hub.subscribe(EventType::runner,
-                      [&runner_count](std::shared_ptr<hgps::EventMessage>) { runner_count++; });
+    auto run_sub = hub.subscribe(
+        EventType::runner,
+        [&runner_count](const std::shared_ptr<hgps::EventMessage> &) { runner_count++; });
     auto err_sub = hub.subscribe(
-        EventType::error, [&error_count](std::shared_ptr<hgps::EventMessage>) { error_count++; });
-    auto result_sub =
-        hub.subscribe(EventType::result,
-                      [&result_count](std::shared_ptr<hgps::EventMessage>) { result_count++; });
+        EventType::error,
+        [&error_count](const std::shared_ptr<hgps::EventMessage> &) { error_count++; });
+    auto result_sub = hub.subscribe(
+        EventType::result,
+        [&result_count](const std::shared_ptr<hgps::EventMessage> &) { result_count++; });
 
     hub.publish(std::make_unique<RunnerEventMessage>("UnitTest", RunnerAction::start));
     hub.publish_async(std::make_unique<InfoEventMessage>("UnitTest", ModelAction::start, 1, 0));

--- a/src/HealthGPS.Tests/HealthGPS.Test.cpp
+++ b/src/HealthGPS.Tests/HealthGPS.Test.cpp
@@ -13,9 +13,10 @@
 #include <map>
 #include <optional>
 
-static std::vector<hgps::MappingEntry> create_mapping_entries() {
-    return {{"Gender", 0}, {"Age", 0}, {"SmokingStatus", 1}, {"AlcoholConsumption", 1}, {"BMI", 2}};
-}
+namespace {
+std::vector<hgps::MappingEntry> mapping_entries{
+    {{"Gender", 0}, {"Age", 0}, {"SmokingStatus", 1}, {"AlcoholConsumption", 1}, {"BMI", 2}}};
+} // anonymous namespace
 
 void create_test_datatable(hgps::core::DataTable &data) {
     using namespace hgps;
@@ -61,8 +62,7 @@ hgps::ModelInput create_test_configuration(hgps::core::DataTable &data) {
         {"gender", "Gender"}, {"age", "Age"}, {"education", "Education"}, {"income", "Income"}};
     auto ses = SESDefinition{.fuction_name = "normal", .parameters = std::vector<double>{0.0, 1.0}};
 
-    auto entries = create_mapping_entries();
-    auto mapping = HierarchicalMapping(std::move(entries));
+    auto mapping = HierarchicalMapping(mapping_entries);
 
     auto diseases = std::vector<core::DiseaseInfo>{
         DiseaseInfo{

--- a/src/HealthGPS.Tests/HealthGPS.Test.cpp
+++ b/src/HealthGPS.Tests/HealthGPS.Test.cpp
@@ -310,7 +310,7 @@ TEST(TestHealthGPS, ModuleFactoryRegistry) {
                              });
 
     auto base_module = factory.create(SimulationModuleType::Analysis, config);
-    auto *country_mod = static_cast<CountryModule *>(base_module.get());
+    auto *country_mod = dynamic_cast<CountryModule *>(base_module.get());
     country_mod->execute("print");
 
     ASSERT_EQ(SimulationModuleType::Analysis, country_mod->type());

--- a/src/HealthGPS.Tests/HealthGPS.Test.cpp
+++ b/src/HealthGPS.Tests/HealthGPS.Test.cpp
@@ -77,7 +77,7 @@ hgps::ModelInput create_test_configuration(hgps::core::DataTable &data) {
                     .name = "Colorectal cancer"},
     };
 
-    return ModelInput(data, settings, info, ses, mapping, diseases);
+    return {data, settings, info, ses, mapping, diseases};
 }
 
 TEST(TestHealthGPS, RandomBitGenerator) {

--- a/src/HealthGPS.Tests/HealthGPS.Test.cpp
+++ b/src/HealthGPS.Tests/HealthGPS.Test.cpp
@@ -13,8 +13,6 @@
 #include <map>
 #include <optional>
 
-namespace fs = std::filesystem;
-
 static std::vector<hgps::MappingEntry> create_mapping_entries() {
     return {{"Gender", 0}, {"Age", 0}, {"SmokingStatus", 1}, {"AlcoholConsumption", 1}, {"BMI", 2}};
 }

--- a/src/HealthGPS.Tests/HierarchicalMapping.Test.cpp
+++ b/src/HealthGPS.Tests/HierarchicalMapping.Test.cpp
@@ -2,9 +2,10 @@
 
 #include "HealthGPS/mapping.h"
 
-static std::vector<hgps::MappingEntry> create_mapping_entries() {
-    return {{"Gender", 0}, {"Age", 0}, {"SmokingStatus", 1}, {"AlcoholConsumption", 1}, {"BMI", 2}};
-}
+namespace {
+std::vector<hgps::MappingEntry> mapping_entries{
+    {{"Gender", 0}, {"Age", 0}, {"SmokingStatus", 1}, {"AlcoholConsumption", 1}, {"BMI", 2}}};
+} // anonymous namespace
 
 TEST(TestHealthGPS_Mapping, CreateEmpty) {
     using namespace hgps;
@@ -19,15 +20,13 @@ TEST(TestHealthGPS_Mapping, CreateEmpty) {
 TEST(TestHealthGPS_Mapping, CreateFull) {
     using namespace hgps;
 
-    auto entries = create_mapping_entries();
-    auto exp_size = entries.size();
-    auto mapping = HierarchicalMapping(std::move(entries));
+    auto mapping = HierarchicalMapping(mapping_entries);
 
     auto level_zero = mapping.at_level(0);
     auto level_one = mapping.at_level(1);
     auto level_two = mapping.at_level(2);
 
-    ASSERT_EQ(exp_size, mapping.size());
+    ASSERT_EQ(mapping_entries.size(), mapping.size());
     ASSERT_EQ(2, mapping.max_level());
 
     ASSERT_EQ(2, level_zero.size());
@@ -38,11 +37,9 @@ TEST(TestHealthGPS_Mapping, CreateFull) {
 TEST(TestHealthGPS_Mapping, AccessByInterator) {
     using namespace hgps;
 
-    auto entries = create_mapping_entries();
-    auto exp_size = entries.size();
-    auto mapping = HierarchicalMapping(std::move(entries));
+    auto mapping = HierarchicalMapping(mapping_entries);
 
-    ASSERT_EQ(exp_size, mapping.size());
+    ASSERT_EQ(mapping_entries.size(), mapping.size());
     for (auto &entry : mapping) {
         ASSERT_GE(entry.level(), 0);
     }
@@ -51,11 +48,9 @@ TEST(TestHealthGPS_Mapping, AccessByInterator) {
 TEST(TestHealthGPS_Mapping, AccessByConstInterator) {
     using namespace hgps;
 
-    auto entries = create_mapping_entries();
-    auto exp_size = entries.size();
-    auto mapping = HierarchicalMapping(std::move(entries));
+    auto mapping = HierarchicalMapping(mapping_entries);
 
-    ASSERT_EQ(exp_size, mapping.size());
+    ASSERT_EQ(mapping_entries.size(), mapping.size());
     for (const auto &entry : mapping) {
         ASSERT_GE(entry.level(), 0);
     }
@@ -64,19 +59,16 @@ TEST(TestHealthGPS_Mapping, AccessByConstInterator) {
 TEST(TestHealthGPS_Mapping, AccessAllEntries) {
     using namespace hgps;
 
-    auto entries = create_mapping_entries();
-    auto exp_size = entries.size();
-    auto mapping = HierarchicalMapping(std::move(entries));
+    auto mapping = HierarchicalMapping(mapping_entries);
     const auto &all_entries = mapping.entries();
 
-    ASSERT_EQ(exp_size, all_entries.size());
+    ASSERT_EQ(mapping_entries.size(), all_entries.size());
 }
 
 TEST(TestHealthGPS_Mapping, AccessSingleEntry) {
     using namespace hgps;
 
-    auto entries = create_mapping_entries();
-    auto mapping = HierarchicalMapping(std::move(entries));
+    auto mapping = HierarchicalMapping(mapping_entries);
 
     auto age_key = core::Identifier{"Age"};
     auto gender_key = core::Identifier{"GENDER"};
@@ -91,11 +83,10 @@ TEST(TestHealthGPS_Mapping, AccessSingleEntry) {
 TEST(TestHealthGPS_Mapping, AccessSingleEntryThrowForUnknowKey) {
     using namespace hgps;
 
-    auto entries = create_mapping_entries();
     auto test_keys = std::vector<core::Identifier>{core::Identifier{"Cat"}, core::Identifier{"Dog"},
                                                    core::Identifier{"Cow"}};
 
-    auto mapping = HierarchicalMapping(std::move(entries));
+    auto mapping = HierarchicalMapping(mapping_entries);
     for (const auto &key : test_keys) {
         ASSERT_THROW(mapping.at(key), std::out_of_range);
     }
@@ -104,9 +95,8 @@ TEST(TestHealthGPS_Mapping, AccessSingleEntryThrowForUnknowKey) {
 TEST(TestHealthGPS_Mapping, AccessAllLevelEntries) {
     using namespace hgps;
 
-    auto entries = create_mapping_entries();
     std::vector<int> exp_size = {2, 2, 1};
-    auto mapping = HierarchicalMapping(std::move(entries));
+    auto mapping = HierarchicalMapping(mapping_entries);
     auto level_0_entries = mapping.at_level(0);
     auto level_1_entries = mapping.at_level(1);
     auto level_2_entries = mapping.at_level(2);

--- a/src/HealthGPS.Tests/Population.Test.cpp
+++ b/src/HealthGPS.Tests/Population.Test.cpp
@@ -25,7 +25,7 @@ TEST(TestHealthGPS_Population, CreateUniquePerson) {
 
     auto p1 = Person{};
     auto p2 = Person{};
-    auto p3 = p1;
+    const auto &p3 = p1;
 
     ASSERT_GT(p1.id(), 0);
     ASSERT_GT(p2.id(), p1.id());

--- a/src/HealthGPS.Tests/RelativeRiskLookup.Test.cpp
+++ b/src/HealthGPS.Tests/RelativeRiskLookup.Test.cpp
@@ -82,8 +82,7 @@ TEST(TestRelativeRiskLookup, InterpolateValueLookup) {
     ASSERT_EQ(expected_rows, lut.rows());
     ASSERT_EQ(expected_cols, lut.columns());
     ASSERT_EQ(expected_size, lut.size());
-    for (size_t i = 0; i < test_values.size(); i++) {
-        auto value = test_values[i];
+    for (float value : test_values) {
         auto lut_value = lut(test_age, value);
         if (value <= lut_cols.front()) {
             ASSERT_EQ(expected_row3.front(), lut_value);

--- a/src/HealthGPS.Tests/Repository.Test.cpp
+++ b/src/HealthGPS.Tests/Repository.Test.cpp
@@ -7,8 +7,6 @@
 
 #include <chrono>
 
-namespace fs = std::filesystem;
-
 // The fixture for testing class Foo.
 class RepositoryTest : public ::testing::Test {
   protected:

--- a/src/HealthGPS.Tests/Scenario.Test.cpp
+++ b/src/HealthGPS.Tests/Scenario.Test.cpp
@@ -20,7 +20,8 @@ hgps::FiscalPolicyDefinition create_fiscal_policy_definition(hgps::FiscalImpactT
     return FiscalPolicyDefinition{impact_type, period, impacts};
 }
 
-hgps::MarketingDynamicDefinition create_dynamic_marketing_definition(std::vector<double> dynamic) {
+hgps::MarketingDynamicDefinition
+create_dynamic_marketing_definition(const std::vector<double> &dynamic) {
     using namespace hgps;
     auto period = PolicyInterval(2022, 2030);
     auto impacts = std::vector<PolicyImpact>{PolicyImpact{bmi_key, -0.12, 5, 12},

--- a/src/HealthGPS.Tests/WeightModel.Test.cpp
+++ b/src/HealthGPS.Tests/WeightModel.Test.cpp
@@ -9,8 +9,6 @@
 
 #include <array>
 
-namespace fs = std::filesystem;
-
 hgps::LmsDefinition lms_parameters;
 
 inline const hgps::core::Identifier bmi_key = hgps::core::Identifier{"bmi"};

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -371,7 +371,7 @@ void AnalysisModule::initialise_output_channels(RuntimeContext &context) {
         return;
     }
 
-    channels_.push_back("count");
+    channels_.emplace_back("count");
     for (const auto &factor : context.mapping().entries()) {
         channels_.emplace_back(factor.key().to_string());
     }

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -67,7 +67,7 @@ void AnalysisModule::initialise_population(RuntimeContext &context) {
 void AnalysisModule::update_population(RuntimeContext &context) { publish_result_message(context); }
 
 double
-AnalysisModule::calculate_residual_disability_weight(const int &age, const core::Gender gender,
+AnalysisModule::calculate_residual_disability_weight(int age, const core::Gender gender,
                                                      const DoubleAgeGenderTable &expected_sum,
                                                      const IntegerAgeGenderTable &expected_count) {
     auto residual_value = 0.0;

--- a/src/HealthGPS/analysis_module.h
+++ b/src/HealthGPS/analysis_module.h
@@ -39,7 +39,7 @@ class AnalysisModule final : public UpdatableModule {
     unsigned int comorbidities_;
     std::string name_{"Analysis"};
 
-    double calculate_residual_disability_weight(int age, const core::Gender gender,
+    double calculate_residual_disability_weight(int age, core::Gender gender,
                                                 const DoubleAgeGenderTable &expected_sum,
                                                 const IntegerAgeGenderTable &expected_count);
 

--- a/src/HealthGPS/analysis_module.h
+++ b/src/HealthGPS/analysis_module.h
@@ -39,7 +39,7 @@ class AnalysisModule final : public UpdatableModule {
     unsigned int comorbidities_;
     std::string name_{"Analysis"};
 
-    double calculate_residual_disability_weight(const int &age, const core::Gender gender,
+    double calculate_residual_disability_weight(int age, const core::Gender gender,
                                                 const DoubleAgeGenderTable &expected_sum,
                                                 const IntegerAgeGenderTable &expected_count);
 

--- a/src/HealthGPS/converter.cpp
+++ b/src/HealthGPS/converter.cpp
@@ -4,8 +4,7 @@
 #include "default_cancer_model.h"
 #include <fmt/format.h>
 
-namespace hgps {
-namespace detail {
+namespace hgps::detail {
 core::Gender StoreConverter::to_gender(const std::string name) {
     if (core::case_insensitive::equals(name, "male")) {
         return core::Gender::male;
@@ -183,5 +182,4 @@ LmsDefinition StoreConverter::to_lms_definition(const std::vector<core::LmsDataR
 
     return LmsDefinition{std::move(lms_dataset)};
 }
-} // namespace detail
-} // namespace hgps
+} // namespace hgps::detail

--- a/src/HealthGPS/converter.cpp
+++ b/src/HealthGPS/converter.cpp
@@ -24,7 +24,7 @@ DiseaseTable StoreConverter::to_disease_table(const core::DiseaseEntity &entity)
         data[v.with_age][v.gender] = DiseaseMeasure(v.measures);
     }
 
-    return DiseaseTable(entity.info, std::move(measures), std::move(data));
+    return {entity.info, std::move(measures), std::move(data)};
 }
 
 FloatAgeGenderTable StoreConverter::to_relative_risk_table(const core::RelativeRiskEntity &entity) {
@@ -51,7 +51,7 @@ FloatAgeGenderTable StoreConverter::to_relative_risk_table(const core::RelativeR
         }
     }
 
-    return FloatAgeGenderTable(MonotonicVector(rows), cols, std::move(data));
+    return {MonotonicVector(rows), cols, std::move(data)};
 }
 
 RelativeRiskLookup StoreConverter::to_relative_risk_lookup(const core::RelativeRiskEntity &entity) {
@@ -72,7 +72,7 @@ RelativeRiskLookup StoreConverter::to_relative_risk_lookup(const core::RelativeR
         }
     }
 
-    return RelativeRiskLookup(MonotonicVector(rows), MonotonicVector(cols), std::move(data));
+    return {MonotonicVector(rows), MonotonicVector(cols), std::move(data)};
 }
 
 RelativeRisk create_relative_risk(const RelativeRiskInfo &info) {
@@ -133,8 +133,7 @@ StoreConverter::to_analysis_definition(const core::DiseaseAnalysisEntity &entity
         weights.emplace(core::Identifier{item.first}, item.second);
     }
 
-    return AnalysisDefinition(std::move(life_expectancy), std::move(cost_of_disease),
-                              std::move(weights));
+    return {std::move(life_expectancy), std::move(cost_of_disease), std::move(weights)};
 }
 
 LifeTable StoreConverter::to_life_table(const std::vector<core::BirthItem> &births,
@@ -149,7 +148,7 @@ LifeTable StoreConverter::to_life_table(const std::vector<core::BirthItem> &birt
         table_deaths[item.at_time].emplace(item.with_age, Mortality(item.males, item.females));
     }
 
-    return LifeTable(std::move(table_births), std::move(table_deaths));
+    return {std::move(table_births), std::move(table_deaths)};
 }
 
 DiseaseParameter StoreConverter::to_disease_parameter(const core::CancerParameterEntity &entity) {
@@ -170,7 +169,7 @@ DiseaseParameter StoreConverter::to_disease_parameter(const core::CancerParamete
         deaths.emplace(item.value - offset, DoubleGenderValue(item.male, item.female));
     }
 
-    return DiseaseParameter(entity.at_time, distribution, survival, deaths);
+    return {entity.at_time, distribution, survival, deaths};
 }
 
 LmsDefinition StoreConverter::to_lms_definition(const std::vector<core::LmsDataRow> &dataset) {
@@ -180,6 +179,6 @@ LmsDefinition StoreConverter::to_lms_definition(const std::vector<core::LmsDataR
             LmsRecord{.lambda = row.lambda, .mu = row.mu, .sigma = row.sigma};
     }
 
-    return LmsDefinition{std::move(lms_dataset)};
+    return {std::move(lms_dataset)};
 }
 } // namespace hgps::detail

--- a/src/HealthGPS/converter.cpp
+++ b/src/HealthGPS/converter.cpp
@@ -5,7 +5,7 @@
 #include <fmt/format.h>
 
 namespace hgps::detail {
-core::Gender StoreConverter::to_gender(const std::string name) {
+core::Gender StoreConverter::to_gender(const std::string &name) {
     if (core::case_insensitive::equals(name, "male")) {
         return core::Gender::male;
     }

--- a/src/HealthGPS/converter.h
+++ b/src/HealthGPS/converter.h
@@ -34,7 +34,7 @@ class StoreConverter {
   public:
     StoreConverter() = delete;
 
-    static core::Gender to_gender(const std::string name);
+    static core::Gender to_gender(const std::string &name);
 
     static DiseaseTable to_disease_table(const core::DiseaseEntity &entity);
 

--- a/src/HealthGPS/data_series.cpp
+++ b/src/HealthGPS/data_series.cpp
@@ -10,15 +10,15 @@ DataSeries::DataSeries(std::size_t sample_size) : sample_size_{sample_size} {
     data_.emplace(core::Gender::female, std::map<std::string, std::vector<double>>{});
 }
 
-std::vector<double> &DataSeries::operator()(core::Gender gender, std::string key) {
+std::vector<double> &DataSeries::operator()(core::Gender gender, const std::string &key) {
     return data_.at(gender).at(key);
 }
 
-std::vector<double> &DataSeries::at(core::Gender gender, std::string key) {
+std::vector<double> &DataSeries::at(core::Gender gender, const std::string &key) {
     return data_.at(gender).at(key);
 }
 
-const std::vector<double> &DataSeries::at(core::Gender gender, std::string key) const {
+const std::vector<double> &DataSeries::at(core::Gender gender, const std::string &key) const {
     return data_.at(gender).at(key);
 }
 

--- a/src/HealthGPS/data_series.h
+++ b/src/HealthGPS/data_series.h
@@ -27,7 +27,7 @@ class DataSeries {
     /// @return The channel data
     /// @throws std::out_of_range if the container does not have a
     /// channel with the specified age and key
-    std::vector<double> &operator()(core::Gender gender, std::string key);
+    std::vector<double> &operator()(core::Gender gender, const std::string &key);
 
     /// @brief Gets a reference to a channel by Gender and identifier
     /// @param gender The gender enumeration
@@ -35,7 +35,7 @@ class DataSeries {
     /// @return The channel data
     /// @throws std::out_of_range if the container does not have a
     /// channel with the specified age and key
-    std::vector<double> &at(core::Gender gender, std::string key);
+    std::vector<double> &at(core::Gender gender, const std::string &key);
 
     /// @brief Gets a read-only reference to a channel by Gender and identifier
     /// @param gender The gender enumeration
@@ -43,7 +43,7 @@ class DataSeries {
     /// @return The channel data
     /// @throws std::out_of_range if the container does not have a
     /// channel with the specified age and key
-    const std::vector<double> &at(core::Gender gender, std::string key) const;
+    const std::vector<double> &at(core::Gender gender, const std::string &key) const;
 
     /// @brief Gets the collection of channel identifiers
     /// @return The collection of channel identifiers

--- a/src/HealthGPS/default_cancer_model.cpp
+++ b/src/HealthGPS/default_cancer_model.cpp
@@ -148,9 +148,8 @@ DoubleAgeGenderTable DefaultCancerModel::calculate_average_relative_risk(Runtime
     return result;
 }
 
-double DefaultCancerModel::calculate_combined_relative_risk(const Person &entity,
-                                                            const int &start_time,
-                                                            const int &time_now) const {
+double DefaultCancerModel::calculate_combined_relative_risk(const Person &entity, int start_time,
+                                                            int time_now) const {
     auto combined_risk_value = 1.0;
     combined_risk_value *= calculate_relative_risk_for_risk_factors(entity);
     combined_risk_value *= calculate_relative_risk_for_diseases(entity, start_time, time_now);
@@ -177,8 +176,8 @@ double DefaultCancerModel::calculate_relative_risk_for_risk_factors(const Person
 }
 
 double DefaultCancerModel::calculate_relative_risk_for_diseases(const Person &entity,
-                                                                const int &start_time,
-                                                                const int &time_now) const {
+                                                                int start_time,
+                                                                int time_now) const {
     auto relative_risk_value = 1.0;
     const auto &lut = definition_.get().relative_risk_diseases();
     for (const auto &disease : entity.diseases) {
@@ -252,9 +251,8 @@ void DefaultCancerModel::update_incidence_cases(RuntimeContext &context) {
     }
 }
 
-double DefaultCancerModel::calculate_incidence_probability(const Person &entity,
-                                                           const int &start_time,
-                                                           const int &time_now) const {
+double DefaultCancerModel::calculate_incidence_probability(const Person &entity, int start_time,
+                                                           int time_now) const {
     auto incidence_id = definition_.get().table().at(MeasureKey::incidence);
     auto combined_relative_risk = calculate_combined_relative_risk(entity, start_time, time_now);
     auto average_relative_risk = average_relative_risk_.at(entity.age, entity.gender);

--- a/src/HealthGPS/default_cancer_model.h
+++ b/src/HealthGPS/default_cancer_model.h
@@ -36,13 +36,13 @@ class DefaultCancerModel final : public DiseaseModel {
     DoubleAgeGenderTable average_relative_risk_;
 
     DoubleAgeGenderTable calculate_average_relative_risk(RuntimeContext &context);
-    double calculate_combined_relative_risk(const Person &entity, const int &start_time,
-                                            const int &time_now) const;
-    double calculate_relative_risk_for_diseases(const Person &entity, const int &start_time,
-                                                const int &time_now) const;
+    double calculate_combined_relative_risk(const Person &entity, int start_time,
+                                            int time_now) const;
+    double calculate_relative_risk_for_diseases(const Person &entity, int start_time,
+                                                int time_now) const;
     double calculate_relative_risk_for_risk_factors(const Person &entity) const;
-    double calculate_incidence_probability(const Person &entity, const int &start_time,
-                                           const int &time_now) const;
+    double calculate_incidence_probability(const Person &entity, int start_time,
+                                           int time_now) const;
 
     void update_remission_cases(RuntimeContext &context);
     void update_incidence_cases(RuntimeContext &context);

--- a/src/HealthGPS/default_disease_model.cpp
+++ b/src/HealthGPS/default_disease_model.cpp
@@ -137,9 +137,8 @@ DoubleAgeGenderTable DefaultDiseaseModel::calculate_average_relative_risk(Runtim
     return result;
 }
 
-double DefaultDiseaseModel::calculate_combined_relative_risk(const Person &entity,
-                                                             const int &start_time,
-                                                             const int &time_now) const {
+double DefaultDiseaseModel::calculate_combined_relative_risk(const Person &entity, int start_time,
+                                                             int time_now) const {
     auto combined_risk_value = 1.0;
     combined_risk_value *= calculate_relative_risk_for_risk_factors(entity);
     combined_risk_value *= calculate_relative_risk_for_diseases(entity, start_time, time_now);
@@ -166,8 +165,8 @@ double DefaultDiseaseModel::calculate_relative_risk_for_risk_factors(const Perso
 }
 
 double DefaultDiseaseModel::calculate_relative_risk_for_diseases(const Person &entity,
-                                                                 const int &start_time,
-                                                                 const int &time_now) const {
+                                                                 int start_time,
+                                                                 int time_now) const {
     auto relative_risk_value = 1.0;
     const auto &lut = definition_.get().relative_risk_diseases();
     for (const auto &disease : entity.diseases) {
@@ -236,9 +235,8 @@ void DefaultDiseaseModel::update_incidence_cases(RuntimeContext &context) {
     }
 }
 
-double DefaultDiseaseModel::calculate_incidence_probability(const Person &entity,
-                                                            const int &start_time,
-                                                            const int &time_now) const {
+double DefaultDiseaseModel::calculate_incidence_probability(const Person &entity, int start_time,
+                                                            int time_now) const {
     auto incidence_id = definition_.get().table().at(MeasureKey::incidence);
     auto combined_relative_risk = calculate_combined_relative_risk(entity, start_time, time_now);
     auto average_relative_risk = average_relative_risk_.at(entity.age, entity.gender);

--- a/src/HealthGPS/default_disease_model.h
+++ b/src/HealthGPS/default_disease_model.h
@@ -35,13 +35,13 @@ class DefaultDiseaseModel final : public DiseaseModel {
     DoubleAgeGenderTable average_relative_risk_;
 
     DoubleAgeGenderTable calculate_average_relative_risk(RuntimeContext &context);
-    double calculate_combined_relative_risk(const Person &entity, const int &start_time,
-                                            const int &time_now) const;
-    double calculate_relative_risk_for_diseases(const Person &entity, const int &start_time,
-                                                const int &time_now) const;
+    double calculate_combined_relative_risk(const Person &entity, int start_time,
+                                            int time_now) const;
+    double calculate_relative_risk_for_diseases(const Person &entity, int start_time,
+                                                int time_now) const;
     double calculate_relative_risk_for_risk_factors(const Person &entity) const;
-    double calculate_incidence_probability(const Person &entity, const int &start_time,
-                                           const int &time_now) const;
+    double calculate_incidence_probability(const Person &entity, int start_time,
+                                           int time_now) const;
 
     void update_remission_cases(RuntimeContext &context);
     void update_incidence_cases(RuntimeContext &context);

--- a/src/HealthGPS/demographic.cpp
+++ b/src/HealthGPS/demographic.cpp
@@ -375,7 +375,7 @@ std::unique_ptr<PopulationModule> build_population_module(Repository &repository
 
     auto min_time = config.start_time();
     auto max_time = config.stop_time();
-    auto time_filter = [&min_time, &max_time](const unsigned int &value) {
+    auto time_filter = [&min_time, &max_time](unsigned int value) {
         return value >= min_time && value <= max_time;
     };
 

--- a/src/HealthGPS/disease_table.cpp
+++ b/src/HealthGPS/disease_table.cpp
@@ -2,11 +2,12 @@
 
 #include <fmt/format.h>
 #include <stdexcept>
+#include <utility>
 
 namespace hgps {
 /* --------------------   Disease Measure Implementation ----------------- */
 
-DiseaseMeasure::DiseaseMeasure(const std::map<int, double> &measures) : measures_{measures} {}
+DiseaseMeasure::DiseaseMeasure(std::map<int, double> measures) : measures_{std::move(measures)} {}
 
 std::size_t DiseaseMeasure::size() const noexcept { return measures_.size(); }
 

--- a/src/HealthGPS/disease_table.cpp
+++ b/src/HealthGPS/disease_table.cpp
@@ -11,11 +11,9 @@ DiseaseMeasure::DiseaseMeasure(std::map<int, double> measures) : measures_{std::
 
 std::size_t DiseaseMeasure::size() const noexcept { return measures_.size(); }
 
-const double &DiseaseMeasure::at(const int measure_id) const { return measures_.at(measure_id); }
+double DiseaseMeasure::at(const int measure_id) const { return measures_.at(measure_id); }
 
-const double &DiseaseMeasure::operator[](const int measure_id) const {
-    return measures_.at(measure_id);
-}
+double DiseaseMeasure::operator[](const int measure_id) const { return measures_.at(measure_id); }
 
 /* --------------------   Disease Table Implementation ----------------- */
 
@@ -59,11 +57,9 @@ bool DiseaseTable::contains(const int age) const noexcept { return data_.contain
 
 const std::map<std::string, int> &DiseaseTable::measures() const noexcept { return measures_; }
 
-const int &DiseaseTable::at(const std::string &measure) const { return measures_.at(measure); }
+int DiseaseTable::at(const std::string &measure) const { return measures_.at(measure); }
 
-const int &DiseaseTable::operator[](const std::string &measure) const {
-    return measures_.at(measure);
-}
+int DiseaseTable::operator[](const std::string &measure) const { return measures_.at(measure); }
 
 DiseaseMeasure &DiseaseTable::operator()(const int age, const core::Gender gender) {
     return data_.at(age).at(gender);

--- a/src/HealthGPS/disease_table.h
+++ b/src/HealthGPS/disease_table.h
@@ -24,7 +24,7 @@ class DiseaseMeasure {
 
     /// @brief Initialises a new instance of the DiseaseMeasure class.
     /// @param measures The disease measures value mapping
-    DiseaseMeasure(const std::map<int, double> &measures);
+    DiseaseMeasure(std::map<int, double> measures);
 
     /// @brief Gets the size of the measure collection
     /// @return

--- a/src/HealthGPS/disease_table.h
+++ b/src/HealthGPS/disease_table.h
@@ -34,13 +34,13 @@ class DiseaseMeasure {
     /// @param measure_id Measure identifier
     /// @return Measure value
     /// @throws std::out_of_range for unknown measure identifier
-    const double &at(int measure_id) const;
+    double at(int measure_id) const;
 
     /// @brief Gets the measure value by identifier
     /// @param measure_id Measure identifier
     /// @return Measure value
     /// @throws std::out_of_range for unknown measure identifier
-    const double &operator[](int measure_id) const;
+    double operator[](int measure_id) const;
 
   private:
     std::map<int, double> measures_;
@@ -88,13 +88,13 @@ class DiseaseTable {
     /// @param measure The measure name
     /// @return Measure identifier
     /// @throws std::out_of_range for unknown measure name
-    const int &at(const std::string &measure) const;
+    int at(const std::string &measure) const;
 
     /// @brief Gets a measure identifier by name
     /// @param measure The measure name
     /// @return Measure identifier
     /// @throws std::out_of_range for unknown measure name
-    const int &operator[](const std::string &measure) const;
+    int operator[](const std::string &measure) const;
 
     /// @brief Lookup for the disease measure entries by age and gender
     /// @param age The age to lookup

--- a/src/HealthGPS/energy_balance_hierarchical_model.cpp
+++ b/src/HealthGPS/energy_balance_hierarchical_model.cpp
@@ -56,7 +56,7 @@ void EnergyBalanceHierarchicalModel::update_risk_factors(RuntimeContext &context
     }
 }
 
-const AgeGroupGenderEquation &EnergyBalanceHierarchicalModel::equations_at(const int &age) const {
+const AgeGroupGenderEquation &EnergyBalanceHierarchicalModel::equations_at(int age) const {
     for (const auto &entry : equations_) {
         if (entry.first.contains(age)) {
             // If there is an equation for the age, return it.

--- a/src/HealthGPS/energy_balance_hierarchical_model.h
+++ b/src/HealthGPS/energy_balance_hierarchical_model.h
@@ -59,7 +59,7 @@ class EnergyBalanceHierarchicalModel final : public HierarchicalLinearModel {
     const std::map<core::Identifier, core::Identifier> &variables_;
     double boundary_percentage_;
 
-    const AgeGroupGenderEquation &equations_at(const int &age) const;
+    const AgeGroupGenderEquation &equations_at(int age) const;
 
     void update_risk_factors_exposure(
         RuntimeContext &context, Person &entity,

--- a/src/HealthGPS/error_message.cpp
+++ b/src/HealthGPS/error_message.cpp
@@ -1,11 +1,12 @@
 #include "error_message.h"
 #include <sstream>
+#include <utility>
 
 namespace hgps {
 
 ErrorEventMessage::ErrorEventMessage(std::string sender, unsigned int run, int time,
                                      std::string what) noexcept
-    : EventMessage{sender, run}, model_time{time}, message{what} {}
+    : EventMessage{sender, run}, model_time{time}, message{std::move(what)} {}
 
 int ErrorEventMessage::id() const noexcept { return static_cast<int>(EventType::error); }
 

--- a/src/HealthGPS/error_message.cpp
+++ b/src/HealthGPS/error_message.cpp
@@ -6,7 +6,7 @@ namespace hgps {
 
 ErrorEventMessage::ErrorEventMessage(std::string sender, unsigned int run, int time,
                                      std::string what) noexcept
-    : EventMessage{sender, run}, model_time{time}, message{std::move(what)} {}
+    : EventMessage{std::move(sender), run}, model_time{time}, message{std::move(what)} {}
 
 int ErrorEventMessage::id() const noexcept { return static_cast<int>(EventType::error); }
 

--- a/src/HealthGPS/event_subscriber.cpp
+++ b/src/HealthGPS/event_subscriber.cpp
@@ -1,8 +1,10 @@
 #include "event_subscriber.h"
 
+#include <utility>
+
 namespace hgps {
 EventSubscriberHandler::EventSubscriberHandler(EventHandlerIdentifier id, EventAggregator *hub)
-    : identifier_{id}, event_hub_{hub} {
+    : identifier_{std::move(id)}, event_hub_{hub} {
 
     if (hub == nullptr) {
         throw std::invalid_argument("The event aggregator hub argument must not be null.");

--- a/src/HealthGPS/fiscal_scenario.cpp
+++ b/src/HealthGPS/fiscal_scenario.cpp
@@ -110,7 +110,7 @@ const std::vector<PolicyImpact> &FiscalPolicyScenario::impacts() const noexcept 
     return definition_.impacts;
 }
 
-FiscalImpactType parse_fiscal_impact_type(std::string impact_type) {
+FiscalImpactType parse_fiscal_impact_type(const std::string &impact_type) {
     if (core::case_insensitive::equals(impact_type, "pessimist")) {
         return FiscalImpactType::pessimist;
     }

--- a/src/HealthGPS/fiscal_scenario.h
+++ b/src/HealthGPS/fiscal_scenario.h
@@ -69,5 +69,5 @@ class FiscalPolicyScenario final : public InterventionScenario {
     std::unordered_map<std::size_t, int> interventions_book_{};
 };
 
-FiscalImpactType parse_fiscal_impact_type(std::string impact);
+FiscalImpactType parse_fiscal_impact_type(const std::string &impact);
 } // namespace hgps

--- a/src/HealthGPS/healthgps.cpp
+++ b/src/HealthGPS/healthgps.cpp
@@ -229,8 +229,7 @@ IntegerAgeGenderTable HealthGPS::get_current_simulated_population() {
     return simulated_population;
 }
 
-void HealthGPS::apply_net_migration(int net_value, const unsigned int &age,
-                                    const core::Gender &gender) {
+void HealthGPS::apply_net_migration(int net_value, unsigned int age, const core::Gender &gender) {
     if (net_value > 0) {
         auto &pop = context_.population();
         auto similar_indices =

--- a/src/HealthGPS/healthgps.h
+++ b/src/HealthGPS/healthgps.h
@@ -79,7 +79,7 @@ class HealthGPS : public Simulation {
 
     hgps::IntegerAgeGenderTable get_current_expected_population() const;
     hgps::IntegerAgeGenderTable get_current_simulated_population();
-    void apply_net_migration(int net_value, const unsigned int &age, const core::Gender &gender);
+    void apply_net_migration(int net_value, unsigned int age, const core::Gender &gender);
     hgps::IntegerAgeGenderTable get_net_migration();
     hgps::IntegerAgeGenderTable create_net_migration();
     std::map<std::string, core::UnivariateSummary> create_input_data_summary() const;

--- a/src/HealthGPS/info_message.cpp
+++ b/src/HealthGPS/info_message.cpp
@@ -7,11 +7,12 @@ namespace hgps {
 
 InfoEventMessage::InfoEventMessage(std::string sender, ModelAction action, unsigned int run,
                                    int time) noexcept
-    : InfoEventMessage(sender, action, run, time, std::string{}) {}
+    : InfoEventMessage(std::move(sender), action, run, time, std::string{}) {}
 
 InfoEventMessage::InfoEventMessage(std::string sender, ModelAction action, unsigned int run,
                                    int time, std::string msg) noexcept
-    : EventMessage{sender, run}, model_action{action}, model_time{time}, message{std::move(msg)} {}
+    : EventMessage{std::move(sender), run}, model_action{action}, model_time{time},
+      message{std::move(msg)} {}
 
 int InfoEventMessage::id() const noexcept { return static_cast<int>(EventType::info); }
 

--- a/src/HealthGPS/info_message.cpp
+++ b/src/HealthGPS/info_message.cpp
@@ -1,6 +1,8 @@
 #include "info_message.h"
 #include <fmt/format.h>
 
+#include <utility>
+
 namespace hgps {
 
 InfoEventMessage::InfoEventMessage(std::string sender, ModelAction action, unsigned int run,
@@ -9,7 +11,7 @@ InfoEventMessage::InfoEventMessage(std::string sender, ModelAction action, unsig
 
 InfoEventMessage::InfoEventMessage(std::string sender, ModelAction action, unsigned int run,
                                    int time, std::string msg) noexcept
-    : EventMessage{sender, run}, model_action{action}, model_time{time}, message{msg} {}
+    : EventMessage{sender, run}, model_action{action}, model_time{time}, message{std::move(msg)} {}
 
 int InfoEventMessage::id() const noexcept { return static_cast<int>(EventType::info); }
 

--- a/src/HealthGPS/intervention_scenario.h
+++ b/src/HealthGPS/intervention_scenario.h
@@ -80,7 +80,7 @@ struct PolicyImpact {
     /// @brief Determine whether this impact should be applied to a given age
     /// @param age The age to check
     /// @return true, if the age is in the impact valid range; otherwise, false.
-    bool contains(const unsigned int &age) const noexcept {
+    bool contains(unsigned int age) const noexcept {
         if (age < from_age) {
             return false;
         }
@@ -120,7 +120,7 @@ struct PolicyInterval {
     /// @brief Determine whether this interval contains a given time
     /// @param time The time to check
     /// @return true, if the time is in the interval range; otherwise, false.
-    bool contains(const int &time) const noexcept {
+    bool contains(int time) const noexcept {
         if (time < start_time) {
             return false;
         }

--- a/src/HealthGPS/intervention_scenario.h
+++ b/src/HealthGPS/intervention_scenario.h
@@ -77,6 +77,7 @@ struct PolicyImpact {
     /// @brief Impact applies to age, if no value, no upper limit
     std::optional<unsigned int> to_age{};
 
+    // NOLINTBEGIN(bugprone-exception-escape)
     /// @brief Determine whether this impact should be applied to a given age
     /// @param age The age to check
     /// @return true, if the age is in the impact valid range; otherwise, false.
@@ -91,6 +92,7 @@ struct PolicyImpact {
 
         return true;
     }
+    // NOLINTEND(bugprone-exception-escape)
 };
 
 /// @brief Defines the policy active interval
@@ -117,6 +119,7 @@ struct PolicyInterval {
     /// @brief The intervention finish time, if given, or no upper bound.
     std::optional<int> finish_time{};
 
+    // NOLINTBEGIN(bugprone-exception-escape)
     /// @brief Determine whether this interval contains a given time
     /// @param time The time to check
     /// @return true, if the time is in the interval range; otherwise, false.
@@ -131,6 +134,7 @@ struct PolicyInterval {
 
         return true;
     }
+    // NOLINTEND(bugprone-exception-escape)
 };
 
 /// @brief Defines the policy dynamic parameters

--- a/src/HealthGPS/mapping.cpp
+++ b/src/HealthGPS/mapping.cpp
@@ -9,7 +9,7 @@
 namespace hgps {
 
 MappingEntry::MappingEntry(std::string name, int level, OptionalInterval range)
-    : name_{std::move(name)}, name_key_{name_}, level_{level}, range_{std::move(range)} {}
+    : name_{std::move(name)}, name_key_{name_}, level_{level}, range_{range} {}
 
 const std::string &MappingEntry::name() const noexcept { return name_; }
 

--- a/src/HealthGPS/mapping.cpp
+++ b/src/HealthGPS/mapping.cpp
@@ -19,7 +19,7 @@ const core::Identifier &MappingEntry::key() const noexcept { return name_key_; }
 
 const OptionalInterval &MappingEntry::range() const noexcept { return range_; }
 
-double MappingEntry::get_bounded_value(const double &value) const noexcept {
+double MappingEntry::get_bounded_value(double value) const noexcept {
     if (range_.has_value()) {
         return std::clamp(value, range_->lower(), range_->upper());
     }

--- a/src/HealthGPS/mapping.cpp
+++ b/src/HealthGPS/mapping.cpp
@@ -36,7 +36,7 @@ inline bool operator<(const MappingEntry &lhs, const MappingEntry &rhs) {
 
 /*-------------   Hierarchical Mapping implementation ------------- */
 
-HierarchicalMapping::HierarchicalMapping(std::vector<MappingEntry> &&mapping)
+HierarchicalMapping::HierarchicalMapping(std::vector<MappingEntry> mapping)
     : mapping_{std::move(mapping)} {
 
     std::sort(mapping_.begin(), mapping_.end());

--- a/src/HealthGPS/mapping.h
+++ b/src/HealthGPS/mapping.h
@@ -48,7 +48,7 @@ class MappingEntry {
     /// @brief Adjusts a value to the factor range, if provided
     /// @param value The value to adjust
     /// @return The bounded value
-    double get_bounded_value(const double &value) const noexcept;
+    double get_bounded_value(double value) const noexcept;
 
   private:
     std::string name_;

--- a/src/HealthGPS/mapping.h
+++ b/src/HealthGPS/mapping.h
@@ -69,7 +69,7 @@ class HierarchicalMapping {
 
     /// @brief Initialises a new instance of the HierarchicalMapping class
     /// @param mapping The collection of mapping entries
-    HierarchicalMapping(std::vector<MappingEntry> &&mapping);
+    HierarchicalMapping(std::vector<MappingEntry> mapping);
 
     /// @brief Gets the collection of mapping entries
     /// @return The mapping entries

--- a/src/HealthGPS/marketing_dynamic_scenario.cpp
+++ b/src/HealthGPS/marketing_dynamic_scenario.cpp
@@ -86,7 +86,7 @@ const PolicyDynamic &MarketingDynamicScenario::dynamic() const noexcept {
     return definition_.dynamic;
 }
 
-int MarketingDynamicScenario::get_index_of_impact_by_age(const unsigned int &age) const {
+int MarketingDynamicScenario::get_index_of_impact_by_age(unsigned int age) const {
     for (auto index = 0; const auto &policy : definition_.impacts) {
         if (policy.contains(age)) {
             return index;

--- a/src/HealthGPS/marketing_dynamic_scenario.h
+++ b/src/HealthGPS/marketing_dynamic_scenario.h
@@ -61,7 +61,7 @@ class MarketingDynamicScenario final : public DynamicInterventionScenario {
     std::set<core::Identifier> factor_impact_;
     std::unordered_map<std::size_t, int> interventions_book_{};
 
-    int get_index_of_impact_by_age(const unsigned int &age) const;
+    int get_index_of_impact_by_age(unsigned int age) const;
     double get_differential_impact(int current_index, int previous_index) const;
 };
 } // namespace hgps

--- a/src/HealthGPS/modelinput.cpp
+++ b/src/HealthGPS/modelinput.cpp
@@ -1,12 +1,15 @@
 #include "modelinput.h"
 
+#include <utility>
+
 namespace hgps {
 
-ModelInput::ModelInput(core::DataTable &data, const Settings &settings, const RunInfo &run_info,
-                       const SESDefinition &ses_info, const HierarchicalMapping &risk_mapping,
-                       const std::vector<core::DiseaseInfo> &diseases)
-    : input_data_{data}, settings_{settings}, run_info_{run_info}, ses_definition_{ses_info},
-      risk_mapping_{risk_mapping}, diseases_{diseases} {}
+ModelInput::ModelInput(core::DataTable &data, Settings settings, const RunInfo &run_info,
+                       SESDefinition ses_info, HierarchicalMapping risk_mapping,
+                       std::vector<core::DiseaseInfo> diseases)
+    : input_data_{data}, settings_{std::move(settings)}, run_info_{run_info},
+      ses_definition_{std::move(ses_info)}, risk_mapping_{std::move(risk_mapping)},
+      diseases_{std::move(diseases)} {}
 
 const Settings &ModelInput::settings() const noexcept { return settings_; }
 

--- a/src/HealthGPS/modelinput.cpp
+++ b/src/HealthGPS/modelinput.cpp
@@ -15,13 +15,11 @@ const Settings &ModelInput::settings() const noexcept { return settings_; }
 
 const core::DataTable &ModelInput::data() const noexcept { return input_data_; }
 
-const unsigned int &ModelInput::start_time() const noexcept { return run_info_.start_time; }
+unsigned int ModelInput::start_time() const noexcept { return run_info_.start_time; }
 
-const unsigned int &ModelInput::stop_time() const noexcept { return run_info_.stop_time; }
+unsigned int ModelInput::stop_time() const noexcept { return run_info_.stop_time; }
 
-const unsigned int &ModelInput::sync_timeout_ms() const noexcept {
-    return run_info_.sync_timeout_ms;
-}
+unsigned int ModelInput::sync_timeout_ms() const noexcept { return run_info_.sync_timeout_ms; }
 
 const std::optional<unsigned int> &ModelInput::seed() const noexcept { return run_info_.seed; }
 

--- a/src/HealthGPS/modelinput.h
+++ b/src/HealthGPS/modelinput.h
@@ -65,15 +65,15 @@ class ModelInput {
 
     /// @brief Gets the experiment start time
     /// @return Experiment start time
-    const unsigned int &start_time() const noexcept;
+    unsigned int start_time() const noexcept;
 
     /// @brief Gets the experiment stop time
     /// @return Experiment stop time
-    const unsigned int &stop_time() const noexcept;
+    unsigned int stop_time() const noexcept;
 
     /// @brief Gets the scenarios data synchronisation timeout (milliseconds)
     /// @return Scenarios synchronisation timeout
-    const unsigned int &sync_timeout_ms() const noexcept;
+    unsigned int sync_timeout_ms() const noexcept;
 
     /// @brief Gets the user custom seed to initialise the pseudo-number generator
     /// @return User custom seed value, if provide; otherwise empty.

--- a/src/HealthGPS/modelinput.h
+++ b/src/HealthGPS/modelinput.h
@@ -51,9 +51,9 @@ class ModelInput {
     /// @param ses_info Socio-economic status (SES) model information
     /// @param risk_mapping Hierarchical risk factors model mappings
     /// @param diseases Selected diseases to include in experiment
-    ModelInput(core::DataTable &data, const Settings &settings, const RunInfo &run_info,
-               const SESDefinition &ses_info, const HierarchicalMapping &risk_mapping,
-               const std::vector<core::DiseaseInfo> &diseases);
+    ModelInput(core::DataTable &data, Settings settings, const RunInfo &run_info,
+               SESDefinition ses_info, HierarchicalMapping risk_mapping,
+               std::vector<core::DiseaseInfo> diseases);
 
     /// @brief Gets the simulation experiment settings definition
     /// @return Experiment settings definition

--- a/src/HealthGPS/modelrunner.cpp
+++ b/src/HealthGPS/modelrunner.cpp
@@ -124,8 +124,8 @@ void ModelRunner::cancel() noexcept {
     }
 }
 
-void ModelRunner::run_model_thread(std::stop_token token, Simulation &model, const unsigned int run,
-                                   const std::optional<unsigned int> seed) {
+void ModelRunner::run_model_thread(const std::stop_token &token, Simulation &model,
+                                   unsigned int run, const std::optional<unsigned int> seed) {
     auto run_start = std::chrono::steady_clock::now();
     notify(std::make_unique<RunnerEventMessage>(fmt::format("{} - {}", runner_id_, model.name()),
                                                 RunnerAction::run_begin, run));

--- a/src/HealthGPS/modelrunner.h
+++ b/src/HealthGPS/modelrunner.h
@@ -59,7 +59,7 @@ class ModelRunner {
     std::stop_source source_;
     std::string runner_id_{};
 
-    void run_model_thread(std::stop_token token, Simulation &model, const unsigned int run,
+    void run_model_thread(const std::stop_token &token, Simulation &model, unsigned int run,
                           const std::optional<unsigned int> seed = std::nullopt);
 
     void notify(std::unique_ptr<hgps::EventMessage> message);

--- a/src/HealthGPS/person.cpp
+++ b/src/HealthGPS/person.cpp
@@ -29,7 +29,7 @@ std::map<core::Identifier, std::function<double(const Person &)>> Person::curren
 Person::Person() : id_{++Person::newUID} {}
 
 Person::Person(const core::Gender birth_gender) noexcept
-    : gender{birth_gender}, age{0}, id_{++Person::newUID} {}
+    : gender{birth_gender}, id_{++Person::newUID} {}
 
 std::size_t Person::id() const noexcept { return id_; }
 

--- a/src/HealthGPS/population.cpp
+++ b/src/HealthGPS/population.cpp
@@ -46,7 +46,7 @@ void Population::add_newborn_babies(std::size_t number, core::Gender gender,
     }
 
     for (auto i = std::size_t{0}; i < remaining; i++) {
-        people_.emplace_back(Person{gender});
+        people_.emplace_back(gender);
     }
 }
 

--- a/src/HealthGPS/random_algorithm.cpp
+++ b/src/HealthGPS/random_algorithm.cpp
@@ -10,9 +10,9 @@ Random::Random(RandomBitGenerator &generator) : engine_{generator} {}
 
 int Random::next_int() { return next_int(0, std::numeric_limits<int>::max() - 1); }
 
-int Random::next_int(const int &max_value) { return next_int(0, max_value); }
+int Random::next_int(int max_value) { return next_int(0, max_value); }
 
-int Random::next_int(const int &min_value, const int &max_value) {
+int Random::next_int(int min_value, int max_value) {
     if (min_value < 0 || max_value < min_value) {
         throw std::invalid_argument(
             "min_value must be non-negative, and less than or equal to max_value.");
@@ -28,7 +28,7 @@ double Random::next_double() noexcept { return engine_.get().next_double(); }
 
 double Random::next_normal() { return next_normal(0.0, 1.0); }
 
-double Random::next_normal(const double &mean, const double &standard_deviation) {
+double Random::next_normal(double mean, double standard_deviation) {
     if (standard_deviation <= 0.0) {
         throw std::invalid_argument("The standard deviation parameter must be greater than zero");
     }
@@ -72,15 +72,15 @@ int Random::next_empirical_discrete(const std::vector<int> &values,
     return values.back();
 }
 
-int Random::next_int_internal(const int &min_value, const int &max_value) {
+int Random::next_int_internal(int min_value, int max_value) {
     return min_value + static_cast<int>((max_value - min_value + 1) * next_double());
 }
 
-double Random::next_uniform_internal(const double &min_value, const double &max_value) {
+double Random::next_uniform_internal(double min_value, double max_value) {
     return min_value + (max_value - min_value) * next_double();
 }
 
-double Random::next_normal_internal(const double &mean, const double &standard_deviation) {
+double Random::next_normal_internal(double mean, double standard_deviation) {
     double p, p1, p2;
     do {
         p1 = next_uniform_internal(-1.0, 1.0);

--- a/src/HealthGPS/random_algorithm.h
+++ b/src/HealthGPS/random_algorithm.h
@@ -19,13 +19,13 @@ class Random {
     /// @brief Generates the next random integer in sequence in range [min(), max_value)
     /// @param max_value The maximum value
     /// @return A random integer value in range [min(), max_value)
-    int next_int(const int &max_value);
+    int next_int(int max_value);
 
     /// @brief Generates the next random integer in sequence in range [min_value, max_value)
     /// @param min_value The minimum value
     /// @param max_value The maximum value
     /// @return A random integer value in range [min_value, max_value)
-    int next_int(const int &min_value, const int &max_value);
+    int next_int(int min_value, int max_value);
 
     /// @brief Generates a random floating point number in range [0,1)
     /// @return A floating point value in range [0,1).
@@ -39,7 +39,7 @@ class Random {
     /// @param mean The mean parameter
     /// @param standard_deviation The standard deviation parameter
     /// @return The generated floating point random number
-    double next_normal(const double &mean, const double &standard_deviation);
+    double next_normal(double mean, double standard_deviation);
 
     /// @brief Samples a random value from an empirical distribution
     /// @param values The empirical distribution values
@@ -55,8 +55,8 @@ class Random {
 
   private:
     std::reference_wrapper<RandomBitGenerator> engine_;
-    int next_int_internal(const int &min_value, const int &max_value);
-    double next_uniform_internal(const double &min_value, const double &max_value);
-    double next_normal_internal(const double &mean, const double &standard_deviation);
+    int next_int_internal(int min_value, int max_value);
+    double next_uniform_internal(double min_value, double max_value);
+    double next_normal_internal(double mean, double standard_deviation);
 };
 } // namespace hgps

--- a/src/HealthGPS/repository.cpp
+++ b/src/HealthGPS/repository.cpp
@@ -56,7 +56,7 @@ std::optional<core::DiseaseInfo> CachedRepository::get_disease_info(core::Identi
         return *it;
     }
 
-    return std::optional<core::DiseaseInfo>();
+    return {};
 }
 
 DiseaseDefinition &CachedRepository::get_disease_definition(const core::DiseaseInfo &info,

--- a/src/HealthGPS/result_message.cpp
+++ b/src/HealthGPS/result_message.cpp
@@ -7,7 +7,7 @@ namespace hgps {
 
 ResultEventMessage::ResultEventMessage(std::string sender, unsigned int run, int time,
                                        ModelResult result)
-    : EventMessage{sender, run}, model_time{time}, content{std::move(result)} {}
+    : EventMessage{std::move(sender), run}, model_time{time}, content{std::move(result)} {}
 
 int ResultEventMessage::id() const noexcept { return static_cast<int>(EventType::result); }
 

--- a/src/HealthGPS/result_message.cpp
+++ b/src/HealthGPS/result_message.cpp
@@ -1,11 +1,13 @@
 #include "result_message.h"
 #include <fmt/format.h>
 
+#include <utility>
+
 namespace hgps {
 
 ResultEventMessage::ResultEventMessage(std::string sender, unsigned int run, int time,
                                        ModelResult result)
-    : EventMessage{sender, run}, model_time{time}, content{result} {}
+    : EventMessage{sender, run}, model_time{time}, content{std::move(result)} {}
 
 int ResultEventMessage::id() const noexcept { return static_cast<int>(EventType::result); }
 

--- a/src/HealthGPS/riskfactor.cpp
+++ b/src/HealthGPS/riskfactor.cpp
@@ -3,9 +3,9 @@
 namespace hgps {
 
 RiskFactorModule::RiskFactorModule(
-    std::map<HierarchicalModelType, std::unique_ptr<HierarchicalLinearModel>> &&models,
-    RiskfactorAdjustmentModel &&adjustments)
-    : models_{std::move(models)}, adjustment_{std::move(adjustments)} {
+    std::map<HierarchicalModelType, std::unique_ptr<HierarchicalLinearModel>> models,
+    const RiskfactorAdjustmentModel &adjustments)
+    : models_{std::move(models)}, adjustment_{adjustments} {
 
     if (models_.empty()) {
         throw std::invalid_argument(
@@ -81,6 +81,6 @@ build_risk_factor_module(Repository &repository, [[maybe_unused]] const ModelInp
 
     auto adjustment_model =
         RiskfactorAdjustmentModel{repository.get_baseline_adjustment_definition()};
-    return std::make_unique<RiskFactorModule>(std::move(models), std::move(adjustment_model));
+    return std::make_unique<RiskFactorModule>(std::move(models), adjustment_model);
 }
 } // namespace hgps

--- a/src/HealthGPS/riskfactor.h
+++ b/src/HealthGPS/riskfactor.h
@@ -19,8 +19,8 @@ class RiskFactorModule final : public RiskFactorHostModule {
     /// module type.
     /// @throws std::out_of_range for model type and model instance type mismatch.
     RiskFactorModule(
-        std::map<HierarchicalModelType, std::unique_ptr<HierarchicalLinearModel>> &&models,
-        RiskfactorAdjustmentModel &&adjustments);
+        std::map<HierarchicalModelType, std::unique_ptr<HierarchicalLinearModel>> models,
+        const RiskfactorAdjustmentModel &adjustments);
 
     SimulationModuleType type() const noexcept override;
 

--- a/src/HealthGPS/runner_message.cpp
+++ b/src/HealthGPS/runner_message.cpp
@@ -1,20 +1,22 @@
 #include "runner_message.h"
 #include <fmt/format.h>
 
+#include <utility>
+
 hgps::RunnerEventMessage::RunnerEventMessage(std::string sender, RunnerAction run_action) noexcept
-    : RunnerEventMessage(sender, run_action, 0u, 0.0) {}
+    : RunnerEventMessage(std::move(sender), run_action, 0u, 0.0) {}
 
 hgps::RunnerEventMessage::RunnerEventMessage(std::string sender, RunnerAction run_action,
                                              double elapsed) noexcept
-    : RunnerEventMessage(sender, run_action, 0u, elapsed) {}
+    : RunnerEventMessage(std::move(sender), run_action, 0u, elapsed) {}
 
 hgps::RunnerEventMessage::RunnerEventMessage(std::string sender, RunnerAction run_action,
                                              unsigned int run) noexcept
-    : RunnerEventMessage(sender, run_action, run, 0.0) {}
+    : RunnerEventMessage(std::move(sender), run_action, run, 0.0) {}
 
 hgps::RunnerEventMessage::RunnerEventMessage(std::string sender, RunnerAction run_action,
                                              unsigned int run, double elapsed) noexcept
-    : EventMessage{sender, run}, action{run_action}, elapsed_ms{elapsed} {}
+    : EventMessage{std::move(sender), run}, action{run_action}, elapsed_ms{elapsed} {}
 
 int hgps::RunnerEventMessage::id() const noexcept { return static_cast<int>(EventType::runner); }
 

--- a/src/HealthGPS/runtime_metric.cpp
+++ b/src/HealthGPS/runtime_metric.cpp
@@ -4,24 +4,24 @@
 namespace hgps {
 std::size_t RuntimeMetric::size() const noexcept { return metrics_.size(); }
 
-double &RuntimeMetric::operator[](const std::string metric_key) { return metrics_[metric_key]; }
+double &RuntimeMetric::operator[](const std::string &metric_key) { return metrics_[metric_key]; }
 
-double &RuntimeMetric::at(const std::string metric_key) { return metrics_.at(metric_key); }
+double &RuntimeMetric::at(const std::string &metric_key) { return metrics_.at(metric_key); }
 
-const double &RuntimeMetric::at(const std::string metric_key) const {
+const double &RuntimeMetric::at(const std::string &metric_key) const {
     return metrics_.at(metric_key);
 }
 
-bool RuntimeMetric::contains(const std::string metric_key) const noexcept {
+bool RuntimeMetric::contains(const std::string &metric_key) const noexcept {
     return metrics_.contains(metric_key);
 }
 
-bool RuntimeMetric::emplace(const std::string metric_key, const double value) {
+bool RuntimeMetric::emplace(const std::string &metric_key, const double value) {
     auto sucess = metrics_.emplace(metric_key, value);
     return sucess.second;
 }
 
-bool RuntimeMetric::erase(const std::string metric_key) {
+bool RuntimeMetric::erase(const std::string &metric_key) {
     auto sucess = metrics_.erase(metric_key);
     return sucess > 0;
 }

--- a/src/HealthGPS/runtime_metric.cpp
+++ b/src/HealthGPS/runtime_metric.cpp
@@ -8,9 +8,7 @@ double &RuntimeMetric::operator[](const std::string &metric_key) { return metric
 
 double &RuntimeMetric::at(const std::string &metric_key) { return metrics_.at(metric_key); }
 
-const double &RuntimeMetric::at(const std::string &metric_key) const {
-    return metrics_.at(metric_key);
-}
+double RuntimeMetric::at(const std::string &metric_key) const { return metrics_.at(metric_key); }
 
 bool RuntimeMetric::contains(const std::string &metric_key) const noexcept {
     return metrics_.contains(metric_key);

--- a/src/HealthGPS/runtime_metric.h
+++ b/src/HealthGPS/runtime_metric.h
@@ -38,7 +38,7 @@ class RuntimeMetric {
     /// @return Reference to metric value.
     /// @throws std::out_of_range if the container does not have a metric with the specified
     /// identifier.
-    const double &at(const std::string &metric_key) const;
+    double at(const std::string &metric_key) const;
 
     /// @brief Checks if the container contains a metric with specific identifier
     /// @param metric_key Metric identifier.

--- a/src/HealthGPS/runtime_metric.h
+++ b/src/HealthGPS/runtime_metric.h
@@ -49,7 +49,7 @@ class RuntimeMetric {
     /// @param metric_key Metric identifier.
     /// @param value Metric value.
     /// @return true if insertion happened; otherwise, false.
-    bool emplace(const std::string &metric_key, const double value);
+    bool emplace(const std::string &metric_key, double value);
 
     /// @brief Removes a specified metric from the container.
     /// @param metric_key Metric identifier.

--- a/src/HealthGPS/runtime_metric.h
+++ b/src/HealthGPS/runtime_metric.h
@@ -24,37 +24,37 @@ class RuntimeMetric {
     /// @brief Gets a reference to a metric value by identifier, no bounds checking.
     /// @param metric_key Metric identifier.
     /// @return Reference to metric value.
-    double &operator[](const std::string metric_key);
+    double &operator[](const std::string &metric_key);
 
     /// @brief Gets a reference to a metric value by identifier with bounds checking.
     /// @param metric_key Metric identifier.
     /// @return Reference to metric value.
     /// @throws std::out_of_range if the container does not have a metric with the specified
     /// identifier.
-    double &at(const std::string metric_key);
+    double &at(const std::string &metric_key);
 
     /// @brief Gets a read-only reference to a metric value by identifier with bounds checking.
     /// @param metric_key Metric identifier.
     /// @return Reference to metric value.
     /// @throws std::out_of_range if the container does not have a metric with the specified
     /// identifier.
-    const double &at(const std::string metric_key) const;
+    const double &at(const std::string &metric_key) const;
 
     /// @brief Checks if the container contains a metric with specific identifier
     /// @param metric_key Metric identifier.
     /// @return true if there is such a metric; otherwise, false.
-    bool contains(const std::string metric_key) const noexcept;
+    bool contains(const std::string &metric_key) const noexcept;
 
     /// @brief Inserts a new metric into the container constructed in-place with arguments.
     /// @param metric_key Metric identifier.
     /// @param value Metric value.
     /// @return true if insertion happened; otherwise, false.
-    bool emplace(const std::string metric_key, const double value);
+    bool emplace(const std::string &metric_key, const double value);
 
     /// @brief Removes a specified metric from the container.
     /// @param metric_key Metric identifier.
     /// @return true if deletion happened; otherwise, false.
-    bool erase(const std::string metric_key);
+    bool erase(const std::string &metric_key);
 
     /// @brief Erases all metrics from the container.
     void clear() noexcept;

--- a/src/HealthGPS/settings.cpp
+++ b/src/HealthGPS/settings.cpp
@@ -18,7 +18,7 @@ Settings::Settings(core::Country country, const float size_fraction,
 
 const core::Country &Settings::country() const noexcept { return country_; }
 
-const float &Settings::size_fraction() const noexcept { return size_fraction_; }
+float Settings::size_fraction() const noexcept { return size_fraction_; }
 
 const core::IntegerInterval &Settings::age_range() const noexcept { return age_range_; }
 } // namespace hgps

--- a/src/HealthGPS/settings.cpp
+++ b/src/HealthGPS/settings.cpp
@@ -1,12 +1,13 @@
 #include <stdexcept>
+#include <utility>
 
 #include "settings.h"
 
 namespace hgps {
 
-Settings::Settings(const core::Country &country, const float size_fraction,
+Settings::Settings(core::Country country, const float size_fraction,
                    const core::IntegerInterval &age_range)
-    : country_{country}, size_fraction_{size_fraction}, age_range_{age_range} {
+    : country_{std::move(country)}, size_fraction_{size_fraction}, age_range_{age_range} {
 
     // TODO: Create a fraction type wrapper
     if (size_fraction <= 0.0 || size_fraction > 1.0) {

--- a/src/HealthGPS/settings.h
+++ b/src/HealthGPS/settings.h
@@ -13,8 +13,7 @@ class Settings {
     /// @param size_fraction Virtual population fraction of the real population
     /// @param age_range Allowed age range in the population
     /// @throws std::out_of_range for size fraction value outside of the range (0, 1].
-    Settings(core::Country country, const float size_fraction,
-             const core::IntegerInterval &age_range);
+    Settings(core::Country country, float size_fraction, const core::IntegerInterval &age_range);
 
     /// @brief Gets the experiment target country information
     /// @return Country information

--- a/src/HealthGPS/settings.h
+++ b/src/HealthGPS/settings.h
@@ -13,7 +13,7 @@ class Settings {
     /// @param size_fraction Virtual population fraction of the real population
     /// @param age_range Allowed age range in the population
     /// @throws std::out_of_range for size fraction value outside of the range (0, 1].
-    Settings(const core::Country &country, const float size_fraction,
+    Settings(core::Country country, const float size_fraction,
              const core::IntegerInterval &age_range);
 
     /// @brief Gets the experiment target country information

--- a/src/HealthGPS/settings.h
+++ b/src/HealthGPS/settings.h
@@ -22,7 +22,7 @@ class Settings {
 
     /// @brief The virtual population fraction from the real population size in range (0, 1]
     /// @return The size fraction in range (0, 1]
-    const float &size_fraction() const noexcept;
+    float size_fraction() const noexcept;
 
     /// @brief The experiment population age range constraint
     /// @return The allowed age range


### PR DESCRIPTION
This PR adds `clang-tidy` checks from the `modernize`, `performance`, `misc` and `cppcoreguidelines` categories and fixes the warnings. With this, I don't think there are really any more checks to add. I also made small tweaks as I went along to `const`ify a few arguments etc.

The biggest improvement is that many more functions now take arguments as const ref rather than pass-by-value. I also made some changes in the opposite direction, removing pointless const refs to basic types (e.g. `const int &`).

Feel free to fix up and merge this while I'm away or wait for me to get back.

Closes #179. Closes #180.