### PR TITLE
Add code for loading nutrient table

### DIFF
--- a/example_new/MAFFCODE_NUTRIENTS_NPM.csv
+++ b/example_new/MAFFCODE_NUTRIENTS_NPM.csv
@@ -1,4 +1,4 @@
-maffcode,description,a_fats,a_saturates,a_monounsats,a_polyunsats,a_carbs,a_cals,a_sodium,a_totalsugars,a_addedsugar,a_alcohol,a_fibre,a_cholest,a_protein,NPM score
+MAFF code,Description,Fat,Saturated fat,Monounsaturated fat,Polyunsaturated fat,Carbohydrate,Energy,Sodium,Total sugar,Added sugar,Alcohol,Fibre,Cholesterol,Protein,NPM score
 402,UHT whole milk,4.13832,2.63676,1.11972,0.13158,4.644,68.48868,0.044118,4.644,0,0,0,13.674,3.4572,1
 403,Sterilised whole milk,4.13832,2.63676,1.11972,0.13158,4.644,68.48868,0.044118,4.644,0,0,0,13.674,3.4572,1
 404,Pasteurised or homogenised whole milk,4.13832,2.63676,1.11972,0.13158,4.644,68.48868,0.044118,4.644,0,0,0,13.674,3.4572,1

--- a/src/HealthGPS.Core/identifier.cpp
+++ b/src/HealthGPS.Core/identifier.cpp
@@ -61,5 +61,5 @@ void from_json(const nlohmann::json &j, Identifier &id) { id = Identifier{j.get<
 
 } // namespace core
 
-core::Identifier operator""_id(const char *id, size_t) { return {id}; }
+core::Identifier operator""_id(const char *id, size_t /*unused*/) { return {id}; }
 } // namespace hgps

--- a/src/HealthGPS.Core/identifier.cpp
+++ b/src/HealthGPS.Core/identifier.cpp
@@ -4,7 +4,8 @@
 #include <algorithm>
 #include <stdexcept>
 
