### PR TITLE
Dummy policy start

### DIFF
--- a/src/HealthGPS.Console/model_parser.cpp
+++ b/src/HealthGPS.Console/model_parser.cpp
@@ -67,14 +67,16 @@ load_dummy_model_definition(hgps::RiskFactorModelType type, const poco::json &op
     std::vector<hgps::core::Identifier> names;
     std::vector<double> values;
     std::vector<double> policy;
+    std::vector<int> policy_start;
     for (const auto &[key, json_params] : opt["ModelParameters"].items()) {
         names.emplace_back(key);
         values.emplace_back(json_params["Value"].get<double>());
         policy.emplace_back(json_params["Policy"].get<double>());
+        policy_start.emplace_back(json_params["PolicyStart"].get<int>());
     }
 
     return std::make_unique<hgps::DummyModelDefinition>(type, std::move(names), std::move(values),
-                                                        std::move(policy));
+                                                        std::move(policy), std::move(policy_start));
 }
 
 std::unique_ptr<hgps::RiskFactorModelDefinition>

--- a/src/HealthGPS/dummy_model.cpp
+++ b/src/HealthGPS/dummy_model.cpp
@@ -14,11 +14,15 @@ void DummyModel::generate_risk_factors(RuntimeContext &context) {
 
     // Initialise everyone.
     for (auto &entity : context.population()) {
-        set_risk_factors(entity, context.scenario().type());
+        set_risk_factors(entity, false);
     }
 }
 
 void DummyModel::update_risk_factors(RuntimeContext &context) {
+
+    // HACK: start intervening after 2 years from sim start.
+    bool intervene = (context.scenario().type() == ScenarioType::intervention &&
+                      (context.time_now() - context.start_time()) >= 2);
 
     // Initialise everyone except inactive.
     for (auto &entity : context.population()) {
@@ -27,16 +31,16 @@ void DummyModel::update_risk_factors(RuntimeContext &context) {
             continue;
         }
 
-        set_risk_factors(entity, context.scenario().type());
+        set_risk_factors(entity, intervene);
     }
 }
 
