### PR TITLE
Remove testing with clang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,6 @@ jobs:
             os: ubuntu-22.04
             compiler: gcc-latest
             is_main: false
-          - platform: linux
-            os: ubuntu-22.04
-            compiler: clang
-            is_main: false
           - platform: windows
             os: windows-2022
             compiler: msvc
@@ -73,14 +69,6 @@ jobs:
 
           # Use environment variable to tell CMake to compile with this version of gcc
           echo CXX=g++-$LATEST_GCC_VERSION >> "$GITHUB_ENV"
-
-      - name: Install clang (Linux)
-        if: matrix.platform == 'linux' && matrix.compiler == 'clang'
-        run: |
-          sudo apt install --no-install-recommends clang
-
-          # Use environment variable to tell CMake to compile with clang
-          echo CXX=clang++ >> "$GITHUB_ENV"
 
       - name: Install VCPKG
         run: |


### PR DESCRIPTION
As it is very annoying having that workflow systematically failing. Also, having a workflow that fails and is ignored defeats the purpose of having that workflow, to start with.

@jamesturner246 feel free to disagree and ignore this PR.