### PR TITLE
Use JSON schema to validate data/index.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         working-directory: ${{github.workspace}}/out/install/${{ matrix.platform }}-release/bin/
         run: |
           mkdir ${{github.workspace}}/artifact
-          7z a -tzip ${{github.workspace}}/artifact/health_gps_${{ matrix.platform }}.zip *.dll *.Console*
+          7z a -tzip ${{github.workspace}}/artifact/health_gps_${{ matrix.platform }}.zip *.dll *.Console* schemas
 
       - name: Upload release artifacts
         if: startsWith(github.ref, 'refs/tags/') && matrix.is_main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,10 @@ if(MSVC)
         message(WARNING "Code coverage cannot be generated for MSVC, ignoring")
     endif()
 
+    # Needed to avoid this error: fatal error C1128: number of sections exceeded object file format
+    # limit: compile with /bigobj
+    add_compile_options(/bigobj)
+
     if(WARNINGS_AS_ERRORS)
         add_compile_options(/WX)
     endif()

--- a/data/index.json
+++ b/data/index.json
@@ -228,7 +228,7 @@
         "format": "csv",
         "delimiter": ",",
         "encoding": "UTF8",
-        "description": "Observed burden of disease measures and disability weigths.",
+        "description": "Observed burden of disease measures and disability weights.",
         "source": "The Institute for Health Metrics and Evaluation - IHME",
         "url": "http://www.healthdata.org/",
         "license": "Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License",

--- a/schemas/v1/data_index.json
+++ b/schemas/v1/data_index.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "http://example.com/data_index.json",
+    "$id": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/data_index.json",
     "title": "Index file for input data",
     "description": "Metadata and paths for Health-GPS input files",
     "type": "object",