-namespace hgps::core {
+namespace hgps {
+namespace core {
 Identifier Identifier::empty() {
     static Identifier instance = Identifier();
     return instance;
@@ -58,4 +59,7 @@ std::ostream &operator<<(std::ostream &stream, const Identifier &identifier) {
 
 void from_json(const nlohmann::json &j, Identifier &id) { id = Identifier{j.get<std::string>()}; }
 
-} // namespace hgps::core
+} // namespace core
+
+core::Identifier operator""_id(const char *id, size_t) { return {id}; }
+} // namespace hgps

--- a/src/HealthGPS.Core/identifier.h
+++ b/src/HealthGPS.Core/identifier.h
@@ -7,7 +7,8 @@
 
 #include "nlohmann/json.hpp"
 
-namespace hgps::core {
+namespace hgps {
+namespace core {
 
 /// @brief Entity unique identifier data type
 ///
@@ -97,7 +98,11 @@ void map_from_json(const nlohmann::json &j, Map<hgps::core::Identifier, Value> &
 }
 } // namespace detail
 
-} // namespace hgps::core
+} // namespace core
+
+//! Allow users to use _id suffix to create Identifier (e.g. "Disease"_id)
+core::Identifier operator""_id(const char *id, size_t);
+} // namespace hgps
 
 namespace std {
 template <class T>

--- a/src/HealthGPS.Tests/CMakeLists.txt
+++ b/src/HealthGPS.Tests/CMakeLists.txt
@@ -16,6 +16,8 @@ target_sources(
             "pch.h"
             "data_config.h"
             "data_config.cpp"
+            "program_path.h"
+            "program_path.cpp"
             "AgeGenderTable.Test.cpp"
             "Channel.Test.cpp"
             "Configuration.Test.cpp"
@@ -41,7 +43,8 @@ target_sources(
             "WeightModel.Test.cpp"
             "CountryModule.h"
             "RiskFactorData.h"
-            "Interval.Test.cpp")
+            "Interval.Test.cpp"
+            "LoadNutrientTable.cpp")
 
 target_link_libraries(
     HealthGPS.Tests
@@ -63,5 +66,16 @@ if(WIN32)
     install(IMPORTED_RUNTIME_ARTIFACTS fmt::fmt)
     install(IMPORTED_RUNTIME_ARTIFACTS GTest::gtest)
 endif()
+
+# Additional data files required for tests
+set(TO_COPY nutrient_table.csv)
+foreach(FILE IN LISTS TO_COPY)
+    add_custom_command(
+        TARGET HealthGPS.Tests
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/${FILE}"
+                "$<TARGET_FILE_DIR:HealthGPS.Tests>")
+    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/${FILE}" DESTINATION bin)
+endforeach(FILE IN LISTS TO_COPY)
 
 set(ROOT_NAMESPACE hgps::test)

--- a/src/HealthGPS.Tests/LoadNutrientTable.cpp
+++ b/src/HealthGPS.Tests/LoadNutrientTable.cpp
@@ -10,17 +10,10 @@
 using namespace hgps;
 
 namespace {
-constexpr auto *csv_data = R"(food,d,e,a,c,b
-chicken,1,2,3,4,5
-crisps,6,7,8,9,10
-tofu,11,12,13,14,15
-)";
-
 const std::vector<core::Identifier> nutrients = {"A"_id, "B"_id, "C"_id};
 } // anonymous namespace
 
 TEST(LoadNutrientTable, GetNutrientIndexes) {
-
     {
         // Note that the case doesn't match; should be case insensitive
         const std::vector<std::string> column_names = {"d", "e", "a", "c", "b"};
@@ -35,16 +28,6 @@ TEST(LoadNutrientTable, GetNutrientIndexes) {
         const std::vector<std::string> column_names = {"D", "E", "A", "C"};
         EXPECT_THROW(detail::get_nutrient_indexes(column_names, nutrients), core::HgpsException);
     }
-}
-
-TEST(LoadNutrientTable, GetNutrientTable) {
-    std::istringstream is{csv_data};
-    rapidcsv::Document doc{is, rapidcsv::LabelParams{0, 0}};
-    const auto table = detail::get_nutrient_table(doc, nutrients, {2, 4, 3});
-
-    const decltype(table) expected = {
-        {"chicken", {3, 5, 4}}, {"crisps", {8, 10, 9}}, {"tofu", {13, 15, 14}}};
-    EXPECT_EQ(table, expected);
 }
 
 TEST(LoadNutrientTable, LoadNutrientTable) {

--- a/src/HealthGPS.Tests/LoadNutrientTable.cpp
+++ b/src/HealthGPS.Tests/LoadNutrientTable.cpp
@@ -1,0 +1,57 @@
+#include "pch.h"
+#include "program_path.h"
+
+#include "HealthGPS.Core/exception.h"
+#include "HealthGPS/nutrients.h"
+
+#include <filesystem>
+#include <sstream>
+
+using namespace hgps;
+
+namespace {
+constexpr auto *csv_data = R"(food,d,e,a,c,b
+chicken,1,2,3,4,5
+crisps,6,7,8,9,10
+tofu,11,12,13,14,15
+)";
+
+const std::vector<core::Identifier> nutrients = {"A"_id, "B"_id, "C"_id};
+} // anonymous namespace
+
+TEST(LoadNutrientTable, GetNutrientIndexes) {
+
+    {
+        // Note that the case doesn't match; should be case insensitive
+        const std::vector<std::string> column_names = {"d", "e", "a", "c", "b"};
+        const auto idx = detail::get_nutrient_indexes(column_names, nutrients);
+        const std::vector<size_t> expected{2, 4, 3};
+        EXPECT_EQ(idx, expected);
+    }
+
+    // Missing nutrient
+    {
+        // "B" is missing
+        const std::vector<std::string> column_names = {"D", "E", "A", "C"};
+        EXPECT_THROW(detail::get_nutrient_indexes(column_names, nutrients), core::HgpsException);
+    }
+}
+
+TEST(LoadNutrientTable, GetNutrientTable) {
+    std::istringstream is{csv_data};
+    rapidcsv::Document doc{is, rapidcsv::LabelParams{0, 0}};
+    const auto table = detail::get_nutrient_table(doc, nutrients, {2, 4, 3});
+
+    const decltype(table) expected = {
+        {"chicken", {3, 5, 4}}, {"crisps", {8, 10, 9}}, {"tofu", {13, 15, 14}}};
+    EXPECT_EQ(table, expected);
+}
+
+TEST(LoadNutrientTable, LoadNutrientTable) {
+    const auto csv_path = (get_program_directory() / "nutrient_table.csv").string();
+    const auto table = load_nutrient_table(csv_path, nutrients);
+
+    const decltype(table) expected = {
+        {"chicken", {3, 5, 4}}, {"crisps", {8, 10, 9}}, {"tofu", {13, 15, 14}}};
+    EXPECT_EQ(table, expected);
+}

--- a/src/HealthGPS.Tests/nutrient_table.csv
+++ b/src/HealthGPS.Tests/nutrient_table.csv
@@ -1,0 +1,4 @@
+food,d,e,a,c,b
+chicken,1,2,3,4,5
+crisps,6,7,8,9,10
+tofu,11,12,13,14,15

--- a/src/HealthGPS.Tests/program_path.cpp
+++ b/src/HealthGPS.Tests/program_path.cpp
@@ -1,0 +1,44 @@
+#include "program_path.h"
+
+#ifdef __linux__
+#include <limits.h>
+#include <unistd.h>
+#endif
+#ifdef _WIN32
+#include <windows.h>
+#endif
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
+
+#include "HealthGPS.Core/exception.h"
+
+std::filesystem::path get_program_directory() { return get_program_path().parent_path(); }
+
+std::filesystem::path get_program_path() {
+    bool success;
+
+#if defined(__linux__)
+    char path[PATH_MAX + 1];
+    ssize_t len = readlink("/proc/self/exe", path, PATH_MAX);
+    if (!(success = (len >= 0))) {
+        path[len] = '\0';
+    }
+#elif defined(_WIN32)
+    wchar_t path[MAX_PATH];
+    DWORD len = GetModuleFileNameW(nullptr, path, MAX_PATH);
+    success = (len > 0);
+#elif defined(__APPLE__)
+    char path[MAXPATHLEN + 1];
+    uint32_t len = sizeof(path);
+    success = (_NSGetExecutablePath(path, &len) == 0);
+#else
+#error "Unsupported platform"
+#endif
+
+    if (!success) {
+        throw hgps::core::HgpsException("Could not get program path");
+    }
+
+    return std::filesystem::path{path};
+}

--- a/src/HealthGPS.Tests/program_path.cpp
+++ b/src/HealthGPS.Tests/program_path.cpp
@@ -1,7 +1,7 @@
 #include "program_path.h"
 
 #ifdef __linux__
-#include <limits.h>
+#include <climits>
 #include <unistd.h>
 #endif
 #ifdef _WIN32

--- a/src/HealthGPS.Tests/program_path.h
+++ b/src/HealthGPS.Tests/program_path.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <filesystem>
+
+//! Get the path to the directory of the currently executing program
+std::filesystem::path get_program_directory();
+
+//! Get the path to the currently executing program
+std::filesystem::path get_program_path();

--- a/src/HealthGPS/CMakeLists.txt
+++ b/src/HealthGPS/CMakeLists.txt
@@ -66,6 +66,8 @@ target_sources(
             "modulefactory.h"
             "mtrandom.cpp"
             "mtrandom.h"
+            "nutrients.h"
+            "nutrients.cpp"
             "person.cpp"
             "person.h"
             "population.cpp"

--- a/src/HealthGPS/energy_balance_model.h
+++ b/src/HealthGPS/energy_balance_model.h
@@ -15,7 +15,7 @@ struct SimulatePersonState {
     /// @brief Body weight
     double BW{};
 
-    /// @brief Pyhsical activity level
+    /// @brief Physical activity level
     double PAL{};
 
     /// @brief Body fat

--- a/src/HealthGPS/nutrients.cpp
+++ b/src/HealthGPS/nutrients.cpp
@@ -1,0 +1,69 @@
+#include "nutrients.h"
+
+#include "HealthGPS.Core/exception.h"
+#include "HealthGPS.Core/string_util.h"
+
+#include "fmt/color.h"
+#include "fmt/format.h"
+
+#include <algorithm>
+#include <iterator>
+
+namespace hgps {
+namespace detail {
+std::vector<size_t> get_nutrient_indexes(const std::vector<std::string> &column_names,
+                                         const std::vector<core::Identifier> &nutrients) {
+    bool nutrients_missing = false;
+
+    std::vector<size_t> nutrient_idx; // Which column each nutrient is in
+    nutrient_idx.reserve(nutrients.size());
+    for (const auto &nutrient : nutrients) {
+        const auto it = std::find(column_names.begin(), column_names.end(), nutrient);
+        if (it == column_names.end()) {
+            if (!nutrients_missing) {
+                nutrients_missing = true;
+                fmt::print(fmt::fg(fmt::color::yellow), "The following nutrients were missing:\n");
+            }
+
+            fmt::print(fmt::fg(fmt::color::yellow), "- {}\n", nutrient.to_string());
+        } else {
+            nutrient_idx.push_back(std::distance(column_names.begin(), it));
+        }
+    }
+
+    if (nutrients_missing) {
+        throw core::HgpsException{"One or more nutrients were missing from CSV file"};
+    }
+
+    return nutrient_idx;
+}
+
+std::unordered_map<core::Identifier, std::vector<double>>
+get_nutrient_table(rapidcsv::Document &doc, const std::vector<core::Identifier> &nutrients,
+                   const std::vector<size_t> &nutrient_idx) {
+
+    std::unordered_map<core::Identifier, std::vector<double>> out;
+    out.reserve(doc.GetRowCount());
+    for (size_t i = 0; i < doc.GetRowCount(); i++) {
+        std::vector<double> row;
+        row.reserve(nutrients.size());
+        for (size_t j = 0; j < nutrients.size(); j++) {
+            row.push_back(doc.GetCell<double>(nutrient_idx[j], i));
+        }
+
+        out.emplace(doc.GetRowName(i), std::move(row));
+    }
+
+    return out;
+}
+} // namespace detail
+
+std::unordered_map<core::Identifier, std::vector<double>>
+load_nutrient_table(const std::string &csv_path, const std::vector<core::Identifier> &nutrients) {
+    rapidcsv::Document doc{csv_path, rapidcsv::LabelParams{0, 0}};
+    const auto column_names = doc.GetColumnNames();
+
+    const auto nutrient_idx = detail::get_nutrient_indexes(column_names, nutrients);
+    return detail::get_nutrient_table(doc, nutrients, nutrient_idx);
+}
+} // namespace hgps

--- a/src/HealthGPS/nutrients.h
+++ b/src/HealthGPS/nutrients.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "HealthGPS.Core/identifier.h"
+
+#include "rapidcsv.h"
+
+#include <unordered_map>
+#include <vector>
+
+namespace hgps {
+namespace detail {
+/// @brief Work out which column each macronutrient isin
+/// @param column_names Column names for CSV file
+/// @param nutrients Macronutrients
+/// @return Index for each macronutrient in order
+std::vector<size_t> get_nutrient_indexes(const std::vector<std::string> &column_names,
+                                         const std::vector<core::Identifier> &nutrients);
+
+std::unordered_map<core::Identifier, std::vector<double>>
+get_nutrient_table(rapidcsv::Document &doc, const std::vector<core::Identifier> &nutrients,
+                   const std::vector<size_t> &nutrient_idx);
+} // namespace detail
+
+/// @brief Load nutrient information from a CSV file
+/// @param csv_path Path to CSV file
+/// @param nutrients Names of macronutrients
+/// @return Mapping from food name to constituent macronutrients
+std::unordered_map<core::Identifier, std::vector<double>>
+load_nutrient_table(const std::string &csv_path, const std::vector<core::Identifier> &nutrients);
+} // namespace hgps

--- a/src/HealthGPS/nutrients.h
+++ b/src/HealthGPS/nutrients.h
@@ -9,7 +9,7 @@
 
 namespace hgps {
 namespace detail {
-/// @brief Work out which column each macronutrient isin
+/// @brief Work out which column each macronutrient is in
 /// @param column_names Column names for CSV file
 /// @param nutrients Macronutrients
 /// @return Index for each macronutrient in order


### PR DESCRIPTION
Add code for loading nutrient table from a CSV file in the form of a `load_nutrient_table()` function. This is currently not integrated with the rest of the code, though I have added tests to verify that it works. I figured that the integration might be dependent on what @jamesturner246 is working on, so it was better to merge this first, then worry about the integration later.

I also added a user-defined literal for `Identifier`s so you can now write `"Disease"_id` etc. (instead of `Identifier{"Disease"}`).

Fixes #217.