-void DummyModel::set_risk_factors(Person &person, ScenarioType scenario) const {
+void DummyModel::set_risk_factors(Person &person, bool intervene) const {
     for (auto i = 0u; i < names_.size(); ++i) {
         person.risk_factors[names_[i]] = values_[i];
 
-        // Apply intervention policy.
-        if (scenario == ScenarioType::intervention) {
+        // Apply policy if we are intervening.
+        if (intervene) {
             person.risk_factors[names_[i]] += policy_[i];
         }
     }

--- a/src/HealthGPS/dummy_model.cpp
+++ b/src/HealthGPS/dummy_model.cpp
@@ -15,7 +15,7 @@ void DummyModel::generate_risk_factors(RuntimeContext &context) {
 
     // Initialise everyone.
     for (auto &entity : context.population()) {
-        set_risk_factors(entity, context);
+        set_risk_factors(entity, context.scenario().type(), 0);
     }
 }
 
@@ -28,21 +28,17 @@ void DummyModel::update_risk_factors(RuntimeContext &context) {
             continue;
         }
 
-        set_risk_factors(entity, context);
+        int time_elapsed = context.time_now() - context.start_time();
+        set_risk_factors(entity, context.scenario().type(), time_elapsed);
     }
 }
 
-void DummyModel::set_risk_factors(Person &person, RuntimeContext &context) const {
+void DummyModel::set_risk_factors(Person &person, ScenarioType scenario, int time_elapsed) const {
     for (auto i = 0u; i < names_.size(); i++) {
         person.risk_factors[names_[i]] = values_[i];
 
-        // Skip policy update if not intervention scenario.
-        if (context.scenario().type() != ScenarioType::intervention) {
-            continue;
-        }
-
-        // Apply policy to factor if start time is reached.
-        if ((context.time_now() - context.start_time()) >= policy_start_[i]) {
+        // Apply policy to factor if intervening and start time is reached.
+        if (scenario == ScenarioType::intervention && time_elapsed >= policy_start_[i]) {
             person.risk_factors[names_[i]] += policy_[i];
         }
     }

--- a/src/HealthGPS/dummy_model.h
+++ b/src/HealthGPS/dummy_model.h
@@ -17,8 +17,10 @@ class DummyModel final : public RiskFactorModel {
     /// @param names Risk factor names
     /// @param values Constant values to set risk factors to
     /// @param policy Risk factor policy in intervention scenario
+    /// @param policy_start Policy start iteration
     DummyModel(RiskFactorModelType type, const std::vector<core::Identifier> &names,
-               const std::vector<double> &values, const std::vector<double> &policy);
+               const std::vector<double> &values, const std::vector<double> &policy,
+               const std::vector<int> &policy_start);
 
     /// @brief Get the risk factor model type
     /// @return The risk factor model type
@@ -39,13 +41,14 @@ class DummyModel final : public RiskFactorModel {
   private:
     /// @brief Set risk factor values and apply intervention policy
     /// @param person The person to set the risk factors for
-    /// @param intervene Flag to apply intervention policy
-    void set_risk_factors(Person &person, bool intervene) const;
+    /// @param context The runtime context
+    void set_risk_factors(Person &person, RuntimeContext &context) const;
 
     const RiskFactorModelType type_;
     const std::vector<core::Identifier> &names_;
     const std::vector<double> &values_;
     const std::vector<double> &policy_;
+    const std::vector<int> &policy_start_;
 };
 
 /// @brief Defines the dummy risk factor model type
@@ -56,8 +59,10 @@ class DummyModelDefinition final : public RiskFactorModelDefinition {
     /// @param names Risk factor names
     /// @param values Constant values to set risk factors to
     /// @param policy Risk factor policy in intervention scenario
+    /// @param policy_start Policy start iteration
     DummyModelDefinition(RiskFactorModelType type, std::vector<core::Identifier> names,
-                         std::vector<double> values, std::vector<double> policy);
+                         std::vector<double> values, std::vector<double> policy,
+                         std::vector<int> policy_start);
 
     /// @brief Construct a new DummyModel from this definition
     /// @return A unique pointer to the new DummyModel instance
@@ -68,6 +73,7 @@ class DummyModelDefinition final : public RiskFactorModelDefinition {
     std::vector<core::Identifier> names_;
     std::vector<double> values_;
     std::vector<double> policy_;
+    std::vector<int> policy_start_;
 };
 
 } // namespace hgps

--- a/src/HealthGPS/dummy_model.h
+++ b/src/HealthGPS/dummy_model.h
@@ -39,8 +39,8 @@ class DummyModel final : public RiskFactorModel {
   private:
     /// @brief Set risk factor values and apply intervention policy
     /// @param person The person to set the risk factors for
-    /// @param scenario The scenario type (baseline or intervention)
-    void set_risk_factors(Person &person, ScenarioType scenario) const;
+    /// @param intervene Flag to apply intervention policy
+    void set_risk_factors(Person &person, bool intervene) const;
 
     const RiskFactorModelType type_;
     const std::vector<core::Identifier> &names_;

--- a/src/HealthGPS/dummy_model.h
+++ b/src/HealthGPS/dummy_model.h
@@ -17,7 +17,7 @@ class DummyModel final : public RiskFactorModel {
     /// @param names Risk factor names
     /// @param values Constant values to set risk factors to
     /// @param policy Risk factor policy in intervention scenario
-    /// @param policy_start Policy start iteration
+    /// @param policy_start Policy start (in years since the start of the simulation)
     DummyModel(RiskFactorModelType type, const std::vector<core::Identifier> &names,
                const std::vector<double> &values, const std::vector<double> &policy,
                const std::vector<int> &policy_start);
@@ -41,8 +41,9 @@ class DummyModel final : public RiskFactorModel {
   private:
     /// @brief Set risk factor values and apply intervention policy
     /// @param person The person to set the risk factors for
-    /// @param context The runtime context
-    void set_risk_factors(Person &person, RuntimeContext &context) const;
+    /// @param scenario The scenario (either baseline or intervention)
+    /// @param time_elapsed The number of years since the start of the simulation
+    void set_risk_factors(Person &person, ScenarioType scenario, int time_elapsed) const;
 
     const RiskFactorModelType type_;
     const std::vector<core::Identifier> &names_;
@@ -59,7 +60,7 @@ class DummyModelDefinition final : public RiskFactorModelDefinition {
     /// @param names Risk factor names
     /// @param values Constant values to set risk factors to
     /// @param policy Risk factor policy in intervention scenario
-    /// @param policy_start Policy start iteration
+    /// @param policy_start Policy start (in years since the start of the simulation)
     DummyModelDefinition(RiskFactorModelType type, std::vector<core::Identifier> names,
                          std::vector<double> values, std::vector<double> policy,
                          std::vector<int> policy_start);

--- a/src/HealthGPS/static_linear_model.cpp
+++ b/src/HealthGPS/static_linear_model.cpp
@@ -48,6 +48,10 @@ void StaticLinearModel::generate_risk_factors(RuntimeContext &context) {
 
 void StaticLinearModel::update_risk_factors(RuntimeContext &context) {
 
+    // HACK: start intervening after 2 years from sim start.
+    bool intervene = (context.scenario().type() == ScenarioType::intervention &&
+                      (context.time_now() - context.start_time()) > 2);
+
     // Initialise newborns and update others.
     for (auto &person : context.population()) {
         // Ignore if inactive.
@@ -75,10 +79,6 @@ void StaticLinearModel::update_risk_factors(RuntimeContext &context) {
         if (!person.is_active()) {
             continue;
         }
-
-        // HACK: start intervening after 2 years from sim start.
-        bool intervene = (context.scenario().type() == ScenarioType::intervention &&
-                          (context.time_now() - context.start_time()) > 2);
 
         if (person.age == 0) {
             initialise_policies(person, context.random(), intervene);

--- a/src/HealthGPS/static_linear_model.cpp
+++ b/src/HealthGPS/static_linear_model.cpp
@@ -42,11 +42,7 @@ void StaticLinearModel::generate_risk_factors(RuntimeContext &context) {
 
     // Initialise everyone.
     for (auto &person : context.population()) {
-        // HACK: start intervening after 2 years from sim start.
-        bool intervene = (context.scenario().type() == ScenarioType::intervention &&
-                          (context.time_now() - context.start_time()) > 2);
-
-        initialise_policies(person, context.random(), intervene);
+        initialise_policies(person, context.random(), false);
     }
 }
 

--- a/src/HealthGPS/static_linear_model.cpp
+++ b/src/HealthGPS/static_linear_model.cpp
@@ -50,7 +50,7 @@ void StaticLinearModel::update_risk_factors(RuntimeContext &context) {
 
     // HACK: start intervening after 2 years from sim start.
     bool intervene = (context.scenario().type() == ScenarioType::intervention &&
-                      (context.time_now() - context.start_time()) > 2);
+                      (context.time_now() - context.start_time()) >= 2);
 
     // Initialise newborns and update others.
     for (auto &person : context.population()) {


### PR DESCRIPTION
This small change adds a per-factor configurable start iteration on which to apply intervention policy updating.

model_parser.cpp is added to load these values from a `DummyModel.json` config. Main changes are in `dummy_model.cpp`. Changes in `static_linear_model.cpp` are minor.

@TinyMarsh, I'll add you to the review if you want to get more of an idea on the workings, but no sweat if you don't.