@@ -8,7 +8,9 @@
         "version": { "const": 2 },
         "country": {
             "allOf": [
-                { "$ref": "http://example.com/file_info.json" },
+                {
+                    "$ref": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/file_info.json"
+                },
                 {
                     "type": "object",
                     "properties": {
@@ -19,7 +21,9 @@
         },
         "demographic": {
             "allOf": [
-                { "$ref": "http://example.com/file_info.json" },
+                {
+                    "$ref": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/file_info.json"
+                },
                 {
                     "type": "object",
                     "properties": {
@@ -64,7 +68,9 @@
         },
         "diseases": {
             "allOf": [
-                { "$ref": "http://example.com/file_info.json" },
+                {
+                    "$ref": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/file_info.json"
+                },
                 {
                     "type": "object",
                     "properties": {
@@ -149,7 +155,9 @@
         },
         "analysis": {
             "allOf": [
-                { "$ref": "http://example.com/file_info.json" },
+                {
+                    "$ref": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/file_info.json"
+                },
                 {
                     "type": "object",
                     "properties": {

--- a/schemas/v1/data_index.json
+++ b/schemas/v1/data_index.json
@@ -1,0 +1,180 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "http://example.com/data_index.json",
+    "title": "Index file for input data",
+    "description": "Metadata and paths for Health-GPS input files",
+    "type": "object",
+    "properties": {
+        "version": { "const": 2 },
+        "country": {
+            "allOf": [
+                { "$ref": "http://example.com/file_info.json" },
+                {
+                    "type": "object",
+                    "properties": {
+                        "file_name": { "type": "string" }
+                    }
+                }
+            ]
+        },
+        "demographic": {
+            "allOf": [
+                { "$ref": "http://example.com/file_info.json" },
+                {
+                    "type": "object",
+                    "properties": {
+                        "age_limits": {
+                            "type": "array",
+                            "prefixItems": [
+                                { "type": "integer", "minimum": 0 },
+                                { "type": "integer", "minimum": 0 }
+                            ],
+                            "minItems": 2,
+                            "items": false
+                        },
+                        "time_limits": {
+                            "type": "array",
+                            "prefixItems": [
+                                { "type": "integer", "minimum": 1900 },
+                                { "type": "integer", "minimum": 1900 }
+                            ],
+                            "minItems": 2,
+                            "items": false
+                        },
+                        "projections": { "type": "integer" },
+                        "population": {
+                            "type": "object",
+                            "properties": {
+                                "description": { "type": "string" },
+                                "path": { "type": "string" },
+                                "file_name": { "type": "string" }
+                            }
+                        },
+                        "mortality": {
+                            "type": "object",
+                            "properties": {
+                                "description": { "type": "string" },
+                                "path": { "type": "string" },
+                                "file_name": { "type": "string" }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "diseases": {
+            "allOf": [
+                { "$ref": "http://example.com/file_info.json" },
+                {
+                    "type": "object",
+                    "properties": {
+                        "age_limits": {
+                            "type": "array",
+                            "prefixItems": [
+                                { "type": "integer", "minimum": 0 },
+                                { "type": "integer", "minimum": 0 }
+                            ],
+                            "minItems": 2,
+                            "items": false
+                        },
+                        "time_year": { "type": "integer", "minimum": 1900 },
+                        "disease": {
+                            "type": "object",
+                            "properties": {
+                                "path": { "type": "string" },
+                                "file_name": { "type": "string" },
+                                "relative_risk": {
+                                    "type": "object",
+                                    "properties": {
+                                        "path": { "type": "string" },
+                                        "to_disease": {
+                                            "type": "object",
+                                            "properties": {
+                                                "path": { "type": "string" },
+                                                "file_name": {
+                                                    "type": "string"
+                                                },
+                                                "default_value": {
+                                                    "type": "number"
+                                                }
+                                            }
+                                        },
+                                        "to_risk_factor": {
+                                            "type": "object",
+                                            "properties": {
+                                                "path": { "type": "string" },
+                                                "file_name": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "parameters": {
+                                            "type": "object",
+                                            "properties": {
+                                                "path": { "type": "string" },
+                                                "files": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "distribution": {
+                                                            "type": "string"
+                                                        },
+                                                        "survival_rate": {
+                                                            "type": "string"
+                                                        },
+                                                        "death_weight": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "registry": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "group": { "enum": ["other", "cancer"] },
+                                    "id": { "type": "string" },
+                                    "name": { "type": "string" }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "analysis": {
+            "allOf": [
+                { "$ref": "http://example.com/file_info.json" },
+                {
+                    "type": "object",
+                    "properties": {
+                        "age_limits": {
+                            "type": "array",
+                            "prefixItems": [
+                                { "type": "integer", "minimum": 0 },
+                                { "type": "integer", "minimum": 0 }
+                            ],
+                            "minItems": 2,
+                            "items": false
+                        },
+                        "time_year": { "type": "integer", "minimum": 1900 },
+                        "disability_file_name": { "type": "string" },
+                        "lms_file_name": { "type": "string" },
+                        "cost_of_disease": {
+                            "type": "object",
+                            "properties": {
+                                "path": { "type": "string" },
+                                "file_name": { "type": "string" }
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/schemas/v1/file_info.json
+++ b/schemas/v1/file_info.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "http://example.com/file_info.json",
+    "$id": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/file_info.json",
     "type": "object",
     "properties": {
         "format": { "const": "csv" },

--- a/schemas/v1/file_info.json
+++ b/schemas/v1/file_info.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "http://example.com/file_info.json",
+    "type": "object",
+    "properties": {
+        "format": { "const": "csv" },
+        "delimiter": { "const": "," },
+        "encoding": { "const": "UTF8" },
+        "description": { "type": "string" },
+        "source": { "type": "string" },
+        "url": { "type": "string", "format": "uri" },
+        "license": { "type": "string" },
+        "path": { "type": "string" }
+    }
+}

--- a/src/HealthGPS.Console/CMakeLists.txt
+++ b/src/HealthGPS.Console/CMakeLists.txt
@@ -70,4 +70,6 @@ if(WIN32)
     install(IMPORTED_RUNTIME_ARTIFACTS fmt::fmt)
 endif()
 
+install(DIRECTORY ../../schemas DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
+
 set(ROOT_NAMESPACE hgps)

--- a/src/HealthGPS.Datastore/CMakeLists.txt
+++ b/src/HealthGPS.Datastore/CMakeLists.txt
@@ -1,10 +1,11 @@
 find_package(fmt CONFIG REQUIRED)
+find_package(jsoncons CONFIG REQUIRED)
 
 add_library(HealthGPS.Datastore STATIC "")
 target_compile_features(HealthGPS.Datastore PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
 
 target_sources(HealthGPS.Datastore PRIVATE "datamanager.cpp" "datamanager.h" "api.h")
 
-target_link_libraries(HealthGPS.Datastore PRIVATE HealthGPS.Core fmt::fmt)
+target_link_libraries(HealthGPS.Datastore PRIVATE HealthGPS.Core fmt::fmt jsoncons)
 
 set(ROOT_NAMESPACE hgps::data)

--- a/src/HealthGPS.Datastore/datamanager.cpp
+++ b/src/HealthGPS.Datastore/datamanager.cpp
@@ -13,20 +13,21 @@ DataManager::DataManager(std::filesystem::path root_directory, VerboseMode verbo
     : root_{std::move(root_directory)}, verbosity_{verbosity} {
     auto full_filename = root_ / "index.json";
     auto ifs = std::ifstream{full_filename, std::ifstream::in};
-    if (ifs) {
-        index_ = nlohmann::json::parse(ifs);
-        if (!index_.contains("version")) {
-            throw std::runtime_error("File-based store, invalid definition missing schema version");
-        }
-
-        auto version = index_["version"].get<int>();
-        if (version != 2) {
-            throw std::runtime_error(fmt::format(
-                "File-based store, index schema version: {} mismatch, supported: 2", version));
-        }
-    } else {
+    if (!ifs) {
         throw std::invalid_argument(
             fmt::format("File-based store, index file: '{}' not found.", full_filename.string()));
+    }
+
+    index_ = nlohmann::json::parse(ifs);
+
+    if (!index_.contains("version")) {
+        throw std::runtime_error("File-based store, invalid definition missing schema version");
+    }
+
+    auto version = index_["version"].get<int>();
+    if (version != 2) {
+        throw std::runtime_error(fmt::format(
+            "File-based store, index schema version: {} mismatch, supported: 2", version));
     }
 }
 

--- a/src/HealthGPS.Datastore/datamanager.cpp
+++ b/src/HealthGPS.Datastore/datamanager.cpp
@@ -12,7 +12,7 @@ namespace hgps::data {
 DataManager::DataManager(std::filesystem::path root_directory, VerboseMode verbosity)
     : root_{std::move(root_directory)}, verbosity_{verbosity} {
     auto full_filename = root_ / "index.json";
-    auto ifs = std::ifstream{full_filename, std::ifstream::in};
+    auto ifs = std::ifstream{full_filename};
     if (!ifs) {
         throw std::invalid_argument(
             fmt::format("File-based store, index file: '{}' not found.", full_filename.string()));

--- a/src/HealthGPS.Datastore/datamanager.cpp
+++ b/src/HealthGPS.Datastore/datamanager.cpp
@@ -39,9 +39,6 @@ void validate_index(const std::filesystem::path &schema_directory, std::ifstream
     // the nlohmann-json representation :-(
     const auto index = json::parse(ifs);
 
-    // Go back to start of file so caller can re-read it
-    ifs.seekg(0);
-
     // Load schema
     auto ifs_schema = std::ifstream{schema_directory / "data_index.json"};
     if (!ifs_schema) {
@@ -68,10 +65,6 @@ DataManager::DataManager(std::filesystem::path root_directory, VerboseMode verbo
             fmt::format("File-based store, index file: '{}' not found.", full_filename.string()));
     }
 
-    // Validate against schema
-    const auto schema_directory = get_program_directory() / "schemas" / "v1";
-    validate_index(schema_directory, ifs);
-
     index_ = nlohmann::json::parse(ifs);
 
     if (!index_.contains("version")) {
@@ -83,6 +76,11 @@ DataManager::DataManager(std::filesystem::path root_directory, VerboseMode verbo
         throw std::runtime_error(fmt::format(
             "File-based store, index schema version: {} mismatch, supported: 2", version));
     }
+
+    // Validate against schema
+    ifs.seekg(0);
+    const auto schema_directory = get_program_directory() / "schemas" / "v1";
+    validate_index(schema_directory, ifs);
 }
 
 std::vector<Country> DataManager::get_countries() const {

--- a/src/HealthGPS.Datastore/datamanager.cpp
+++ b/src/HealthGPS.Datastore/datamanager.cpp
@@ -15,7 +15,8 @@ namespace {
 using namespace jsoncons;
 
 json resolve_uri(const jsoncons::uri &uri, const std::filesystem::path &schema_directory) {
-    constexpr const char *url_prefix = "http://example.com/";
+    constexpr const char *url_prefix =
+        "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/";
 
     const auto &uri_str = uri.string();
     if (!uri_str.starts_with(url_prefix)) {
@@ -23,7 +24,8 @@ json resolve_uri(const jsoncons::uri &uri, const std::filesystem::path &schema_d
     }
 
     // Strip URL prefix and load file from local filesystem
-    const auto schema_path = schema_directory / std::filesystem::path{uri.path().substr(1)};
+    const auto filename = std::filesystem::path{uri.path()}.filename();
+    const auto schema_path = schema_directory / filename;
     auto ifs = std::ifstream{schema_path};
     if (!ifs) {
         throw std::runtime_error("Failed to read schema file");

--- a/src/HealthGPS.Tests/CMakeLists.txt
+++ b/src/HealthGPS.Tests/CMakeLists.txt
@@ -16,8 +16,6 @@ target_sources(
             "pch.h"
             "data_config.h"
             "data_config.cpp"
-            "program_path.h"
-            "program_path.cpp"
             "AgeGenderTable.Test.cpp"
             "Channel.Test.cpp"
             "Configuration.Test.cpp"

--- a/src/HealthGPS.Tests/CMakeLists.txt
+++ b/src/HealthGPS.Tests/CMakeLists.txt
@@ -66,14 +66,9 @@ if(WIN32)
 endif()
 
 # Additional data files required for tests
-set(TO_COPY nutrient_table.csv)
+set(TO_COPY nutrient_table.csv ../../schemas)
 foreach(FILE IN LISTS TO_COPY)
-    add_custom_command(
-        TARGET HealthGPS.Tests
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/${FILE}"
-                "$<TARGET_FILE_DIR:HealthGPS.Tests>")
-    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/${FILE}" DESTINATION bin)
+    file(COPY "${FILE}" DESTINATION ".")
 endforeach(FILE IN LISTS TO_COPY)
 
 set(ROOT_NAMESPACE hgps::test)

--- a/src/HealthGPS.Tests/HealthGPS.Test.cpp
+++ b/src/HealthGPS.Tests/HealthGPS.Test.cpp
@@ -234,36 +234,6 @@ TEST(TestHealthGPS, CreateRuntimeContext) {
     ASSERT_EQ(0, context.time_now());
 }
 
-/*
-TEST(TestHealthGPS, SimulationInitialise)
-{
-        using namespace hgps;
-        using namespace hgps::data;
-
-        DataTable data;
-        create_test_datatable(data);
-
-        auto bus = DefaultEventBus{};
-        auto channel = SyncChannel{};
-        auto rnd = MTRandom32{ 123456789 };
-        auto scenario = BaselineScenario{ channel };
-        auto config = create_test_configuration(data);
-        auto definition = SimulationDefinition(config, std::move(scenario), std::move(rnd));
-
-        auto manager = DataManager(store_full_path);
-        auto repository = CachedRepository(manager);
-
-        auto baseline_data = hgps::RiskFactorSexAgeTable{};
-        repository.register_linear_model_definition(RiskFactorModelType::Static,
-get_static_test_model(baseline_data));
-        repository.register_linear_model_definition(RiskFactorModelType::Dynamic,
-get_dynamic_test_model(baseline_data));
-
-        auto factory = get_default_simulation_module_factory(repository);
-        ASSERT_NO_THROW(HealthGPS(std::move(definition), factory, bus));
-}
-*/
-
 TEST(TestHealthGPS, ModuleFactoryRegistry) {
     using namespace hgps;
     using namespace hgps::data;

--- a/src/HealthGPS.Tests/LoadNutrientTable.cpp
+++ b/src/HealthGPS.Tests/LoadNutrientTable.cpp
@@ -1,8 +1,8 @@
 #include "pch.h"
-#include "program_path.h"
 
 #include "HealthGPS.Core/exception.h"
 #include "HealthGPS/nutrients.h"
+#include "HealthGPS/program_path.h"
 
 #include <filesystem>
 #include <sstream>
@@ -31,7 +31,7 @@ TEST(LoadNutrientTable, GetNutrientIndexes) {
 }
 
 TEST(LoadNutrientTable, LoadNutrientTable) {
-    const auto csv_path = (get_program_directory() / "nutrient_table.csv").string();
+    const auto csv_path = (hgps::get_program_directory() / "nutrient_table.csv").string();
     const auto table = load_nutrient_table(csv_path, nutrients);
 
     const decltype(table) expected = {

--- a/src/HealthGPS/CMakeLists.txt
+++ b/src/HealthGPS/CMakeLists.txt
@@ -76,6 +76,8 @@ target_sources(
             "person.h"
             "population.cpp"
             "population.h"
+            "program_path.cpp"
+            "program_path.h"
             "physical_activity_scenario.cpp"
             "physical_activity_scenario.h"
             "random_algorithm.cpp"

--- a/src/HealthGPS/program_path.cpp
+++ b/src/HealthGPS/program_path.cpp
@@ -16,6 +16,7 @@ namespace {
 void throw_path_error() { throw hgps::core::HgpsException("Could not get program path"); }
 } // anonymous namespace
 
+namespace hgps {
 std::filesystem::path get_program_directory() { return get_program_path().parent_path(); }
 
 std::filesystem::path get_program_path() {
@@ -35,3 +36,4 @@ std::filesystem::path get_program_path() {
 
     return path.data();
 }
+} // namespace hgps

--- a/src/HealthGPS/program_path.h
+++ b/src/HealthGPS/program_path.h
@@ -2,8 +2,10 @@
 
 #include <filesystem>
 
+namespace hgps {
 //! Get the path to the directory of the currently executing program
 std::filesystem::path get_program_directory();
 
 //! Get the path to the currently executing program
 std::filesystem::path get_program_path();
+} // namespace hgps

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,6 +10,7 @@
         "cxxopts",
         "eigen3",
         "nlohmann-json",
+        "jsoncons",
         "rapidcsv",
         "crossguid",
         "gtest",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -16,5 +16,5 @@
         "gtest",
         "tbb"
     ],
-    "builtin-baseline": "1e334d770ac71a89d1c36d51019e60dd08b68f76"
+    "builtin-baseline": "bd2b54836beed96e1efbe9aaf8ee800f5448856d"
 }


### PR DESCRIPTION
This is still a WIP. Tests are failing and the implementation is currently a bit hacky.

I started by writing a JSON schema for the data/index.json file. The current format of this file might leave something to be desired, but I thought it was best to have a schema for the current format and if/when we want to change it, we can amend the schema as needed.

I wrote a small script to validate the schema from Python, as a proof of concept (see below), but I figured that seeing as I'd gone to the trouble of writing the schema in the first place, we might as well use it for validation from the C++ code for now, which will drastically improve the error checking. We can always redo it in Python if we decide to change course.

One slightly nasty aspect of the C++ implementation is that the JSON schema library I was using doesn't work with `nlohmann-json`, which is what we're using everywhere else. This means that `index.json` currently has to be loaded once with `jsoncons` (for the validation) and again with `nlohmann-json` (for actually using the data). There are things we can do about this, but that's a task for later.

I've used placeholder URLs for the schema IDs for now, but when it comes to the final version we should actually publish the schemas somewhere so that users can easily validate the data files themselves. (If we were using real URLs we wouldn't need to intercept the URL resolving either.)

Closes #360.

FYI: Here's how you can validate the file from Python:

```py
"""Validate data/index.json using a JSON schema."""
import json
from jsonschema.validators import Draft202012Validator
from referencing import Registry, Resource
from referencing.exceptions import NoSuchResource
from pathlib import Path

REPO_PATH = Path(__file__).parent
SCHEMA_ROOT = REPO_PATH / "schemas" / "v1"
URL_PREFIX = "http://example.com/"

def retrieve_from_filesystem(uri: str):
    """Strip the prefix from the URI and load the local files."""
    if not uri.startswith(URL_PREFIX):
        raise NoSuchResource(ref=uri)

    path = SCHEMA_ROOT / uri[len(URL_PREFIX):]
    with path.open() as f:
        return Resource.from_contents(json.load(f))


def main():
    print('STARTING')
    SCHEMA_PATH = SCHEMA_ROOT / "data_index.json"
    DATA_PATH = REPO_PATH / "data" / "index.json"

    with SCHEMA_PATH.open() as f:
        schema = json.load(f)
    with DATA_PATH.open() as f:
        data = json.load(f)

    registry = Registry(retrieve=retrieve_from_filesystem)
    Draft202012Validator.check_schema(schema)
    validator = Draft202012Validator(schema=schema, registry=registry)
    validator.validate(data)

    print('VALIDATED SUCCESSFULLY :-D')

if __name__ == '__main__':
    main()
```
