### PR TITLE
Update and adjust weight

### DIFF
--- a/src/HealthGPS/kevin_hall_model.cpp
+++ b/src/HealthGPS/kevin_hall_model.cpp
@@ -361,7 +361,7 @@ double KevinHallModel::get_weight_quantile(double epa_quantile, core::Gender sex
     double epa_percentile = epa_index / epa_quantiles_.size();
 
     // Find weight quantile.
-    size_t weight_index = static_cast<size_t>(epa_percentile * (weight_quantiles_.size() - 1));
+    auto weight_index = static_cast<size_t>(epa_percentile * (weight_quantiles_.size() - 1));
     return weight_quantiles_.at(sex)[weight_index];
 }
 

--- a/src/HealthGPS/kevin_hall_model.cpp
+++ b/src/HealthGPS/kevin_hall_model.cpp
@@ -356,7 +356,7 @@ double KevinHallModel::get_weight_quantile(double epa_quantile, core::Gender sex
 
     // Compute Energy Physical Activity percentile (taking midpoint of duplicates).
     auto epa_range = std::equal_range(epa_quantiles_.begin(), epa_quantiles_.end(), epa_quantile);
-    double epa_index = std::distance(epa_quantiles_.begin(), epa_range.first);
+    double epa_index = static_cast<double>(std::distance(epa_quantiles_.begin(), epa_range.first));
     epa_index += std::distance(epa_range.first, epa_range.second) / 2.0;
     double epa_percentile = epa_index / epa_quantiles_.size();
 

--- a/src/HealthGPS/kevin_hall_model.cpp
+++ b/src/HealthGPS/kevin_hall_model.cpp
@@ -171,18 +171,26 @@ void KevinHallModel::set_nutrient_intakes(Person &person) const {
 }
 
 void KevinHallModel::initialise_energy_intake(Person &person) const {
+
+    // Initialise energy intake.
     set_energy_intake(person);
 
-    // Begin at steady state (EI = EE).
-    person.risk_factors["EnergyExpenditure"_id] = person.risk_factors.at("EnergyIntake"_id);
+    // Start with previous = current.
+    double energy_intake = person.risk_factors.at("EnergyIntake"_id);
+    person.risk_factors["EnergyIntake_previous"_id] = energy_intake;
 
-    // TODO: set old value to new value
+    // Begin at steady state (EI = EE).
+    person.risk_factors["EnergyExpenditure"_id] = energy_intake;
 }
 
 void KevinHallModel::update_energy_intake(Person &person) const {
-    set_energy_intake(person);
 
-    // TODO: set old value to previous value
+    // Set previous energy intake.
+    double previous_energy_intake = person.risk_factors.at("EnergyIntake"_id);
+    person.risk_factors.at("EnergyIntake_previous"_id) = previous_energy_intake;
+
+    // Update energy intake.
+    set_energy_intake(person);
 }
 
 void KevinHallModel::set_energy_intake(Person &person) const {
@@ -251,7 +259,7 @@ void KevinHallModel::initialise_kevin_hall_state(Person &person,
 
 SimulatePersonState KevinHallModel::simulate_person(Person &person, double shift) const {
     // Initial simulated person state.
-    const double H_0 = person.get_risk_factor_value("Height"_id);
+    const double H = person.get_risk_factor_value("Height"_id);
     const double BW_0 = person.get_risk_factor_value("Weight"_id);
     const double PAL_0 = person.get_risk_factor_value("PhysicalActivity"_id);
     const double F_0 = person.get_risk_factor_value("BodyFat"_id);
@@ -260,9 +268,6 @@ SimulatePersonState KevinHallModel::simulate_person(Person &person, double shift
     const double G_0 = person.get_risk_factor_value("Glycogen"_id);
     const double EI_0 = person.get_risk_factor_value("EnergyIntake"_id);
     const double CI_0 = person.get_risk_factor_value("Carbohydrate"_id);
-
-    // TODO: Compute height.
-    double H = H_0;
 
     // TODO: Compute physical activity level.
     double PAL = PAL_0;

--- a/src/HealthGPS/kevin_hall_model.cpp
+++ b/src/HealthGPS/kevin_hall_model.cpp
@@ -143,15 +143,23 @@ void KevinHallModel::initialise_nutrient_intakes(Person &person) const {
     // Initialise nutrient intakes.
     set_nutrient_intakes(person);
 
-    // TODO: set old value to new value (only some nutrients)
+    // Start with previous = current.
+    double carbohydrate = person.risk_factors.at("Carbohydrate"_id);
+    person.risk_factors["Carbohydrate_previous"_id] = carbohydrate;
+    double sodium = person.risk_factors.at("Sodium"_id);
+    person.risk_factors["Sodium_previous"_id] = sodium;
 }
 
 void KevinHallModel::update_nutrient_intakes(Person &person) const {
 
+    // Set previous nutrient intakes.
+    double previous_carbohydrate = person.risk_factors.at("Carbohydrate"_id);
+    person.risk_factors.at("Carbohydrate_previous"_id) = previous_carbohydrate;
+    double previous_sodium = person.risk_factors.at("Sodium"_id);
+    person.risk_factors.at("Sodium_previous"_id) = previous_sodium;
+
     // Update nutrient intakes.
     set_nutrient_intakes(person);
-
-    // TODO: set old value to previous value (only some nutrients)
 }
 
 void KevinHallModel::set_nutrient_intakes(Person &person) const {

--- a/src/HealthGPS/kevin_hall_model.cpp
+++ b/src/HealthGPS/kevin_hall_model.cpp
@@ -356,9 +356,9 @@ double KevinHallModel::get_weight_quantile(double epa_quantile, core::Gender sex
 
     // Compute Energy Physical Activity percentile (taking midpoint of duplicates).
     auto epa_range = std::equal_range(epa_quantiles_.begin(), epa_quantiles_.end(), epa_quantile);
-    double epa_index = static_cast<double>(std::distance(epa_quantiles_.begin(), epa_range.first));
+    auto epa_index = static_cast<double>(std::distance(epa_quantiles_.begin(), epa_range.first));
     epa_index += std::distance(epa_range.first, epa_range.second) / 2.0;
-    double epa_percentile = epa_index / epa_quantiles_.size();
+    auto epa_percentile = epa_index / epa_quantiles_.size();
 
     // Find weight quantile.
     auto weight_index = static_cast<size_t>(epa_percentile * (weight_quantiles_.size() - 1));

--- a/src/HealthGPS/kevin_hall_model.h
+++ b/src/HealthGPS/kevin_hall_model.h
@@ -70,16 +70,6 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     /// @param person The person to compute energy intake for
     void set_energy_intake(Person &person) const;
 
-    /// @brief  Initialise the Kevin Hall state variables of a person
-    /// @param person The person to initialise
-    /// @param adjustment An optional weight adjustment term (default is zero)
-    void initialise_kevin_hall_state(Person &person,
-                                     std::optional<double> adjustment = std::nullopt) const;
-
-    /// @brief Run the Kevin Hall energy balance model for a given person
-    /// @param person The person to simulate
-    void simulate_person(Person &person) const;
-
     /// @brief Compute glycogen.
     /// @param CI The carbohydrate intake
     /// @param CI_0 The initial carbohydrate intake
@@ -104,13 +94,36 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     /// @return The computed energy cost per unit body weight
     double compute_delta(int age, core::Gender sex, double PAL, double BW, double H) const;
 
+    /// @brief Compute energy expenditure.
+    /// @param BW The body weight
+    /// @param F The fat mass
+    /// @param L The lean tissue
+    /// @param EI The energy intake
+    /// @param K The model intercept
+    /// @param delta The energy cost per unit body weight
+    /// @param x TODO: what is this?
+    /// @return The computed energy expenditure
+    double compute_EE(double BW, double F, double L, double EI, double K, double delta,
+                      double x) const;
+
     /// @brief Initialises the weight of a person.
     /// @param person The person fo initialise the weight for.
     void initialise_weight(Person &person) const;
 
-    /// @brief Updates the weight of a person.
+    /// @brief  Initialise the Kevin Hall state variables of a person
+    /// @param person The person to initialise
+    /// @param adjustment An optional weight adjustment term (default is zero)
+    void initialise_kevin_hall_state(Person &person,
+                                     std::optional<double> adjustment = std::nullopt) const;
+
+    /// @brief Run the Kevin Hall energy balance model for a given person
+    /// @param person The person to simulate
+    void kevin_hall_run(Person &person) const;
+
+    /// @brief Adjusts the Kevin Hall variables of a person to baseline.
     /// @param person The person fo update the weight for.
-    void update_weight(Person &person) const;
+    /// @param adjustment The weight adjustment term
+    void kevin_hall_adjust(Person &person, double adjustment) const;
 
     /// @brief Returns the weight quantile for the given E overPA quantile and sex.
     /// @param epa_quantile The Energy / Physical Activity quantile.
@@ -123,6 +136,12 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     /// @return The weight power means by sex and age
     UnorderedMap2d<core::Gender, int, double>
     compute_mean_weight(Population &population, std::optional<double> power = std::nullopt) const;
+
+    /// @brief Compute or recieve Kevin Hall adjustments for sex and age
+    /// @param population The population to compute the adjustments for
+    /// @return The Kevin Hall adjustments by sex and age
+    UnorderedMap2d<core::Gender, int, double>
+    get_kevin_hall_adjustments(Population &population) const;
 
     // // TODO: implement this
     // /// @brief Initialises the height of a person.
@@ -153,6 +172,7 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     static constexpr int kevin_hall_age_min = 19; // Minimum age for the model.
     static constexpr double rho_F = 39.5e3;       // Energy content of fat (kJ/kg).
     static constexpr double rho_L = 7.6e3;        // Energy content of lean (kJ/kg).
+    static constexpr double rho_G = 17.6e3;       // Energy content of glycogen (kJ/kg).
     static constexpr double gamma_F = 13.0;       // RMR fat coefficients (kJ/kg/day).
     static constexpr double gamma_L = 92.0;       // RMR lean coefficients (kJ/kg/day).
     static constexpr double eta_F = 750.0;        // Fat synthesis energy coefficient (kJ/kg).

--- a/src/HealthGPS/kevin_hall_model.h
+++ b/src/HealthGPS/kevin_hall_model.h
@@ -12,6 +12,9 @@
 
 namespace hgps {
 
+/// @brief Defines a table type for Kevin Hall adjustments by sex and age
+using KevinHallAdjustmentTable = UnorderedMap2d<core::Gender, int, double>;
+
 /// @brief Implements the energy balance model type
 ///
 /// @details The dynamic model is used to advance the virtual population over time.
@@ -125,6 +128,11 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     /// @param adjustment The weight adjustment term
     void kevin_hall_adjust(Person &person, double adjustment) const;
 
+    /// @brief Compute Kevin Hall adjustments for sex and age
+    /// @param population The population to compute the adjustments for
+    /// @return The Kevin Hall adjustments by sex and age
+    KevinHallAdjustmentTable compute_kevin_hall_adjustments(Population &population) const;
+
     /// @brief Returns the weight quantile for the given E overPA quantile and sex.
     /// @param epa_quantile The Energy / Physical Activity quantile.
     /// @param sex The sex of the person.
@@ -134,14 +142,8 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     /// @param population The population to compute the mean for
     /// @param power The (optional) power to raise the weight to
     /// @return The weight power means by sex and age
-    UnorderedMap2d<core::Gender, int, double>
-    compute_mean_weight(Population &population, std::optional<double> power = std::nullopt) const;
-
-    /// @brief Compute or recieve Kevin Hall adjustments for sex and age
-    /// @param population The population to compute the adjustments for
-    /// @return The Kevin Hall adjustments by sex and age
-    UnorderedMap2d<core::Gender, int, double>
-    get_kevin_hall_adjustments(Population &population) const;
+    KevinHallAdjustmentTable compute_mean_weight(Population &population,
+                                                 std::optional<double> power = std::nullopt) const;
 
     // // TODO: implement this
     // /// @brief Initialises the height of a person.

--- a/src/HealthGPS/kevin_hall_model.h
+++ b/src/HealthGPS/kevin_hall_model.h
@@ -161,17 +161,21 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     /// @param person The person fo initialise the weight for.
     void initialise_weight(Person &person) const;
 
+    /// @brief Updates the weight of a person.
+    /// @param person The person fo update the weight for.
+    void update_weight(Person &person) const;
+
     /// @brief Returns the weight quantile for the given E overPA quantile and sex.
     /// @param epa_quantile The Energy / Physical Activity quantile.
     /// @param sex The sex of the person.
     double get_weight_quantile(double epa_quantile, core::Gender sex) const;
 
-    /// @brief Compute the mean of weight raised to power for eacg sex and age
+    /// @brief Compute the mean of weight (optionally raised to a power) for eac sex and age
     /// @param population The population to compute the mean for
-    /// @param power The power to raise the weight to
+    /// @param power The (optional) power to raise the weight to
     /// @return The weight power means by sex and age
-    UnorderedMap2d<core::Gender, int, double> compute_mean_weight_powers(Population &population,
-                                                                         double power) const;
+    UnorderedMap2d<core::Gender, int, double>
+    compute_mean_weight(Population &population, std::optional<double> power = std::nullopt) const;
 
     // // TODO: implement this
     // /// @brief Initialises the height of a person.
@@ -199,16 +203,17 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     const std::vector<double> &epa_quantiles_;
 
     // Model parameters.
-    static constexpr double rho_F = 39.5e3; // Energy content of fat (kJ/kg).
-    static constexpr double rho_L = 7.6e3;  // Energy content of lean (kJ/kg).
-    static constexpr double gamma_F = 13.0; // RMR fat coefficients (kJ/kg/day).
-    static constexpr double gamma_L = 92.0; // RMR lean coefficients (kJ/kg/day).
-    static constexpr double eta_F = 750.0;  // Fat synthesis energy coefficient (kJ/kg).
-    static constexpr double eta_L = 960.0;  // Lean synthesis energy coefficient (kJ/kg).
-    static constexpr double beta_TEF = 0.1; // TEF from energy intake (unitless).
-    static constexpr double beta_AT = 0.14; // AT from energy intake (unitless).
-    static constexpr double xi_Na = 3000.0; // Na from ECF changes (mg/L/day).
-    static constexpr double xi_CI = 4000.0; // Na from carbohydrate changes (mg/day).
+    static constexpr int kevin_hall_age_min = 19; // Minimum age for the model.
+    static constexpr double rho_F = 39.5e3;       // Energy content of fat (kJ/kg).
+    static constexpr double rho_L = 7.6e3;        // Energy content of lean (kJ/kg).
+    static constexpr double gamma_F = 13.0;       // RMR fat coefficients (kJ/kg/day).
+    static constexpr double gamma_L = 92.0;       // RMR lean coefficients (kJ/kg/day).
+    static constexpr double eta_F = 750.0;        // Fat synthesis energy coefficient (kJ/kg).
+    static constexpr double eta_L = 960.0;        // Lean synthesis energy coefficient (kJ/kg).
+    static constexpr double beta_TEF = 0.1;       // TEF from energy intake (unitless).
+    static constexpr double beta_AT = 0.14;       // AT from energy intake (unitless).
+    static constexpr double xi_Na = 3000.0;       // Na from ECF changes (mg/L/day).
+    static constexpr double xi_CI = 4000.0;       // Na from carbohydrate changes (mg/day).
 };
 
 /// @brief Defines the energy balance model data type

--- a/src/HealthGPS/kevin_hall_model.h
+++ b/src/HealthGPS/kevin_hall_model.h
@@ -12,39 +12,6 @@
 
 namespace hgps {
 
-/// @brief State data type for a simulated person
-struct SimulatePersonState {
-    /// @brief Height
-    double H{};
-
-    /// @brief Body weight
-    double BW{};
-
-    /// @brief Physical activity level
-    double PAL{};
-
-    /// @brief Body fat
-    double F{};
-
-    /// @brief Lean tissue
-    double L{};
-
-    /// @brief Extracellular fluid
-    double ECF{};
-
-    /// @brief Glycogen
-    double G{};
-
-    /// @brief Energy expenditure
-    double EE{};
-
-    /// @brief Energy intake
-    double EI{};
-
-    /// @brief Baseline adjustment coefficient
-    double adjust{};
-};
-
 /// @brief Implements the energy balance model type
 ///
 /// @details The dynamic model is used to advance the virtual population over time.
@@ -109,11 +76,9 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     void initialise_kevin_hall_state(Person &person,
                                      std::optional<double> adjustment = std::nullopt) const;
 
-    /// @brief Simulates the energy balance model for a given person
+    /// @brief Run the Kevin Hall energy balance model for a given person
     /// @param person The person to simulate
-    /// @param shift Model adjustment term
-    /// @return The state of the person
-    SimulatePersonState simulate_person(Person &person, double shift) const;
+    void simulate_person(Person &person) const;
 
     /// @brief Compute glycogen.
     /// @param CI The carbohydrate intake
@@ -122,19 +87,13 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     /// @return The computed glycogen
     double compute_G(double CI, double CI_0, double G_0) const;
 
-    /// @brief Compute water.
-    /// @param G The glycogen
-    /// @return The computed water
-    double compute_W(double G) const;
-
     /// @brief Compute extracellular fluid.
-    /// @param EI The energy intake
-    /// @param EI_0 The initial energy intake
+    /// @param delta_Na The change in dietary sodium
     /// @param CI The carbohydrate intake
     /// @param CI_0 The initial carbohydrate intake
     /// @param ECF_0 The initial extracellular fluid
     /// @return The computed extracellular fluid
-    double compute_ECF(double EI, double EI_0, double CI, double CI_0, double ECF_0) const;
+    double compute_ECF(double delta_Na, double CI, double CI_0, double ECF_0) const;
 
     /// @brief Compute energy cost per unit body weight.
     /// @param age The age of the person
@@ -144,18 +103,6 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     /// @param H The height (cm)
     /// @return The computed energy cost per unit body weight
     double compute_delta(int age, core::Gender sex, double PAL, double BW, double H) const;
-
-    /// @brief Compute thermic effect of food.
-    /// @param EI The energy intake
-    /// @param EI_0 The initial energy intake
-    /// @return The computed thermic effect of food
-    double compute_TEF(double EI, double EI_0) const;
-
-    /// @brief Compute adaptive thermogenesis.
-    /// @param EI The energy intake
-    /// @param EI_0 The initial energy intake
-    /// @return The computed adaptive thermogenesis
-    double compute_AT(double EI, double EI_0) const;
 
     /// @brief Initialises the weight of a person.
     /// @param person The person fo initialise the weight for.

--- a/src/HealthGPS/kevin_hall_model.h
+++ b/src/HealthGPS/kevin_hall_model.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "HealthGPS.Core/exception.h"
+
 #include "interfaces.h"
 #include "map2d.h"
 #include "mapping.h"
@@ -101,6 +103,12 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     /// @param person The person to compute energy intake for
     void set_energy_intake(Person &person) const;
 
+    /// @brief  Initialise the Kevin Hall state variables of a person
+    /// @param person The person to initialise
+    /// @param adjustment An optional weight adjustment term (default is zero)
+    void initialise_kevin_hall_state(Person &person,
+                                     std::optional<double> adjustment = std::nullopt) const;
+
     /// @brief Simulates the energy balance model for a given person
     /// @param person The person to simulate
     /// @param shift Model adjustment term
@@ -129,12 +137,13 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     double compute_ECF(double EI, double EI_0, double CI, double CI_0, double ECF_0) const;
 
     /// @brief Compute energy cost per unit body weight.
+    /// @param age The age of the person
+    /// @param sex the sex of the person
     /// @param PAL The physical activity level
-    /// @param RMR The resting metabolic rate
     /// @param BW The body weight
+    /// @param H The height (cm)
     /// @return The computed energy cost per unit body weight
-    double compute_delta(double PAL, double BW, double H, unsigned int age,
-                         core::Gender gender) const;
+    double compute_delta(int age, core::Gender sex, double PAL, double BW, double H) const;
 
     /// @brief Compute thermic effect of food.
     /// @param EI The energy intake

--- a/src/HealthGPS/kevin_hall_model.h
+++ b/src/HealthGPS/kevin_hall_model.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "interfaces.h"
+#include "map2d.h"
 #include "mapping.h"
 #include "risk_factor_adjustable_model.h"
 
@@ -150,14 +151,36 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     double compute_AT(double EI, double EI_0) const;
 
     /// @brief Initialises the weight of a person.
-    /// @details It uses the baseline adjustment to get its initial value, based on its sex and age.
     /// @param person The person fo initialise the weight for.
-    void initialise_weight(Person &person);
+    void initialise_weight(Person &person) const;
 
     /// @brief Returns the weight quantile for the given E overPA quantile and sex.
     /// @param epa_quantile The Energy / Physical Activity quantile.
     /// @param sex The sex of the person.
-    double get_weight_quantile(double epa_quantile, core::Gender sex);
+    double get_weight_quantile(double epa_quantile, core::Gender sex) const;
+
+    /// @brief Compute the mean of weight raised to power for eacg sex and age
+    /// @param population The population to compute the mean for
+    /// @param power The power to raise the weight to
+    /// @return The weight power means by sex and age
+    UnorderedMap2d<core::Gender, int, double> compute_mean_weight_powers(Population &population,
+                                                                         double power) const;
+
+    // // TODO: implement this
+    // /// @brief Initialises the height of a person.
+    // /// @param person The person fo initialise the height for.
+    // void initialise_height(Person &person);
+
+    // // TODO: implement this
+    // /// @brief Updates the height of a person.
+    // /// @param person The person fo update the height for.
+    // void update_height(Person &person);
+
+    // // TODO: implement this
+    // /// @brief Compute a new height value for the given person.
+    // /// @param person The person to compute the height for.
+    // /// @return The computed height.
+    // double compute_new_height(Person &person);
 
     const std::unordered_map<core::Identifier, double> &energy_equation_;
     const std::unordered_map<core::Identifier, core::DoubleInterval> &nutrient_ranges_;

--- a/src/HealthGPS/person.cpp
+++ b/src/HealthGPS/person.cpp
@@ -18,15 +18,7 @@ std::map<core::Identifier, std::function<double(const Person &)>> Person::curren
     {"SES"_id, [](const Person &p) { return p.ses; }},
 
     // HACK: ew, gross... allows us to mock risk factors we don't have data for yet
-    {"Height"_id, [](const Person &) { return 0.5; }},
     //{"BMI"_id, [](const Person &) { return 0.5; }},
-    {"BodyFat"_id, [](const Person &) { return 0.5; }},
-    {"LeanTissue"_id, [](const Person &) { return 0.5; }},
-    {"ExtracellularFluid"_id, [](const Person &) { return 0.5; }},
-    {"Glycogen"_id, [](const Person &) { return 0.5; }},
-    {"EnergyExpenditure"_id, [](const Person &) { return 0.5; }},
-    {"EnergyIntake"_id, [](const Person &) { return 0.5; }},
-    {"Carbohydrate"_id, [](const Person &) { return 0.5; }},
 };
 
 Person::Person() : id_{++Person::newUID} {}


### PR DESCRIPTION
This PR consists of a majority rewrite of the Kevin Hall variable update step in `KevinHallModel`, to allow setting Kevin Hall risk factors, adjusting them with a new baseline adjustment code, and communicating those adjustments to the intervention scenario.

Now, starting with a call to the update step `update_risk_factors`  of this model, the following things happen:

1. Nutrient and energy intake are initialised for newborns, and updated for others.
2. Under 19: KevinHall does not apply, so initialise. Over 19: KevinHall applies, so run model.
3. Compute weight adjust, and compensation to other variables, and send adjustments to intervention.
4. Under 19: Reinitialise KevinHall variables with adjustment. Over 19: adjust KevinHall variables.
5. Send adjustments to intervention, if applicable.

All the existing baseline adjustment code was removed, and I and another tidy up.

Fixes #260 
