### PR TITLE
Add dummy risk factor model class.

### DIFF
--- a/src/HealthGPS.Console/model_parser.cpp
+++ b/src/HealthGPS.Console/model_parser.cpp
@@ -81,6 +81,9 @@ std::unique_ptr<hgps::RiskFactorModelDefinition>
 load_static_risk_model_definition(const std::string &model_name, const poco::json &opt,
                                   const host::Configuration &config) {
     // Load this static model with the appropriate loader.
+    if (hgps::core::case_insensitive::equals(model_name, "dummy")) {
+        return load_dummy_model_definition(hgps::RiskFactorModelType::Static, opt);
+    }
     if (hgps::core::case_insensitive::equals(model_name, "hlm")) {
         return load_hlm_risk_model_definition(opt);
     }
@@ -331,6 +334,9 @@ std::unique_ptr<hgps::RiskFactorModelDefinition>
 load_dynamic_risk_model_definition(const std::string &model_name, const poco::json &opt,
                                    const host::Configuration &config) {
     // Load this dynamic model with the appropriate loader.
+    if (hgps::core::case_insensitive::equals(model_name, "dummy")) {
+        return load_dummy_model_definition(hgps::RiskFactorModelType::Dynamic, opt);
+    }
     if (hgps::core::case_insensitive::equals(model_name, "ebhlm")) {
         return load_ebhlm_risk_model_definition(opt, config);
     }

--- a/src/HealthGPS.Console/model_parser.cpp
+++ b/src/HealthGPS.Console/model_parser.cpp
@@ -59,6 +59,24 @@ hgps::RiskFactorSexAgeTable load_risk_factor_expected(const host::Configuration 
     return table;
 }
 
+std::unique_ptr<hgps::DummyModelDefinition>
+load_dummy_model_definition(hgps::RiskFactorModelType type, const poco::json &opt) {
+    MEASURE_FUNCTION();
+
+    // Get dummy model parameters
+    std::vector<hgps::core::Identifier> names;
+    std::vector<double> values;
+    std::vector<double> policy;
+    for (const auto &[key, json_params] : opt["ModelParameters"].items()) {
+        names.emplace_back(key);
+        values.emplace_back(json_params["Value"].get<double>());
+        policy.emplace_back(json_params["Policy"].get<double>());
+    }
+
+    return std::make_unique<hgps::DummyModelDefinition>(type, std::move(names), std::move(values),
+                                                        std::move(policy));
+}
+
 std::unique_ptr<hgps::RiskFactorModelDefinition>
 load_static_risk_model_definition(const std::string &model_name, const poco::json &opt,
                                   const host::Configuration &config) {

--- a/src/HealthGPS.Console/model_parser.cpp
+++ b/src/HealthGPS.Console/model_parser.cpp
@@ -81,13 +81,13 @@ std::unique_ptr<hgps::RiskFactorModelDefinition>
 load_static_risk_model_definition(const std::string &model_name, const poco::json &opt,
                                   const host::Configuration &config) {
     // Load this static model with the appropriate loader.
-    if (hgps::core::case_insensitive::equals(model_name, "dummy")) {
+    if (model_name == "dummy") {
         return load_dummy_model_definition(hgps::RiskFactorModelType::Static, opt);
     }
-    if (hgps::core::case_insensitive::equals(model_name, "hlm")) {
+    if (model_name == "hlm") {
         return load_hlm_risk_model_definition(opt);
     }
-    if (hgps::core::case_insensitive::equals(model_name, "staticlinear")) {
+    if (model_name == "staticlinear") {
         return load_staticlinear_risk_model_definition(opt, config);
     }
 
@@ -334,13 +334,13 @@ std::unique_ptr<hgps::RiskFactorModelDefinition>
 load_dynamic_risk_model_definition(const std::string &model_name, const poco::json &opt,
                                    const host::Configuration &config) {
     // Load this dynamic model with the appropriate loader.
-    if (hgps::core::case_insensitive::equals(model_name, "dummy")) {
+    if (model_name == "dummy") {
         return load_dummy_model_definition(hgps::RiskFactorModelType::Dynamic, opt);
     }
-    if (hgps::core::case_insensitive::equals(model_name, "ebhlm")) {
+    if (model_name == "ebhlm") {
         return load_ebhlm_risk_model_definition(opt, config);
     }
-    if (hgps::core::case_insensitive::equals(model_name, "kevinhall")) {
+    if (model_name == "kevinhall") {
         return load_kevinhall_risk_model_definition(opt, config);
     }
 

--- a/src/HealthGPS.Console/model_parser.h
+++ b/src/HealthGPS.Console/model_parser.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "HealthGPS/dummy_model.h"
 #include "HealthGPS/dynamic_hierarchical_linear_model.h"
 #include "HealthGPS/kevin_hall_model.h"
 #include "HealthGPS/risk_factor_adjustable_model.h"
@@ -17,6 +18,14 @@ namespace host {
 /// @param config The model configuration
 /// @return An instance of the hgps::RiskFactorSexAgeTable type
 hgps::RiskFactorSexAgeTable load_risk_factor_expected(const Configuration &config);
+
+/// @brief Loads either a static or dynamic dummy risk factor model from a JSON file
+/// @param type Model type (static or dynamic)
+/// @param opt The parsed model definition JSON file
+/// @return An instance of the hgps::DummyModelDefinition type
+/// @throw std::invalid_argument if error parsing model configuration file
+std::unique_ptr<hgps::DummyModelDefinition>
+load_dummy_model_definition(hgps::RiskFactorModelType type, const poco::json &opt);
 
 /// @brief Loads a static risk factor model from a JSON file
 /// @param model_name The name of the model to use

--- a/src/HealthGPS/CMakeLists.txt
+++ b/src/HealthGPS/CMakeLists.txt
@@ -26,6 +26,8 @@ target_sources(
             "disease.h"
             "disease_table.cpp"
             "disease_table.h"
+            "dummy_model.cpp"
+            "dummy_model.h"
             "dynamic_hierarchical_linear_model.cpp"
             "dynamic_hierarchical_linear_model.h"
             "kevin_hall_model.cpp"

--- a/src/HealthGPS/dummy_model.cpp
+++ b/src/HealthGPS/dummy_model.cpp
@@ -4,20 +4,7 @@ namespace hgps {
 
 DummyModel::DummyModel(RiskFactorModelType type, const std::vector<core::Identifier> &names,
                        const std::vector<double> &values, const std::vector<double> &policy)
-    : type_{type}, names_{names}, values_{values}, policy_{policy} {
-    if (names_.empty()) {
-        throw core::HgpsException("Risk factor names list is empty");
-    }
-    if (values_.empty()) {
-        throw core::HgpsException("Risk factor values list is empty");
-    }
-    if (policy_.empty()) {
-        throw core::HgpsException("Risk factor policy lisy empty");
-    }
-    if (names_.size() != values_.size() || names_.size() != policy_.size()) {
-        throw core::HgpsException("Risk factor name, value and policy list sizes mismatch");
-    }
-}
+    : type_{type}, names_{names}, values_{values}, policy_{policy} {}
 
 RiskFactorModelType DummyModel::type() const noexcept { return type_; }
 
@@ -60,6 +47,7 @@ DummyModelDefinition::DummyModelDefinition(RiskFactorModelType type,
                                            std::vector<double> values, std::vector<double> policy)
     : type_{type}, names_{std::move(names)}, values_{std::move(values)},
       policy_{std::move(policy)} {
+
     if (names_.empty()) {
         throw core::HgpsException("Risk factor names list is empty");
     }

--- a/src/HealthGPS/dummy_model.cpp
+++ b/src/HealthGPS/dummy_model.cpp
@@ -1,0 +1,75 @@
+#include "dummy_model.h"
+
+namespace hgps {
+
+DummyModel::DummyModel(RiskFactorModelType type, const std::vector<core::Identifier> &names,
+                       const std::vector<double> &values, const std::vector<double> &policy)
+    : type_{type}, names_{names}, values_{values}, policy_{policy} {
+    if (names_.empty()) {
+        throw core::HgpsException("Risk factor names list is empty");
+    }
+    if (values_.empty()) {
+        throw core::HgpsException("Risk factor values list is empty");
+    }
+    if (policy_.empty()) {
+        throw core::HgpsException("Risk factor policy lisy empty");
+    }
+}
+
+RiskFactorModelType DummyModel::type() const noexcept { return type_; }
+
+std::string DummyModel::name() const noexcept { return "Dummy"; }
+
+void DummyModel::generate_risk_factors(RuntimeContext &context) {
+
+    // Initialise everyone.
+    for (auto &entity : context.population()) {
+        set_risk_factors(entity, context.scenario().type());
+    }
+}
+
+void DummyModel::update_risk_factors(RuntimeContext &context) {
+
+    // Initialise everyone except inactive.
+    for (auto &entity : context.population()) {
+        // Ignore if inactive.
+        if (!entity.is_active()) {
+            continue;
+        }
+
+        set_risk_factors(entity, context.scenario().type());
+    }
+}
+
+void DummyModel::set_risk_factors(Person &person, ScenarioType scenario) const {
+    for (auto i = 0u; i < names_.size(); ++i) {
+        person.risk_factors[names_[i]] = values_[i];
+
+        // Apply intervention policy.
+        if (scenario == ScenarioType::intervention) {
+            person.risk_factors[names_[i]] += policy_[i];
+        }
+    }
+}
+
+DummyModelDefinition::DummyModelDefinition(RiskFactorModelType type,
+                                           std::vector<core::Identifier> names,
+                                           std::vector<double> values, std::vector<double> policy)
+    : type_{type}, names_{std::move(names)}, values_{std::move(values)},
+      policy_{std::move(policy)} {
+    if (names_.empty()) {
+        throw core::HgpsException("Risk factor names list is empty");
+    }
+    if (values_.empty()) {
+        throw core::HgpsException("Risk factor values list is empty");
+    }
+    if (policy_.empty()) {
+        throw core::HgpsException("Risk factor policy lisy empty");
+    }
+}
+
+std::unique_ptr<RiskFactorModel> DummyModelDefinition::create_model() const {
+    return std::make_unique<DummyModel>(type_, names_, values_, policy_);
+}
+
+} // namespace hgps

--- a/src/HealthGPS/dummy_model.cpp
+++ b/src/HealthGPS/dummy_model.cpp
@@ -14,6 +14,9 @@ DummyModel::DummyModel(RiskFactorModelType type, const std::vector<core::Identif
     if (policy_.empty()) {
         throw core::HgpsException("Risk factor policy lisy empty");
     }
+    if (names_.size() != values_.size() || names_.size() != policy_.size()) {
+        throw core::HgpsException("Risk factor name, value and policy list sizes mismatch");
+    }
 }
 
 RiskFactorModelType DummyModel::type() const noexcept { return type_; }
@@ -65,6 +68,9 @@ DummyModelDefinition::DummyModelDefinition(RiskFactorModelType type,
     }
     if (policy_.empty()) {
         throw core::HgpsException("Risk factor policy lisy empty");
+    }
+    if (names_.size() != values_.size() || names_.size() != policy_.size()) {
+        throw core::HgpsException("Risk factor name, value and policy list sizes mismatch");
     }
 }
 

--- a/src/HealthGPS/dummy_model.h
+++ b/src/HealthGPS/dummy_model.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "risk_factor_model.h"
+
+#include <string>
+#include <vector>
+
+namespace hgps {
+
+/// @brief Implements the dummy risk factor model type
+///
+/// @details The dummy model is used to fix risk factors to known constant values.
+class DummyModel final : public RiskFactorModel {
+  public:
+    /// @brief Initialises a new instance of the DummyModel class
+    /// @param type Risk factor model type
+    /// @param names Risk factor names
+    /// @param values Constant values to set risk factors to
+    /// @param policy Risk factor policy in intervention scenario
+    DummyModel(RiskFactorModelType type, const std::vector<core::Identifier> &names,
+               const std::vector<double> &values, const std::vector<double> &policy);
+
+    RiskFactorModelType type() const noexcept override;
+
+    std::string name() const noexcept override;
+
+    void generate_risk_factors(RuntimeContext &context) override;
+
+    void update_risk_factors(RuntimeContext &context) override;
+
+  private:
+    /// @brief Set risk factor values and apply intervention policy
+    /// @param person The person to set the risk factors for
+    /// @param scenario The scenario type (baseline or intervention)
+    void set_risk_factors(Person &person, ScenarioType scenario) const;
+
+    const RiskFactorModelType type_;
+    const std::vector<core::Identifier> &names_;
+    const std::vector<double> &values_;
+    const std::vector<double> &policy_;
+};
+
+/// @brief Defines the dummy risk factor model type
+class DummyModelDefinition final : public RiskFactorModelDefinition {
+  public:
+    /// @brief Initialises a new instance of the DummyModelFactory class
+    /// @param type Risk factor model type
+    /// @param names Risk factor names
+    /// @param values Constant values to set risk factors to
+    /// @param policy Risk factor policy in intervention scenario
+    DummyModelDefinition(RiskFactorModelType type, std::vector<core::Identifier> names,
+                         std::vector<double> values, std::vector<double> policy);
+
+    /// @brief Construct a new DummyModel from this definition
+    /// @return A unique pointer to the new DummyModel instance
+    std::unique_ptr<RiskFactorModel> create_model() const override;
+
+  private:
+    RiskFactorModelType type_;
+    std::vector<core::Identifier> names_;
+    std::vector<double> values_;
+    std::vector<double> policy_;
+};
+
+} // namespace hgps

--- a/src/HealthGPS/dummy_model.h
+++ b/src/HealthGPS/dummy_model.h
@@ -20,12 +20,20 @@ class DummyModel final : public RiskFactorModel {
     DummyModel(RiskFactorModelType type, const std::vector<core::Identifier> &names,
                const std::vector<double> &values, const std::vector<double> &policy);
 
+    /// @brief Get the risk factor model type
+    /// @return The risk factor model type
     RiskFactorModelType type() const noexcept override;
 
+    /// @brief Get the risk factor model name
+    /// @return The risk factor model name
     std::string name() const noexcept override;
 
+    /// @brief Initialise risk factor values and apply intervention policy
+    /// @param context The runtime context
     void generate_risk_factors(RuntimeContext &context) override;
 
+    /// @brief Update risk factor values and apply intervention policy
+    /// @param context The runtime context
     void update_risk_factors(RuntimeContext &context) override;
 
   private:

--- a/src/HealthGPS/dynamic_hierarchical_linear_model.cpp
+++ b/src/HealthGPS/dynamic_hierarchical_linear_model.cpp
@@ -12,16 +12,7 @@ DynamicHierarchicalLinearModel::DynamicHierarchicalLinearModel(
     const std::map<core::IntegerInterval, AgeGroupGenderEquation> &equations,
     const std::map<core::Identifier, core::Identifier> &variables, double boundary_percentage)
     : RiskFactorAdjustableModel{expected}, equations_{equations}, variables_{variables},
-      boundary_percentage_{boundary_percentage} {
-
-    if (equations_.empty()) {
-        throw core::HgpsException("The model equations definition must not be empty");
-    }
-
-    if (variables_.empty()) {
-        throw core::HgpsException("The model variables definition must not be empty");
-    }
-}
+      boundary_percentage_{boundary_percentage} {}
 
 RiskFactorModelType DynamicHierarchicalLinearModel::type() const noexcept {
     return RiskFactorModelType::Dynamic;
@@ -155,7 +146,6 @@ DynamicHierarchicalLinearModelDefinition::DynamicHierarchicalLinearModelDefiniti
     if (equations_.empty()) {
         throw core::HgpsException("The model equations definition must not be empty");
     }
-
     if (variables_.empty()) {
         throw core::HgpsException("The model variables definition must not be empty");
     }

--- a/src/HealthGPS/kevin_hall_model.cpp
+++ b/src/HealthGPS/kevin_hall_model.cpp
@@ -35,30 +35,7 @@ KevinHallModel::KevinHallModel(
     : RiskFactorAdjustableModel{expected}, energy_equation_{energy_equation},
       nutrient_ranges_{nutrient_ranges}, nutrient_equations_{nutrient_equations},
       food_prices_{food_prices}, weight_quantiles_{weight_quantiles}, epa_quantiles_{epa_quantiles},
-      height_stddev_{height_stddev}, height_slope_{height_slope} {
-
-    if (energy_equation_.empty()) {
-        throw core::HgpsException("Energy equation mapping is empty");
-    }
-    if (nutrient_ranges_.empty()) {
-        throw core::HgpsException("Nutrient range mapping is empty");
-    }
-    if (nutrient_equations_.empty()) {
-        throw core::HgpsException("Nutrient equation mapping is empty");
-    }
-    if (food_prices_.empty()) {
-        throw core::HgpsException("Food price mapping is empty");
-    }
-    if (weight_quantiles_.empty()) {
-        throw core::HgpsException("Weight quantiles mapping is empty");
-    }
-    if (epa_quantiles_.empty()) {
-        throw core::HgpsException("Energy Physical Activity quantiles mapping is empty");
-    }
-    if (height_stddev_.empty()) {
-        throw core::HgpsException("Height standard deviation mapping is empty");
-    }
-}
+      height_stddev_{height_stddev}, height_slope_{height_slope} {}
 
 RiskFactorModelType KevinHallModel::type() const noexcept { return RiskFactorModelType::Dynamic; }
 

--- a/src/HealthGPS/static_hierarchical_linear_model.cpp
+++ b/src/HealthGPS/static_hierarchical_linear_model.cpp
@@ -8,16 +8,7 @@ namespace hgps {
 StaticHierarchicalLinearModel::StaticHierarchicalLinearModel(
     const std::unordered_map<core::Identifier, LinearModel> &models,
     const std::map<int, HierarchicalLevel> &levels)
-    : models_{models}, levels_{levels} {
-
-    if (models_.empty()) {
-        throw core::HgpsException("The hierarchical model equations definition must not be empty");
-    }
-
-    if (levels_.empty()) {
-        throw core::HgpsException("The hierarchical model levels definition must not be empty");
-    }
-}
+    : models_{models}, levels_{levels} {}
 
 RiskFactorModelType StaticHierarchicalLinearModel::type() const noexcept {
     return RiskFactorModelType::Static;
@@ -128,7 +119,6 @@ StaticHierarchicalLinearModelDefinition::StaticHierarchicalLinearModelDefinition
     if (models_.empty()) {
         throw core::HgpsException("The hierarchical model equations definition must not be empty");
     }
-
     if (levels_.empty()) {
         throw core::HgpsException("The hierarchical model levels definition must not be empty");
     }

--- a/src/HealthGPS/static_linear_model.cpp
+++ b/src/HealthGPS/static_linear_model.cpp
@@ -21,39 +21,7 @@ StaticLinearModel::StaticLinearModel(
       stddev_{stddev}, cholesky_{cholesky}, policy_models_{policy_models},
       policy_ranges_{policy_ranges}, policy_cholesky_{policy_cholesky}, info_speed_{info_speed},
       rural_prevalence_{rural_prevalence}, income_models_{income_models},
-      physical_activity_stddev_{physical_activity_stddev} {
-
-    if (names_.empty()) {
-        throw core::HgpsException("Risk factor names list is empty");
-    }
-    if (models_.empty()) {
-        throw core::HgpsException("Risk factor model list is empty");
-    }
-    if (lambda_.empty()) {
-        throw core::HgpsException("Risk factor lambda list is empty");
-    }
-    if (stddev_.empty()) {
-        throw core::HgpsException("Risk factor standard deviation list is empty");
-    }
-    if (!cholesky_.allFinite()) {
-        throw core::HgpsException("Risk factor Cholesky matrix contains non-finite values");
-    }
-    if (policy_models_.empty()) {
-        throw core::HgpsException("Intervention policy model list is empty");
-    }
-    if (policy_ranges_.empty()) {
-        throw core::HgpsException("Intervention policy ranges list is empty");
-    }
-    if (!policy_cholesky_.allFinite()) {
-        throw core::HgpsException("Intervention policy Cholesky matrix contains non-finite values");
-    }
-    if (rural_prevalence_.empty()) {
-        throw core::HgpsException("Rural prevalence mapping is empty");
-    }
-    if (income_models_.empty()) {
-        throw core::HgpsException("Income models mapping is empty");
-    }
-}
+      physical_activity_stddev_{physical_activity_stddev} {}
 
 RiskFactorModelType StaticLinearModel::type() const noexcept { return RiskFactorModelType::Static; }
 


### PR DESCRIPTION
Fixes #300 

This change adds a simple `DummyModel` risk factor model, and `DummyModelDefinition` classes, along with `model_parser.cpp` code for loading parameters from a new `Dummy.json` config.

The idea is that we can force risk factors to certain configurable constant values, and modify them by some configurable constant amount in the intervention scenario.

This removes much of the stochasticity from the model, allowing us (and future unit tests) to focus on only effect and stochasticity in the disease mechanism, with minimal example code.