### PR TITLE
`RuntimeContext` tweaks

### DIFF
--- a/src/HealthGPS/runtime_context.cpp
+++ b/src/HealthGPS/runtime_context.cpp
@@ -23,7 +23,7 @@ RuntimeMetric &RuntimeContext::metrics() noexcept { return metrics_; }
 
 Scenario &RuntimeContext::scenario() noexcept { return definition_.get().scenario(); }
 
-Random &RuntimeContext::random() noexcept { return generator_; }
+Random &RuntimeContext::random() const noexcept { return generator_; }
 
 const HierarchicalMapping &RuntimeContext::mapping() const noexcept {
     return definition_.get().inputs().risk_mapping();

--- a/src/HealthGPS/runtime_context.cpp
+++ b/src/HealthGPS/runtime_context.cpp
@@ -17,6 +17,8 @@ int RuntimeContext::sync_timeout_millis() const noexcept {
 
 Population &RuntimeContext::population() noexcept { return population_; }
 
+const Population &RuntimeContext::population() const noexcept { return population_; }
+
 RuntimeMetric &RuntimeContext::metrics() noexcept { return metrics_; }
 
 Scenario &RuntimeContext::scenario() noexcept { return definition_.get().scenario(); }

--- a/src/HealthGPS/runtime_context.h
+++ b/src/HealthGPS/runtime_context.h
@@ -60,7 +60,7 @@ class RuntimeContext {
 
     /// @brief Gets a reference to the engine random number generator
     /// @return Random number generator
-    Random &random() noexcept;
+    Random &random() const noexcept;
 
     /// @brief Gets a read-only reference to the hierarchical risk factors mapping
     /// @return Risk factor mapping
@@ -103,7 +103,7 @@ class RuntimeContext {
     std::reference_wrapper<EventAggregator> event_bus_;
     std::reference_wrapper<SimulationDefinition> definition_;
     Population population_;
-    Random generator_;
+    mutable Random generator_;
     RuntimeMetric metrics_{};
     unsigned int current_run_{};
     int model_start_time_{};

--- a/src/HealthGPS/runtime_context.h
+++ b/src/HealthGPS/runtime_context.h
@@ -46,6 +46,10 @@ class RuntimeContext {
     /// @return Virtual population
     Population &population() noexcept;
 
+    /// @brief Gets a reference to the virtual population container
+    /// @return Virtual population
+    const Population &population() const noexcept;
+
     /// @brief Gets a reference to the runtime metrics container
     /// @return Runtime metrics
     RuntimeMetric &metrics() noexcept;


### PR DESCRIPTION
I made a couple of small changes to `RuntimeContext` while working on #222. It turns out that #222 isn't currently doable, because there are models which modify `Person`s retrieved from the `RuntimeContext`, so `RuntimeContext` can't be `const`. I think the changes are worth having anyway though.

As @dalonsoa suggested, it would be better to break up the `RuntimeContext` object into separate parts, some of which could be passed in as non-`const` references. Is there an issue open for this?