### PR TITLE
Fix expected value adjustment

### DIFF
--- a/src/HealthGPS.Tests/Channel.Test.cpp
+++ b/src/HealthGPS.Tests/Channel.Test.cpp
@@ -1,7 +1,6 @@
 #include "pch.h"
 
 #include "HealthGPS/channel.h"
-#include <oneapi/tbb/parallel_for_each.h>
 #include <thread>
 
 TEST(ChannelTest, DefaultConstruction) {

--- a/src/HealthGPS/risk_factor_adjustable_model.cpp
+++ b/src/HealthGPS/risk_factor_adjustable_model.cpp
@@ -18,8 +18,8 @@ struct FirstMoment {
         sum_ += value;
     }
 
-    // Empty mean is zero, not NaN, since the slot may not be empty in intervention scenario.
-    double mean() const noexcept { return (count_ > 0) ? (sum_ / count_) : 0.0; }
+    // Empty mean is NaN, so risk factors are not adjusted.
+    double mean() const noexcept { return sum_ / count_; }
 
   private:
     int count_{};
@@ -32,24 +32,20 @@ namespace hgps {
 
 RiskFactorAdjustableModel::RiskFactorAdjustableModel(
     const RiskFactorSexAgeTable &risk_factor_expected)
-    : risk_factor_expected_{risk_factor_expected} {
-
-    if (risk_factor_expected_.empty()) {
-        throw core::HgpsException("Risk factor expected value mapping is empty");
-    }
-}
+    : risk_factor_expected_{risk_factor_expected} {}
 
 const RiskFactorSexAgeTable &RiskFactorAdjustableModel::get_risk_factor_expected() const noexcept {
     return risk_factor_expected_;
 }
 
-void RiskFactorAdjustableModel::adjust_risk_factors(
-    RuntimeContext &context, const std::vector<core::Identifier> &keys) const {
+void RiskFactorAdjustableModel::adjust_risk_factors(RuntimeContext &context,
+                                                    const std::vector<core::Identifier> &factors,
+                                                    OptionalRanges ranges) const {
     RiskFactorSexAgeTable adjustments;
 
     // Baseline scenatio: compute adjustments.
     if (context.scenario().type() == ScenarioType::baseline) {
-        adjustments = calculate_adjustments(context, keys);
+        adjustments = calculate_adjustments(context, factors);
     }
 
     // Intervention scenario: receive adjustments from baseline scenario.
@@ -77,9 +73,18 @@ void RiskFactorAdjustableModel::adjust_risk_factors(
             return;
         }
 
-        for (const auto &factor : keys) {
-            double delta = adjustments.at(person.gender, factor).at(person.age);
-            person.risk_factors.at(factor) += delta;
+        for (size_t i = 0; i < factors.size(); i++) {
+            double delta = adjustments.at(person.gender, factors[i]).at(person.age);
+            double value = person.risk_factors.at(factors[i]) + delta;
+
+            // Clamp value to an optionally specified range.
+            if (ranges.has_value()) {
+                const auto &range = ranges.value().get()[i];
+                value = range.clamp(value);
+            }
+
+            // Set the adjusted value.
+            person.risk_factors.at(factors[i]) = value;
         }
     });
 
@@ -90,27 +95,32 @@ void RiskFactorAdjustableModel::adjust_risk_factors(
     }
 }
 
-RiskFactorSexAgeTable
-RiskFactorAdjustableModel::calculate_adjustments(RuntimeContext &context,
-                                                 const std::vector<core::Identifier> &keys) const {
+RiskFactorSexAgeTable RiskFactorAdjustableModel::calculate_adjustments(
+    RuntimeContext &context, const std::vector<core::Identifier> &factors) const {
     auto age_range = context.age_range();
     auto age_count = age_range.upper() + 1;
 
     // Compute simulated means.
-    auto simulated_means = calculate_simulated_mean(context.population(), age_range, keys);
+    auto simulated_means = calculate_simulated_mean(context.population(), age_range, factors);
 
     // Compute adjustments.
     auto adjustments = RiskFactorSexAgeTable{};
     for (const auto &[sex, simulated_means_by_sex] : simulated_means) {
-        for (const auto &factor : keys) {
-            adjustments.emplace(sex, factor, std::vector<double>(age_count, 0.0));
+        for (const auto &factor : factors) {
+            adjustments.emplace(sex, factor, std::vector<double>(age_count));
             for (auto age = age_range.lower(); age <= age_range.upper(); age++) {
                 double expect = risk_factor_expected_.at(sex, factor).at(age);
                 double sim_mean = simulated_means_by_sex.at(factor).at(age);
-                double delta = expect - sim_mean;
-                if (!std::isnan(delta)) {
-                    adjustments.at(sex, factor).at(age) = delta;
+
+                // Delta should remain zero if simulated mean is NaN.
+                double delta = 0.0;
+
+                // Else, delta is the distance from expected value.
+                if (!std::isnan(sim_mean)) {
+                    delta = expect - sim_mean;
                 }
+
+                adjustments.at(sex, factor).at(age) = delta;
             }
         }
     }
@@ -121,7 +131,7 @@ RiskFactorAdjustableModel::calculate_adjustments(RuntimeContext &context,
 RiskFactorSexAgeTable
 RiskFactorAdjustableModel::calculate_simulated_mean(Population &population,
                                                     const core::IntegerInterval age_range,
-                                                    const std::vector<core::Identifier> &keys) {
+                                                    const std::vector<core::Identifier> &factors) {
     auto age_count = age_range.upper() + 1;
 
     // Compute first moments.
@@ -131,7 +141,7 @@ RiskFactorAdjustableModel::calculate_simulated_mean(Population &population,
             continue;
         }
 
-        for (const auto &factor : keys) {
+        for (const auto &factor : factors) {
             if (!moments.contains(person.gender, factor)) {
                 moments.emplace(person.gender, factor, std::vector<FirstMoment>(age_count));
             }
@@ -143,8 +153,8 @@ RiskFactorAdjustableModel::calculate_simulated_mean(Population &population,
     // Compute means.
     auto means = RiskFactorSexAgeTable{};
     for (const auto &[sex, moments_by_sex] : moments) {
-        for (const auto &factor : keys) {
-            means.emplace(sex, factor, std::vector<double>(age_count, 0.0));
+        for (const auto &factor : factors) {
+            means.emplace(sex, factor, std::vector<double>(age_count));
             for (auto age = age_range.lower(); age <= age_range.upper(); age++) {
                 double value = moments_by_sex.at(factor).at(age).mean();
                 means.at(sex, factor).at(age) = value;

--- a/src/HealthGPS/risk_factor_adjustable_model.h
+++ b/src/HealthGPS/risk_factor_adjustable_model.h
@@ -7,7 +7,16 @@
 #include "risk_factor_model.h"
 #include "runtime_context.h"
 
+#include <functional>
+#include <optional>
 #include <vector>
+
+namespace { // anonymous namespace
+
+using OptionalRanges =
+    std::optional<std::reference_wrapper<const std::vector<hgps::core::DoubleInterval>>>;
+
+} // anonymous namespace
 
 namespace hgps {
 
@@ -27,17 +36,18 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
 
     /// @brief Adjust risk factors such that mean sim value matches expected value
     /// @param context The simulation run-time context
-    /// @param keys A list of keys for risk factors to be adjusted
-    void adjust_risk_factors(RuntimeContext &context,
-                             const std::vector<core::Identifier> &keys) const;
+    /// @param factors A list of risk factors to be adjusted
+    /// @param ranges An optional list of risk factor value boundaries
+    void adjust_risk_factors(RuntimeContext &context, const std::vector<core::Identifier> &factors,
+                             OptionalRanges ranges = std::nullopt) const;
 
   private:
     RiskFactorSexAgeTable calculate_adjustments(RuntimeContext &context,
-                                                const std::vector<core::Identifier> &keys) const;
+                                                const std::vector<core::Identifier> &factors) const;
 
     static RiskFactorSexAgeTable
     calculate_simulated_mean(Population &population, core::IntegerInterval age_range,
-                             const std::vector<core::Identifier> &keys);
+                             const std::vector<core::Identifier> &factors);
 
     const RiskFactorSexAgeTable &risk_factor_expected_;
 };


### PR DESCRIPTION
This PR contains the changes from the messy `main_hslope` branch for fixing the expected risk factor value adjustment.

The problem was that the mean of empty groups in the baseline sim was set erroneously to zero. This meant that the same group in the intervention scenario was being adjusted by `delta = expect - sim_mean = expect`, which is clearly wrong.

The issue only occurred in naturally smaller groups, such as 90+, which makes sense because it was more likely to occur that the baseline group is empty, but intervention group was non-empty.

The solution here is to simply not adjust groups with NaN baseline means.
