### PR TITLE
TBB'ification of threading and tidy-up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,9 @@ if(MSVC)
     if(WARNINGS_AS_ERRORS)
         add_compile_options(/WX)
     endif()
+
+    # Suppress warnings about std::getenv
+    add_compile_definitions(-D_CRT_SECURE_NO_WARNINGS)
 else()
     add_compile_options(-Wall -Wextra -Wpedantic)
 

--- a/src/HealthGPS.Console/event_monitor.h
+++ b/src/HealthGPS.Console/event_monitor.h
@@ -2,6 +2,7 @@
 #include <thread>
 
 #include <oneapi/tbb/concurrent_queue.h>
+#include <oneapi/tbb/task_group.h>
 
 #include "HealthGPS/event_aggregator.h"
 
@@ -34,17 +35,17 @@ class EventMonitor final : public hgps::EventMessageVisitor {
 
   private:
     ResultWriter &result_writer_;
-    std::vector<std::jthread> threads_;
+    tbb::task_group_context tg_context_;
+    tbb::task_group tg_;
     std::vector<std::unique_ptr<hgps::EventSubscriber>> handlers_;
     tbb::concurrent_queue<std::shared_ptr<hgps::EventMessage>> info_queue_;
     tbb::concurrent_queue<std::shared_ptr<hgps::EventMessage>> results_queue_;
-    std::stop_source cancel_source_;
 
     void info_event_handler(std::shared_ptr<hgps::EventMessage> message);
     void error_event_handler(const std::shared_ptr<hgps::EventMessage> &message);
     void result_event_handler(std::shared_ptr<hgps::EventMessage> message);
 
-    void info_dispatch_thread(const std::stop_token &token);
-    void result_dispatch_thread(const std::stop_token &token);
+    void info_dispatch_thread();
+    void result_dispatch_thread();
 };
 } // namespace host

--- a/src/HealthGPS.Console/program.cpp
+++ b/src/HealthGPS.Console/program.cpp
@@ -145,7 +145,6 @@ int main(int argc, char *argv[]) { // NOLINT(bugprone-exception-escape)
 
         // Create simulation engine for each scenario, baseline is always simulated.
         auto runtime = 0.0;
-        std::atomic<bool> done(false);
         fmt::print(fg(fmt::color::cyan), "\nStarting baseline simulation with {} trials ...\n\n",
                    config.trial_runs);
         auto baseline_sim = create_baseline_simulation(channel, factory, event_bus, model_input);
@@ -155,34 +154,11 @@ int main(int argc, char *argv[]) { // NOLINT(bugprone-exception-escape)
                        config.trial_runs);
             auto policy_sim = create_intervention_simulation(
                 channel, factory, event_bus, model_input, config.active_intervention.value());
-
-            // Run simulations side by side on a background thread
-            auto worker =
-                std::jthread{[&runtime, &executive, &baseline_sim, &policy_sim, &config, &done] {
-                    runtime = executive.run(baseline_sim, policy_sim, config.trial_runs);
-                    done.store(true);
-                }};
-
-            // Wait until done or error, before joining the thread
-            while (!done.load()) {
-                std::this_thread::sleep_for(std::chrono::microseconds(100));
-            }
-            worker.join();
+            runtime = executive.run(baseline_sim, policy_sim, config.trial_runs);
         } else {
             // Baseline only, close channel not store any message
             channel.close();
-
-            // Run simulation on a background thread
-            auto worker = std::jthread{[&runtime, &executive, &baseline_sim, &config, &done] {
-                runtime = executive.run(baseline_sim, config.trial_runs);
-                done.store(true);
-            }};
-
-            // Wait until done or error, before joining the thread
-            while (!done.load()) {
-                std::this_thread::sleep_for(std::chrono::microseconds(100));
-            }
-            worker.join();
+            runtime = executive.run(baseline_sim, config.trial_runs);
         }
 
         // Waits for messages queue to be processed before stopping events monitor

--- a/src/HealthGPS.Console/program.cpp
+++ b/src/HealthGPS.Console/program.cpp
@@ -162,7 +162,6 @@ int main(int argc, char *argv[]) { // NOLINT(bugprone-exception-escape)
         }
 
         // Waits for messages queue to be processed before stopping events monitor
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
         fmt::print(fg(fmt::color::light_green), "\nCompleted, elapsed time : {}ms\n\n", runtime);
         event_monitor.stop();
 

--- a/src/HealthGPS.Console/program.cpp
+++ b/src/HealthGPS.Console/program.cpp
@@ -27,7 +27,8 @@ void print_app_title() {
     fmt::print(fg(fmt::color::yellow) | fmt::emphasis::bold,
                "\n# Health-GPS Microsimulation for Policy Options #\n\n");
 
-    fmt::print("Today: {}\n\n", get_time_now_str());
+    fmt::print("Today: {}\nMaximum threads: {}\n\n", get_time_now_str(),
+               tbb::global_control::active_value(tbb::global_control::max_allowed_parallelism));
 }
 
 /// @brief Prints application exit message

--- a/src/HealthGPS.Console/program.cpp
+++ b/src/HealthGPS.Console/program.cpp
@@ -161,7 +161,6 @@ int main(int argc, char *argv[]) { // NOLINT(bugprone-exception-escape)
             runtime = executive.run(baseline_sim, config.trial_runs);
         }
 
-        // Waits for messages queue to be processed before stopping events monitor
         fmt::print(fg(fmt::color::light_green), "\nCompleted, elapsed time : {}ms\n\n", runtime);
         event_monitor.stop();
 


### PR DESCRIPTION
As discussed, we want to try to bring as many of the threads in Health-GPS under the control of TBB's task scheduler so that the maximum thread limit we impose on it will be respected program-wide.

To do this, I've changed `EventMonitor` to use a `tbb::task` group for the info and results threads, which previously ran on `std::jthread`s (which, oddly enough, were housed in a `std::vector`, despite there only ever being two of them). While I was at it, I noticed that the code was doing a lot of waiting around for messages to be received (using `std::this_thread::sleep_for`), which is likely to be inefficient, so I switched out the `tbb::concurrent_queue`s we were using for `tbb::concurrent_bounded_queue`s, which provide blocking methods.

I also removed the pointless additional thread that was being created to run the baseline simulation, so it just runs on the main thread.

These changes mean that on my 4-core Intel laptop there are now only 9 threads created by default (== 8 logical cores + 1) rather than 12, which is what it was before. I still don't know where that ninth thread is coming from -- maybe TBB creates 8 threads of its own and then the ninth one is just the main thread? In any case, it's an improvement and hopefully it'll stop @jzhu20's jobs from being killed.

Pleasingly, these changes also seem to bring a modest performance increase (>10%).

Previously on the `example_new` dataset it took:

```
________________________________________________________
Executed in  367.99 secs    fish           external
   usr time  773.88 secs    1.41 millis  773.88 secs
   sys time   22.55 secs    0.00 millis   22.55 secs
```

Now it takes:

```
________________________________________________________
Executed in  320.82 secs    fish           external
   usr time  672.96 secs  420.00 micros  672.96 secs
   sys time   13.99 secs   87.00 micros   13.99 secs
```