### PR TITLE
Disease incidence in output CSV

### DIFF
--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -297,9 +297,12 @@ void AnalysisModule::calculate_population_statistics(RuntimeContext &context,
                 entity.get_risk_factor_value(factor.key());
         }
 
-        for (const auto &item : entity.diseases) {
-            if (item.second.status == DiseaseStatus::active) {
-                series(gender, item.first.to_string()).at(age)++;
+        for (const auto &[disease_name, disease_state] : entity.diseases) {
+            if (disease_state.status == DiseaseStatus::active) {
+                series(gender, "prevalence_" + disease_name.to_string()).at(age)++;
+                if (disease_state.start_time == context.time_now()) {
+                    series(gender, "incidence_" + disease_name.to_string()).at(age)++;
+                }
             }
         }
 
@@ -375,7 +378,8 @@ void AnalysisModule::initialise_output_channels(RuntimeContext &context) {
     }
 
     for (const auto &disease : context.diseases()) {
-        channels_.emplace_back(disease.code.to_string());
+        channels_.emplace_back("prevalence_" + disease.code.to_string());
+        channels_.emplace_back("incidence_" + disease.code.to_string());
     }
 
     channels_.emplace_back("disability_weight");

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -91,7 +91,7 @@ AnalysisModule::calculate_residual_disability_weight(int age, const core::Gender
 void AnalysisModule::publish_result_message(RuntimeContext &context) const {
     auto sample_size = context.age_range().upper() + 1u;
     auto result = ModelResult{sample_size};
-    auto handle = core::run_async(&hgps::AnalysisModule::calculate_historical_statistics, this,
+    auto handle = core::run_async(&AnalysisModule::calculate_historical_statistics, this,
                                   std::ref(context), std::ref(result));
 
     calculate_population_statistics(context, result.series);
@@ -127,8 +127,8 @@ void AnalysisModule::calculate_historical_statistics(RuntimeContext &context,
     auto analysis_time = static_cast<unsigned int>(context.time_now());
 
     auto daly_handle =
-        core::run_async(&hgps::AnalysisModule::calculate_dalys, this,
-                        std::ref(context.population()), age_upper_bound, analysis_time);
+        core::run_async(&AnalysisModule::calculate_dalys, this, std::ref(context.population()),
+                        age_upper_bound, analysis_time);
 
     auto population_size = static_cast<int>(context.population().size());
     auto population_dead = 0;
@@ -261,8 +261,8 @@ DALYsIndicator AnalysisModule::calculate_dalys(Population &population, unsigned 
 }
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
-void hgps::AnalysisModule::calculate_population_statistics(RuntimeContext &context,
-                                                           DataSeries &series) const {
+void AnalysisModule::calculate_population_statistics(RuntimeContext &context,
+                                                     DataSeries &series) const {
     using namespace core;
 
     auto min_age = context.age_range().lower();
@@ -346,17 +346,17 @@ void hgps::AnalysisModule::calculate_population_statistics(RuntimeContext &conte
 }
 // NOLINTEND(readability-function-cognitive-complexity)
 
-void AnalysisModule::classify_weight(hgps::DataSeries &series, const hgps::Person &entity) const {
+void AnalysisModule::classify_weight(DataSeries &series, const Person &entity) const {
     auto weight_class = weight_classifier_.classify_weight(entity);
     switch (weight_class) {
-    case hgps::WeightCategory::normal:
+    case WeightCategory::normal:
         series(entity.gender, "normal_weight").at(entity.age)++;
         break;
-    case hgps::WeightCategory::overweight:
+    case WeightCategory::overweight:
         series(entity.gender, "over_weight").at(entity.age)++;
         series(entity.gender, "above_weight").at(entity.age)++;
         break;
-    case hgps::WeightCategory::obese:
+    case WeightCategory::obese:
         series(entity.gender, "obese_weight").at(entity.age)++;
         series(entity.gender, "above_weight").at(entity.age)++;
         break;

--- a/src/HealthGPS/default_cancer_model.cpp
+++ b/src/HealthGPS/default_cancer_model.cpp
@@ -23,23 +23,27 @@ const core::Identifier &DefaultCancerModel::disease_type() const noexcept {
 }
 
 void DefaultCancerModel::initialise_disease_status(RuntimeContext &context) {
+    int prevalence_id = definition_.get().table().at(MeasureKey::prevalence);
+
     auto relative_risk_table = calculate_average_relative_risk(context);
-    auto prevalence_id = definition_.get().table().at(MeasureKey::prevalence);
-    for (auto &entity : context.population()) {
-        if (!entity.is_active() || !definition_.get().table().contains(entity.age)) {
+    for (auto &person : context.population()) {
+        if (!person.is_active() || !definition_.get().table().contains(person.age)) {
             continue;
         }
 
-        auto relative_risk_value = calculate_relative_risk_for_risk_factors(entity);
-        auto average_relative_risk = relative_risk_table(entity.age, entity.gender);
-        auto prevalence = definition_.get().table()(entity.age, entity.gender).at(prevalence_id);
-        auto probability = prevalence * relative_risk_value / average_relative_risk;
-        auto hazard = context.random().next_double();
+        double relative_risk = 1.0;
+        relative_risk *= calculate_relative_risk_for_risk_factors(person);
+
+        double average_relative_risk = relative_risk_table(person.age, person.gender);
+
+        double prevalence = definition_.get().table()(person.age, person.gender).at(prevalence_id);
+        double probability = prevalence * relative_risk / average_relative_risk;
+        double hazard = context.random().next_double();
         if (hazard < probability) {
-            auto onset = calculate_time_since_onset(context, entity.gender);
-            entity.diseases[disease_type()] = Disease{.status = DiseaseStatus::active,
-                                                      .start_time = context.time_now(),
-                                                      .time_since_onset = onset};
+            int time_since_onset = calculate_time_since_onset(context, person.gender);
+            person.diseases[disease_type()] = Disease{.status = DiseaseStatus::active,
+                                                      .start_time = (context.time_now() - 1),
+                                                      .time_since_onset = time_since_onset};
         }
     }
 }
@@ -50,19 +54,21 @@ void DefaultCancerModel::initialise_average_relative_risk(RuntimeContext &contex
     auto count = create_age_gender_table<double>(age_range);
     auto &pop = context.population();
     auto sum_mutex = std::mutex{};
-    std::for_each(core::execution_policy, pop.cbegin(), pop.cend(), [&](const auto &entity) {
-        if (!entity.is_active()) {
+    std::for_each(core::execution_policy, pop.cbegin(), pop.cend(), [&](const auto &person) {
+        if (!person.is_active()) {
             return;
         }
 
-        auto combine_risk =
-            calculate_combined_relative_risk(entity, context.start_time(), context.time_now());
+        double relative_risk = 1.0;
+        relative_risk *= calculate_relative_risk_for_risk_factors(person);
+        relative_risk *= calculate_relative_risk_for_diseases(person);
+
         auto lock = std::unique_lock{sum_mutex};
-        sum(entity.age, entity.gender) += combine_risk;
-        count(entity.age, entity.gender)++;
+        sum(person.age, person.gender) += relative_risk;
+        count(person.age, person.gender)++;
     });
 
-    auto default_average = 1.0;
+    double default_average = 1.0;
     for (int age = age_range.lower(); age <= age_range.upper(); age++) {
         auto male_average = default_average;
         auto female_average = default_average;
@@ -89,22 +95,22 @@ void DefaultCancerModel::update_disease_status(RuntimeContext &context) {
     update_incidence_cases(context);
 }
 
-double DefaultCancerModel::get_excess_mortality(const Person &entity) const noexcept {
-    const auto &disease_info = entity.diseases.at(disease_type());
+double DefaultCancerModel::get_excess_mortality(const Person &person) const noexcept {
+    int mortality_id = definition_.get().table().at(MeasureKey::mortality);
+
+    const auto &disease_info = person.diseases.at(disease_type());
     auto max_onset = definition_.get().parameters().max_time_since_onset;
     if (disease_info.time_since_onset < 0 || disease_info.time_since_onset >= max_onset) {
         return 0.0;
     }
 
-    auto mortality_id = definition_.get().table().at(MeasureKey::mortality);
-    auto excess_mortality = definition_.get().table()(entity.age, entity.gender).at(mortality_id);
-    const auto &death_weight =
+    double excess_mortality = definition_.get().table()(person.age, person.gender).at(mortality_id);
+    const auto &sex_death_weights =
         definition_.get().parameters().death_weight.at(disease_info.time_since_onset);
-    if (entity.gender == core::Gender::male) {
-        return excess_mortality * death_weight.males;
-    }
+    double death_weight =
+        (person.gender == core::Gender::male) ? sex_death_weights.males : sex_death_weights.females;
 
-    return excess_mortality * death_weight.females;
+    return excess_mortality * death_weight;
 }
 
 DoubleAgeGenderTable DefaultCancerModel::calculate_average_relative_risk(RuntimeContext &context) {
@@ -113,18 +119,20 @@ DoubleAgeGenderTable DefaultCancerModel::calculate_average_relative_risk(Runtime
     auto count = create_age_gender_table<double>(age_range);
     auto &pop = context.population();
     auto sum_mutex = std::mutex{};
-    std::for_each(core::execution_policy, pop.cbegin(), pop.cend(), [&](const auto &entity) {
-        if (!entity.is_active()) {
+    std::for_each(core::execution_policy, pop.cbegin(), pop.cend(), [&](const auto &person) {
+        if (!person.is_active()) {
             return;
         }
 
-        auto combine_risk = calculate_relative_risk_for_risk_factors(entity);
+        double relative_risk = 1.0;
+        relative_risk *= calculate_relative_risk_for_risk_factors(person);
+
         auto lock = std::unique_lock{sum_mutex};
-        sum(entity.age, entity.gender) += combine_risk;
-        count(entity.age, entity.gender)++;
+        sum(person.age, person.gender) += relative_risk;
+        count(person.age, person.gender)++;
     });
 
-    auto default_average = 1.0;
+    double default_average = 1.0;
     auto result = create_age_gender_table<double>(age_range);
     for (int age = age_range.lower(); age <= age_range.upper(); age++) {
         auto male_average = default_average;
@@ -148,117 +156,105 @@ DoubleAgeGenderTable DefaultCancerModel::calculate_average_relative_risk(Runtime
     return result;
 }
 
-double DefaultCancerModel::calculate_combined_relative_risk(const Person &entity, int start_time,
-                                                            int time_now) const {
-    auto combined_risk_value = 1.0;
-    combined_risk_value *= calculate_relative_risk_for_risk_factors(entity);
-    combined_risk_value *= calculate_relative_risk_for_diseases(entity, start_time, time_now);
-    return combined_risk_value;
-}
+double DefaultCancerModel::calculate_relative_risk_for_risk_factors(const Person &person) const {
+    const auto &relative_risk_tables = definition_.get().relative_risk_factors();
 
-double DefaultCancerModel::calculate_relative_risk_for_risk_factors(const Person &entity) const {
-    auto relative_risk_value = 1.0;
-    const auto &relative_factors = definition_.get().relative_risk_factors();
-    for (const auto &factor : entity.risk_factors) {
-        if (!relative_factors.contains(factor.first)) {
+    double relative_risk = 1.0;
+    for (const auto &[factor_name, factor_value] : person.risk_factors) {
+        if (!relative_risk_tables.contains(factor_name)) {
             continue;
         }
 
-        const auto &lut = relative_factors.at(factor.first).at(entity.gender);
-        auto factor_value =
-            weight_classifier_.adjust_risk_factor_value(entity, factor.first, factor.second);
-        auto lookup_value = static_cast<float>(factor_value);
-        auto relative_factor_value = lut(entity.age, lookup_value);
-        relative_risk_value *= relative_factor_value;
+        auto factor_value_adjusted = static_cast<float>(
+            weight_classifier_.adjust_risk_factor_value(person, factor_name, factor_value));
+
+        const auto &rr_table = relative_risk_tables.at(factor_name);
+        relative_risk *= rr_table.at(person.gender)(person.age, factor_value_adjusted);
     }
 
-    return relative_risk_value;
+    return relative_risk;
 }
 
-double DefaultCancerModel::calculate_relative_risk_for_diseases(const Person &entity,
-                                                                int start_time,
-                                                                int time_now) const {
-    auto relative_risk_value = 1.0;
-    const auto &lut = definition_.get().relative_risk_diseases();
-    for (const auto &disease : entity.diseases) {
-        if (!lut.contains(disease.first)) {
+double DefaultCancerModel::calculate_relative_risk_for_diseases(const Person &person) const {
+    const auto &relative_risk_tables = definition_.get().relative_risk_diseases();
+
+    double relative_risk = 1.0;
+    for (const auto &[disease_name, disease_state] : person.diseases) {
+        if (!relative_risk_tables.contains(disease_name)) {
             continue;
         }
 
         // Only include existing diseases
-        if (disease.second.status == DiseaseStatus::active &&
-            (start_time == time_now || disease.second.start_time < time_now)) {
-            auto relative_disease_vale = lut.at(disease.first)(entity.age, entity.gender);
-
-            relative_risk_value *= relative_disease_vale;
+        if (disease_state.status == DiseaseStatus::active) {
+            const auto &rr_table = relative_risk_tables.at(disease_name);
+            relative_risk *= rr_table(person.age, person.gender);
         }
     }
 
-    return relative_risk_value;
+    return relative_risk;
 }
 
 void DefaultCancerModel::update_remission_cases(RuntimeContext &context) {
-    auto max_onset = definition_.get().parameters().max_time_since_onset;
-    auto &pop = context.population();
-    std::for_each(core::execution_policy, pop.begin(), pop.end(), [&](auto &entity) {
-        if (entity.age == 0 || !entity.is_active()) {
-            return;
+    int max_onset = definition_.get().parameters().max_time_since_onset;
+
+    for (auto &person : context.population()) {
+        // Skip if person is inactive or newborn.
+        if (!person.is_active() || person.age == 0) {
+            continue;
         }
 
-        if (!entity.diseases.contains(disease_type()) ||
-            entity.diseases.at(disease_type()).status != DiseaseStatus::active) {
-            return;
+        // Skip if person does not have the disease.
+        if (!person.diseases.contains(disease_type()) ||
+            person.diseases.at(disease_type()).status != DiseaseStatus::active) {
+            continue;
         }
 
         // Increment duration by one year
-        auto &disease = entity.diseases.at(disease_type());
+        auto &disease = person.diseases.at(disease_type());
         disease.time_since_onset++;
         if (disease.time_since_onset >= max_onset) {
             disease.status = DiseaseStatus::free;
             disease.time_since_onset = -1;
         }
-    });
+    }
 }
 
 void DefaultCancerModel::update_incidence_cases(RuntimeContext &context) {
-    for (auto &entity : context.population()) {
-        if (!entity.is_active()) {
+    int incidence_id = definition_.get().table().at(MeasureKey::incidence);
+
+    for (auto &person : context.population()) {
+        // Skip if person is inactive.
+        if (!person.is_active()) {
             continue;
         }
 
-        if (entity.age == 0) {
-            if (!entity.diseases.empty()) {
-                entity.diseases.clear(); // Should not have nay disease at birth!
-            }
-
+        // Clear newborn diseases.
+        if (person.age == 0) {
+            person.diseases.clear();
             continue;
         }
 
-        // Already have disease
-        if (entity.diseases.contains(disease_type()) &&
-            entity.diseases.at(disease_type()).status == DiseaseStatus::active) {
+        // Skip if the person already has the disease.
+        if (person.diseases.contains(disease_type()) &&
+            person.diseases.at(disease_type()).status == DiseaseStatus::active) {
             continue;
         }
 
-        auto probability =
-            calculate_incidence_probability(entity, context.start_time(), context.time_now());
-        auto hazard = context.random().next_double();
+        double relative_risk = 1.0;
+        relative_risk *= calculate_relative_risk_for_risk_factors(person);
+        relative_risk *= calculate_relative_risk_for_diseases(person);
+
+        double average_relative_risk = average_relative_risk_.at(person.age, person.gender);
+
+        double incidence = definition_.get().table()(person.age, person.gender).at(incidence_id);
+        double probability = incidence * relative_risk / average_relative_risk;
+        double hazard = context.random().next_double();
         if (hazard < probability) {
-            entity.diseases[disease_type()] = Disease{.status = DiseaseStatus::active,
+            person.diseases[disease_type()] = Disease{.status = DiseaseStatus::active,
                                                       .start_time = context.time_now(),
                                                       .time_since_onset = 0};
         }
     }
-}
-
-double DefaultCancerModel::calculate_incidence_probability(const Person &entity, int start_time,
-                                                           int time_now) const {
-    auto incidence_id = definition_.get().table().at(MeasureKey::incidence);
-    auto combined_relative_risk = calculate_combined_relative_risk(entity, start_time, time_now);
-    auto average_relative_risk = average_relative_risk_.at(entity.age, entity.gender);
-    auto incidence = definition_.get().table()(entity.age, entity.gender).at(incidence_id);
-    auto probability = incidence * combined_relative_risk / average_relative_risk;
-    return probability;
 }
 
 int DefaultCancerModel::calculate_time_since_onset(RuntimeContext &context,
@@ -267,12 +263,9 @@ int DefaultCancerModel::calculate_time_since_onset(RuntimeContext &context,
     const auto &pdf = definition_.get().parameters().prevalence_distribution;
     auto values = std::vector<int>{};
     auto cumulative = std::vector<double>{};
-    auto sum = 0.0;
+    double sum = 0.0;
     for (const auto &item : pdf) {
-        auto p = item.second.males;
-        if (gender != core::Gender::male) {
-            p = item.second.females;
-        }
+        double p = (gender == core::Gender::male) ? item.second.males : item.second.females;
 
         sum += p;
         values.emplace_back(item.first);
@@ -281,4 +274,5 @@ int DefaultCancerModel::calculate_time_since_onset(RuntimeContext &context,
 
     return context.random().next_empirical_discrete(values, cumulative);
 }
+
 } // namespace hgps

--- a/src/HealthGPS/default_cancer_model.cpp
+++ b/src/HealthGPS/default_cancer_model.cpp
@@ -42,7 +42,7 @@ void DefaultCancerModel::initialise_disease_status(RuntimeContext &context) {
         if (hazard < probability) {
             int time_since_onset = calculate_time_since_onset(context, person.gender);
             person.diseases[disease_type()] = Disease{.status = DiseaseStatus::active,
-                                                      .start_time = (context.time_now() - 1),
+                                                      .start_time = 0,
                                                       .time_since_onset = time_since_onset};
         }
     }

--- a/src/HealthGPS/default_cancer_model.cpp
+++ b/src/HealthGPS/default_cancer_model.cpp
@@ -14,9 +14,7 @@ DefaultCancerModel::DefaultCancerModel(DiseaseDefinition &definition, WeightMode
     }
 }
 
-core::DiseaseGroup DefaultCancerModel::group() const noexcept {
-    return definition_.get().identifier().group;
-}
+core::DiseaseGroup DefaultCancerModel::group() const noexcept { return core::DiseaseGroup::cancer; }
 
 const core::Identifier &DefaultCancerModel::disease_type() const noexcept {
     return definition_.get().identifier().code;
@@ -41,6 +39,7 @@ void DefaultCancerModel::initialise_disease_status(RuntimeContext &context) {
         double hazard = context.random().next_double();
         if (hazard < probability) {
             int time_since_onset = calculate_time_since_onset(context, person.gender);
+            // start_time = 0 means the disease existed before the simulation started.
             person.diseases[disease_type()] = Disease{.status = DiseaseStatus::active,
                                                       .start_time = 0,
                                                       .time_since_onset = time_since_onset};

--- a/src/HealthGPS/default_cancer_model.h
+++ b/src/HealthGPS/default_cancer_model.h
@@ -28,7 +28,7 @@ class DefaultCancerModel final : public DiseaseModel {
 
     void update_disease_status(RuntimeContext &context) override;
 
-    double get_excess_mortality(const Person &entity) const noexcept override;
+    double get_excess_mortality(const Person &person) const noexcept override;
 
   private:
     std::reference_wrapper<DiseaseDefinition> definition_;
@@ -36,16 +36,16 @@ class DefaultCancerModel final : public DiseaseModel {
     DoubleAgeGenderTable average_relative_risk_;
 
     DoubleAgeGenderTable calculate_average_relative_risk(RuntimeContext &context);
-    double calculate_combined_relative_risk(const Person &entity, int start_time,
-                                            int time_now) const;
-    double calculate_relative_risk_for_diseases(const Person &entity, int start_time,
-                                                int time_now) const;
-    double calculate_relative_risk_for_risk_factors(const Person &entity) const;
-    double calculate_incidence_probability(const Person &entity, int start_time,
-                                           int time_now) const;
+
+    double calculate_relative_risk_for_diseases(const Person &person) const;
+
+    double calculate_relative_risk_for_risk_factors(const Person &person) const;
 
     void update_remission_cases(RuntimeContext &context);
+
     void update_incidence_cases(RuntimeContext &context);
+
     int calculate_time_since_onset(RuntimeContext &context, const core::Gender &gender) const;
 };
+
 } // namespace hgps

--- a/src/HealthGPS/default_cancer_model.h
+++ b/src/HealthGPS/default_cancer_model.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include "disease_definition.h"
 #include "gender_table.h"
 #include "interfaces.h"
@@ -18,16 +19,39 @@ class DefaultCancerModel final : public DiseaseModel {
     DefaultCancerModel(DiseaseDefinition &definition, WeightModel &&classifier,
                        const core::IntegerInterval &age_range);
 
+    /// @brief Returns the disease group type (cancer).
+    /// @return The disease group type (cancer).
     core::DiseaseGroup group() const noexcept override;
 
+    /// @brief Returns the cancer type identifier.
+    /// @return The cancer type identifier
     const core::Identifier &disease_type() const noexcept override;
 
+    /// @brief Initialises the cancer status of the population (from prevalence).
+    /// Cancer start_time = 0 disambiguates from incidence cases on start year.
+    /// Must be followed by:
+    ///   * initialise_average_relative_risk (used to preserve distribution)
+    ///   * update_disease_status (to simulate incidence cases on start year)
+    /// @param context The runtime context instance
     void initialise_disease_status(RuntimeContext &context) override;
 
+    /// @brief Initialise average relative risk for cancer model on start year.
+    /// The average relative risks from risk factors and diseases on start year
+    /// is used to normalise the relative risks for an indivudual at a given time
+    /// To preserve the distribution of this cancer as the simulation prorgesses.
+    /// @param context The runtime context instance
     void initialise_average_relative_risk(RuntimeContext &context) override;
 
+    /// @brief Simulates cancer remission and incidence cases of the population.
+    /// For each year, this method calls the following methods in ordrer:
+    ////  * update_remission_cases
+    ////  * update_incidence_cases
+    /// @param context The runtime context instance
     void update_disease_status(RuntimeContext &context) override;
 
+    /// @brief Returns the excess mortality for a given person's age and sex.
+    /// @param person The person instance to calculate the excess mortality
+    /// @return The excess mortality for a given person's age and sex
     double get_excess_mortality(const Person &person) const noexcept override;
 
   private:
@@ -35,16 +59,42 @@ class DefaultCancerModel final : public DiseaseModel {
     WeightModel weight_classifier_;
     DoubleAgeGenderTable average_relative_risk_;
 
+    /// @brief Initialise average relative risk for cancer model on start year.
+    /// This method is similar to initialise_average_relative_risk, and used internally
+    /// by initialise_disease_status.
+    ///
+    /// Since disease status is not yet initialised, this method only considers
+    /// relative risk from risk factors. We can eventualy bootstrap the final average
+    /// relative risk once initialise_disease_status has finished initialising by calling
+    /// the initialise_average_relative_risk method.
+    /// @param context The runtime context instance
     DoubleAgeGenderTable calculate_average_relative_risk(RuntimeContext &context);
 
+    /// @brief Caculates the relative risk for this cancer given other diseases.
+    /// @param person The person to calculate the relative risk
+    /// @return The relative risk for this cancer given other diseases
     double calculate_relative_risk_for_diseases(const Person &person) const;
 
+    /// @brief Caculates the relative risk for this cancer given risk factors.
+    /// @param person The person to calculate the relative risk
+    /// @return The relative risk for this cancer given risk factors
     double calculate_relative_risk_for_risk_factors(const Person &person) const;
 
+    /// @brief Simulates the remission cases of the population for this cancer.
+    /// Each person may be freed from this cancer status based on time since onset.
+    /// @param context The runtime context instance
     void update_remission_cases(RuntimeContext &context);
 
+    /// @brief Simulates the incidence cases of the population for this cancer.
+    /// Each person may be affected by this cancer status based on incidence probability
+    /// and relative risks from their risk risk factors and other diseases.
+    /// @param context The runtime context instance
     void update_incidence_cases(RuntimeContext &context);
 
+    /// @brief Generates a random time since onset during initialisation.
+    /// @param context The runtime context instance
+    /// @param gender The person's sex
+    /// @return the time since cancer onset
     int calculate_time_since_onset(RuntimeContext &context, const core::Gender &gender) const;
 };
 

--- a/src/HealthGPS/default_disease_model.cpp
+++ b/src/HealthGPS/default_disease_model.cpp
@@ -155,8 +155,8 @@ double DefaultDiseaseModel::calculate_relative_risk_for_risk_factors(const Perso
             continue;
         }
 
-        auto factor_value_adjusted =
-            weight_classifier_.adjust_risk_factor_value(person, factor_name, factor_value);
+        float factor_value_adjusted = static_cast<float>(
+            weight_classifier_.adjust_risk_factor_value(person, factor_name, factor_value));
 
         const auto &rr_table = relative_risk_tables.at(factor_name);
         relative_risk *= rr_table.at(person.gender)(person.age, factor_value_adjusted);

--- a/src/HealthGPS/default_disease_model.cpp
+++ b/src/HealthGPS/default_disease_model.cpp
@@ -41,7 +41,7 @@ void DefaultDiseaseModel::initialise_disease_status(RuntimeContext &context) {
         double hazard = context.random().next_double();
         if (hazard < probability) {
             person.diseases[disease_type()] =
-                Disease{.status = DiseaseStatus::active, .start_time = (context.time_now() - 1)};
+                Disease{.status = DiseaseStatus::active, .start_time = 0};
         }
     }
 }

--- a/src/HealthGPS/default_disease_model.cpp
+++ b/src/HealthGPS/default_disease_model.cpp
@@ -188,10 +188,12 @@ double DefaultDiseaseModel::calculate_relative_risk_for_diseases(const Person &p
 void DefaultDiseaseModel::update_remission_cases(RuntimeContext &context) {
     auto remission_id = definition_.get().table().at(MeasureKey::remission);
     for (auto &person : context.population()) {
-        if (person.age == 0 || !person.is_active()) {
+        // Skip if person is inactive or newborn.
+        if (!person.is_active() || person.age == 0) {
             continue;
         }
 
+        // Skip if person does not have the disease.
         if (!person.diseases.contains(disease_type()) ||
             person.diseases.at(disease_type()).status != DiseaseStatus::active) {
             continue;
@@ -207,19 +209,18 @@ void DefaultDiseaseModel::update_remission_cases(RuntimeContext &context) {
 
 void DefaultDiseaseModel::update_incidence_cases(RuntimeContext &context) {
     for (auto &person : context.population()) {
+        // Skip if person is inactive.
         if (!person.is_active()) {
             continue;
         }
 
+        // Clear newborn diseases.
         if (person.age == 0) {
-            if (!person.diseases.empty()) {
-                person.diseases.clear(); // Should not have nay disease at birth!
-            }
-
+            person.diseases.clear();
             continue;
         }
 
-        // Already have disease
+        // Skip if the person already has the disease.
         if (person.diseases.contains(disease_type()) &&
             person.diseases.at(disease_type()).status == DiseaseStatus::active) {
             continue;

--- a/src/HealthGPS/default_disease_model.cpp
+++ b/src/HealthGPS/default_disease_model.cpp
@@ -155,7 +155,7 @@ double DefaultDiseaseModel::calculate_relative_risk_for_risk_factors(const Perso
             continue;
         }
 
-        float factor_value_adjusted = static_cast<float>(
+        auto factor_value_adjusted = static_cast<float>(
             weight_classifier_.adjust_risk_factor_value(person, factor_name, factor_value));
 
         const auto &rr_table = relative_risk_tables.at(factor_name);

--- a/src/HealthGPS/default_disease_model.cpp
+++ b/src/HealthGPS/default_disease_model.cpp
@@ -14,9 +14,7 @@ DefaultDiseaseModel::DefaultDiseaseModel(DiseaseDefinition &definition, WeightMo
     }
 }
 
-core::DiseaseGroup DefaultDiseaseModel::group() const noexcept {
-    return definition_.get().identifier().group;
-}
+core::DiseaseGroup DefaultDiseaseModel::group() const noexcept { return core::DiseaseGroup::other; }
 
 const core::Identifier &DefaultDiseaseModel::disease_type() const noexcept {
     return definition_.get().identifier().code;
@@ -40,6 +38,7 @@ void DefaultDiseaseModel::initialise_disease_status(RuntimeContext &context) {
         double probability = prevalence * relative_risk / average_relative_risk;
         double hazard = context.random().next_double();
         if (hazard < probability) {
+            // start_time = 0 means the disease existed before the simulation started.
             person.diseases[disease_type()] =
                 Disease{.status = DiseaseStatus::active, .start_time = 0};
         }

--- a/src/HealthGPS/default_disease_model.cpp
+++ b/src/HealthGPS/default_disease_model.cpp
@@ -41,7 +41,7 @@ void DefaultDiseaseModel::initialise_disease_status(RuntimeContext &context) {
         double hazard = context.random().next_double();
         if (hazard < probability) {
             person.diseases[disease_type()] =
-                Disease{.status = DiseaseStatus::active, .start_time = context.time_now()};
+                Disease{.status = DiseaseStatus::active, .start_time = (context.time_now() - 1)};
         }
     }
 }

--- a/src/HealthGPS/default_disease_model.h
+++ b/src/HealthGPS/default_disease_model.h
@@ -5,6 +5,7 @@
 #include "weight_model.h"
 
 namespace hgps {
+
 /// @brief Defines the standard diseases (non-cancer) model data type.
 class DefaultDiseaseModel final : public DiseaseModel {
   public:
@@ -27,7 +28,7 @@ class DefaultDiseaseModel final : public DiseaseModel {
 
     void update_disease_status(RuntimeContext &context) override;
 
-    double get_excess_mortality(const Person &entity) const noexcept override;
+    double get_excess_mortality(const Person &person) const noexcept override;
 
   private:
     std::reference_wrapper<DiseaseDefinition> definition_;
@@ -35,15 +36,16 @@ class DefaultDiseaseModel final : public DiseaseModel {
     DoubleAgeGenderTable average_relative_risk_;
 
     DoubleAgeGenderTable calculate_average_relative_risk(RuntimeContext &context);
-    double calculate_combined_relative_risk(const Person &entity, int start_time,
+    double calculate_combined_relative_risk(const Person &person, int start_time,
                                             int time_now) const;
-    double calculate_relative_risk_for_diseases(const Person &entity, int start_time,
+    double calculate_relative_risk_for_diseases(const Person &person, int start_time,
                                                 int time_now) const;
-    double calculate_relative_risk_for_risk_factors(const Person &entity) const;
-    double calculate_incidence_probability(const Person &entity, int start_time,
+    double calculate_relative_risk_for_risk_factors(const Person &person) const;
+    double calculate_incidence_probability(const Person &person, int start_time,
                                            int time_now) const;
 
     void update_remission_cases(RuntimeContext &context);
     void update_incidence_cases(RuntimeContext &context);
 };
+
 } // namespace hgps

--- a/src/HealthGPS/default_disease_model.h
+++ b/src/HealthGPS/default_disease_model.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include "disease_definition.h"
 #include "gender_table.h"
 #include "interfaces.h"
@@ -18,16 +19,39 @@ class DefaultDiseaseModel final : public DiseaseModel {
     DefaultDiseaseModel(DiseaseDefinition &definition, WeightModel &&classifier,
                         const core::IntegerInterval &age_range);
 
+    /// @brief Returns the disease group type (other).
+    /// @return The disease group type (other).
     core::DiseaseGroup group() const noexcept override;
 
+    /// @brief Returns the disease type identifier.
+    /// @return The disease type identifier
     const core::Identifier &disease_type() const noexcept override;
 
+    /// @brief Initialises the disease status of the population (from prevalence).
+    /// Disease start_time = 0 disambiguates from incidence cases on start year.
+    /// Must be followed by:
+    ///   * initialise_average_relative_risk (used to preserve distribution)
+    ///   * update_disease_status (to simulate incidence cases on start year)
+    /// @param context The runtime context instance
     void initialise_disease_status(RuntimeContext &context) override;
 
+    /// @brief Initialise average relative risk for disease model on start year.
+    /// The average relative risks from risk factors and diseases on start year
+    /// is used to normalise the relative risks for an indivudual at a given time
+    /// To preserve the distribution of this disease as the simulation prorgesses.
+    /// @param context The runtime context instance
     void initialise_average_relative_risk(RuntimeContext &context) override;
 
+    /// @brief Simulates disease remission and incidence cases of the population.
+    /// For each year, this method calls the following methods in ordrer:
+    ////  * update_remission_cases
+    ////  * update_incidence_cases
+    /// @param context The runtime context instance
     void update_disease_status(RuntimeContext &context) override;
 
+    /// @brief Returns the excess mortality for a given person's age and sex.
+    /// @param person The person instance to calculate the excess mortality
+    /// @return The excess mortality for a given person's age and sex
     double get_excess_mortality(const Person &person) const noexcept override;
 
   private:
@@ -35,14 +59,36 @@ class DefaultDiseaseModel final : public DiseaseModel {
     WeightModel weight_classifier_;
     DoubleAgeGenderTable average_relative_risk_;
 
+    /// @brief Initialise average relative risk for disease model on start year.
+    /// This method is similar to initialise_average_relative_risk, and used internally
+    /// by initialise_disease_status.
+    ///
+    /// Since disease status is not yet initialised, this method only considers
+    /// relative risk from risk factors. We can eventualy bootstrap the final average
+    /// relative risk once initialise_disease_status has finished initialising by calling
+    /// the initialise_average_relative_risk method.
+    /// @param context The runtime context instance
     DoubleAgeGenderTable calculate_average_relative_risk(RuntimeContext &context);
 
+    /// @brief Caculates the relative risk for this disease given other diseases.
+    /// @param person The person to calculate the relative risk
+    /// @return The relative risk for this disease given other diseases
     double calculate_relative_risk_for_diseases(const Person &person) const;
 
+    /// @brief Caculates the relative risk for this disease given risk factors.
+    /// @param person The person to calculate the relative risk
+    /// @return The relative risk for this disease given risk factors
     double calculate_relative_risk_for_risk_factors(const Person &person) const;
 
+    /// @brief Simulates the remission cases of the population for this disease.
+    /// Each person may be freed from this disease status based on remission probability.
+    /// @param context The runtime context instance
     void update_remission_cases(RuntimeContext &context);
 
+    /// @brief Simulates the incidence cases of the population for this disease.
+    /// Each person may be affected by this disease status based on incidence probability
+    /// and relative risks from their risk risk factors and other diseases.
+    /// @param context The runtime context instance
     void update_incidence_cases(RuntimeContext &context);
 };
 

--- a/src/HealthGPS/default_disease_model.h
+++ b/src/HealthGPS/default_disease_model.h
@@ -36,15 +36,17 @@ class DefaultDiseaseModel final : public DiseaseModel {
     DoubleAgeGenderTable average_relative_risk_;
 
     DoubleAgeGenderTable calculate_average_relative_risk(RuntimeContext &context);
+
     double calculate_combined_relative_risk(const Person &person, int start_time,
                                             int time_now) const;
+
     double calculate_relative_risk_for_diseases(const Person &person, int start_time,
                                                 int time_now) const;
+
     double calculate_relative_risk_for_risk_factors(const Person &person) const;
-    double calculate_incidence_probability(const Person &person, int start_time,
-                                           int time_now) const;
 
     void update_remission_cases(RuntimeContext &context);
+
     void update_incidence_cases(RuntimeContext &context);
 };
 

--- a/src/HealthGPS/default_disease_model.h
+++ b/src/HealthGPS/default_disease_model.h
@@ -37,11 +37,7 @@ class DefaultDiseaseModel final : public DiseaseModel {
 
     DoubleAgeGenderTable calculate_average_relative_risk(RuntimeContext &context);
 
-    double calculate_combined_relative_risk(const Person &person, int start_time,
-                                            int time_now) const;
-
-    double calculate_relative_risk_for_diseases(const Person &person, int start_time,
-                                                int time_now) const;
+    double calculate_relative_risk_for_diseases(const Person &person) const;
 
     double calculate_relative_risk_for_risk_factors(const Person &person) const;
 

--- a/src/HealthGPS/disease.cpp
+++ b/src/HealthGPS/disease.cpp
@@ -37,6 +37,11 @@ void DiseaseModule::initialise_population(RuntimeContext &context) {
     for (auto &model : models_) {
         model.second->initialise_average_relative_risk(context);
     }
+
+    // Do a 'dry run' to get simulated incidence.
+    for (auto &model : models_) {
+        model.second->update_disease_status(context);
+    }
 }
 
 void DiseaseModule::update_population(RuntimeContext &context) {

--- a/src/HealthGPS/disease.cpp
+++ b/src/HealthGPS/disease.cpp
@@ -29,6 +29,7 @@ DiseaseModule::operator[](const core::Identifier &disease_id) const {
 }
 
 void DiseaseModule::initialise_population(RuntimeContext &context) {
+    // Initialise disease status based on prevalence
     for (auto &model : models_) {
         model.second->initialise_disease_status(context);
     }
@@ -38,7 +39,7 @@ void DiseaseModule::initialise_population(RuntimeContext &context) {
         model.second->initialise_average_relative_risk(context);
     }
 
-    // Do a 'dry run' to get simulated incidence.
+    // After initialising with prevalence, do a 'dry run' to simulate incidence.
     for (auto &model : models_) {
         model.second->update_disease_status(context);
     }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,9 +1,12 @@
 {
-    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
-    "name": "cpp20-study",
-    "version": "0.1.0",
+    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+    "name": "healthgps",
+    "version": "1.2.2.0",
     "dependencies": [
-        "fmt",
+        {
+            "name": "fmt",
+            "version>=": "10.2.1"
+        },
         "cxxopts",
         "eigen3",
         "nlohmann-json",


### PR DESCRIPTION
Fixes #325.

This PR allows HGPS to output disease incidence (in addition to prevalence) for an age/sex group in the output CSV file. Also the default disease module and analysis module code is cleaned up a little.

Incidence is calculated as
```
Incidence = (New Cases) / (Population x Timeframe)
```
with `Timeframe = 1`. 

Since disease updates are computed in the disease module, and output means generated in the analysis module, formerly there was no way for the analysis module to compute on only new diseases. The approach taken in the new analysis code is to compare current time with disease onset, and increment a disease incidence counter if they match. 

An issue was that disease *initialisation* method applied diseases as a function of `prevalence` (higher), instead of being a function of `incidence` (lower) as in the *update* method, so the above approach would overestimate disease incidence on the first simulated year. To work around this, the initialisation method now does an additional 'dry run' step, with further disease status remissions (using probability `remission`) and incidences (using the correct probability `incidence`).

In the initialise method, the diseases allocated using `prevalence` are disambiguated from the dry run allocations using `incidence`, so the analysis module's incidence code only considers the latter and ignores the former. This is done by assigning the onset date of `prevalence` cases to be `start_time - 1` and onset date of `incidence` cases o be `start_time`. Perhaps a more obvious way of disambiguating is to set `prevalence` case start dates to zero.
