### PR TITLE
Bounded nutrients

### DIFF
--- a/src/HealthGPS.Console/model_parser.cpp
+++ b/src/HealthGPS.Console/model_parser.cpp
@@ -180,6 +180,7 @@ load_staticlinear_risk_model_definition(const poco::json &opt, const host::Confi
     // Risk factor and intervention policy: names, models, parameters and correlation/covariance.
     std::vector<hgps::core::Identifier> names;
     std::vector<hgps::LinearModelParams> models;
+    std::vector<hgps::core::DoubleInterval> ranges;
     std::vector<double> lambda;
     std::vector<double> stddev;
     std::vector<hgps::LinearModelParams> policy_models;
@@ -206,6 +207,7 @@ load_staticlinear_risk_model_definition(const poco::json &opt, const host::Confi
 
         // Write risk factor data structures.
         models.emplace_back(std::move(model));
+        ranges.emplace_back(json_params["Range"].get<hgps::core::DoubleInterval>());
         lambda.emplace_back(json_params["Lambda"].get<double>());
         stddev.emplace_back(json_params["StdDev"].get<double>());
         for (size_t j = 0; j < correlation_table.num_rows(); j++) {
@@ -326,10 +328,10 @@ load_staticlinear_risk_model_definition(const poco::json &opt, const host::Confi
     const double physical_activity_stddev = opt["PhysicalActivityStdDev"].get<double>();
 
     return std::make_unique<hgps::StaticLinearModelDefinition>(
-        std::move(expected), std::move(names), std::move(models), std::move(lambda),
-        std::move(stddev), std::move(cholesky), std::move(policy_models), std::move(policy_ranges),
-        std::move(policy_cholesky), info_speed, std::move(rural_prevalence),
-        std::move(income_models), physical_activity_stddev);
+        std::move(expected), std::move(names), std::move(models), std::move(ranges),
+        std::move(lambda), std::move(stddev), std::move(cholesky), std::move(policy_models),
+        std::move(policy_ranges), std::move(policy_cholesky), info_speed,
+        std::move(rural_prevalence), std::move(income_models), physical_activity_stddev);
 }
 
 std::unique_ptr<hgps::RiskFactorModelDefinition>

--- a/src/HealthGPS/static_linear_model.cpp
+++ b/src/HealthGPS/static_linear_model.cpp
@@ -337,19 +337,19 @@ void StaticLinearModel::initialise_physical_activity(Person &person, Random &ran
 
 StaticLinearModelDefinition::StaticLinearModelDefinition(
     RiskFactorSexAgeTable expected, std::vector<core::Identifier> names,
-    std::vector<LinearModelParams> models, std::vector<double> lambda, std::vector<double> stddev,
-    Eigen::MatrixXd cholesky, std::vector<LinearModelParams> policy_models,
-    std::vector<core::DoubleInterval> policy_ranges, Eigen::MatrixXd policy_cholesky,
-    double info_speed,
+    std::vector<LinearModelParams> models, std::vector<core::DoubleInterval> ranges,
+    std::vector<double> lambda, std::vector<double> stddev, Eigen::MatrixXd cholesky,
+    std::vector<LinearModelParams> policy_models, std::vector<core::DoubleInterval> policy_ranges,
+    Eigen::MatrixXd policy_cholesky, double info_speed,
     std::unordered_map<core::Identifier, std::unordered_map<core::Gender, double>> rural_prevalence,
     std::unordered_map<core::Income, LinearModelParams> income_models,
     double physical_activity_stddev)
     : RiskFactorAdjustableModelDefinition{std::move(expected)}, names_{std::move(names)},
-      models_{std::move(models)}, lambda_{std::move(lambda)}, stddev_{std::move(stddev)},
-      cholesky_{std::move(cholesky)}, policy_models_{std::move(policy_models)},
-      policy_ranges_{std::move(policy_ranges)}, policy_cholesky_{std::move(policy_cholesky)},
-      info_speed_{info_speed}, rural_prevalence_{std::move(rural_prevalence)},
-      income_models_{std::move(income_models)},
+      models_{std::move(models)}, ranges_{std::move(ranges)}, lambda_{std::move(lambda)},
+      stddev_{std::move(stddev)}, cholesky_{std::move(cholesky)},
+      policy_models_{std::move(policy_models)}, policy_ranges_{std::move(policy_ranges)},
+      policy_cholesky_{std::move(policy_cholesky)}, info_speed_{info_speed},
+      rural_prevalence_{std::move(rural_prevalence)}, income_models_{std::move(income_models)},
       physical_activity_stddev_{physical_activity_stddev} {
 
     if (names_.empty()) {
@@ -357,6 +357,9 @@ StaticLinearModelDefinition::StaticLinearModelDefinition(
     }
     if (models_.empty()) {
         throw core::HgpsException("Risk factor model list is empty");
+    }
+    if (ranges_.empty()) {
+        throw core::HgpsException("Risk factor ranges list is empty");
     }
     if (lambda_.empty()) {
         throw core::HgpsException("Risk factor lambda list is empty");

--- a/src/HealthGPS/static_linear_model.cpp
+++ b/src/HealthGPS/static_linear_model.cpp
@@ -8,17 +8,17 @@ namespace hgps {
 
 StaticLinearModel::StaticLinearModel(
     const RiskFactorSexAgeTable &expected, const std::vector<core::Identifier> &names,
-    const std::vector<LinearModelParams> &models, const std::vector<double> &lambda,
-    const std::vector<double> &stddev, const Eigen::MatrixXd &cholesky,
-    const std::vector<LinearModelParams> &policy_models,
+    const std::vector<LinearModelParams> &models, const std::vector<core::DoubleInterval> &ranges,
+    const std::vector<double> &lambda, const std::vector<double> &stddev,
+    const Eigen::MatrixXd &cholesky, const std::vector<LinearModelParams> &policy_models,
     const std::vector<core::DoubleInterval> &policy_ranges, const Eigen::MatrixXd &policy_cholesky,
     double info_speed,
     const std::unordered_map<core::Identifier, std::unordered_map<core::Gender, double>>
         &rural_prevalence,
     const std::unordered_map<core::Income, LinearModelParams> &income_models,
     double physical_activity_stddev)
-    : RiskFactorAdjustableModel{expected}, names_{names}, models_{models}, lambda_{lambda},
-      stddev_{stddev}, cholesky_{cholesky}, policy_models_{policy_models},
+    : RiskFactorAdjustableModel{expected}, names_{names}, models_{models}, ranges_{ranges},
+      lambda_{lambda}, stddev_{stddev}, cholesky_{cholesky}, policy_models_{policy_models},
       policy_ranges_{policy_ranges}, policy_cholesky_{policy_cholesky}, info_speed_{info_speed},
       rural_prevalence_{rural_prevalence}, income_models_{income_models},
       physical_activity_stddev_{physical_activity_stddev} {}
@@ -389,7 +389,7 @@ StaticLinearModelDefinition::StaticLinearModelDefinition(
 
 std::unique_ptr<RiskFactorModel> StaticLinearModelDefinition::create_model() const {
     const auto &expected = get_risk_factor_expected();
-    return std::make_unique<StaticLinearModel>(expected, names_, models_, lambda_, stddev_,
+    return std::make_unique<StaticLinearModel>(expected, names_, models_, ranges_, lambda_, stddev_,
                                                cholesky_, policy_models_, policy_ranges_,
                                                policy_cholesky_, info_speed_, rural_prevalence_,
                                                income_models_, physical_activity_stddev_);

--- a/src/HealthGPS/static_linear_model.h
+++ b/src/HealthGPS/static_linear_model.h
@@ -26,11 +26,12 @@ class StaticLinearModel final : public RiskFactorAdjustableModel {
     /// @param expected The risk factor expected values by sex and age
     /// @param names The risk factor names
     /// @param models The linear models used to compute a person's risk factor values
+    /// @param ranges The value range of each risk factor
     /// @param lambda The lambda values of the risk factors
     /// @param stddev The standard deviations of the risk factors
     /// @param cholesky Cholesky decomposition of the risk factor correlation matrix
     /// @param policy_models The linear models used to compute a person's intervention policies
-    /// @param policy_ranges The boundaries of the intervention policy values
+    /// @param policy_ranges The value range of each intervention policy
     /// @param policy_cholesky Cholesky decomposition of the intervention policy covariance matrix
     /// @param info_speed The information speed of risk factor updates
     /// @param rural_prevalence Rural sector prevalence for age groups and sex
@@ -39,7 +40,8 @@ class StaticLinearModel final : public RiskFactorAdjustableModel {
     /// @throws HgpsException for invalid arguments
     StaticLinearModel(
         const RiskFactorSexAgeTable &expected, const std::vector<core::Identifier> &names,
-        const std::vector<LinearModelParams> &models, const std::vector<double> &lambda,
+        const std::vector<LinearModelParams> &models,
+        const std::vector<core::DoubleInterval> &ranges, const std::vector<double> &lambda,
         const std::vector<double> &stddev, const Eigen::MatrixXd &cholesky,
         const std::vector<LinearModelParams> &policy_models,
         const std::vector<core::DoubleInterval> &policy_ranges,
@@ -100,6 +102,7 @@ class StaticLinearModel final : public RiskFactorAdjustableModel {
 
     const std::vector<core::Identifier> &names_;
     const std::vector<LinearModelParams> &models_;
+    const std::vector<core::DoubleInterval> &ranges_;
     const std::vector<double> &lambda_;
     const std::vector<double> &stddev_;
     const Eigen::MatrixXd &cholesky_;

--- a/src/HealthGPS/static_linear_model.h
+++ b/src/HealthGPS/static_linear_model.h
@@ -120,11 +120,12 @@ class StaticLinearModelDefinition : public RiskFactorAdjustableModelDefinition {
     /// @param expected The risk factor expected values by sex and age
     /// @param names The risk factor names
     /// @param models The linear models used to compute a person's risk factors
+    /// @param ranges The value range of each risk factor
     /// @param lambda The lambda values of the risk factors
     /// @param stddev The standard deviations of the risk factors
     /// @param cholesky Cholesky decomposition of the risk factor correlation matrix
     /// @param policy_models The linear models used to compute a person's intervention policies
-    /// @param policy_ranges The boundaries of the intervention policy values
+    /// @param policy_ranges The value range of each intervention policy
     /// @param policy_cholesky Cholesky decomposition of the intervention policy covariance matrix
     /// @param info_speed The information speed of risk factor updates
     /// @param rural_prevalence Rural sector prevalence for age groups and sex
@@ -133,8 +134,8 @@ class StaticLinearModelDefinition : public RiskFactorAdjustableModelDefinition {
     /// @throws HgpsException for invalid arguments
     StaticLinearModelDefinition(
         RiskFactorSexAgeTable expected, std::vector<core::Identifier> names,
-        std::vector<LinearModelParams> models, std::vector<double> lambda,
-        std::vector<double> stddev, Eigen::MatrixXd cholesky,
+        std::vector<LinearModelParams> models, std::vector<core::DoubleInterval> ranges,
+        std::vector<double> lambda, std::vector<double> stddev, Eigen::MatrixXd cholesky,
         std::vector<LinearModelParams> policy_models,
         std::vector<core::DoubleInterval> policy_ranges, Eigen::MatrixXd policy_cholesky,
         double info_speed,
@@ -150,6 +151,7 @@ class StaticLinearModelDefinition : public RiskFactorAdjustableModelDefinition {
   private:
     std::vector<core::Identifier> names_;
     std::vector<LinearModelParams> models_;
+    std::vector<core::DoubleInterval> ranges_;
     std::vector<double> lambda_;
     std::vector<double> stddev_;
     Eigen::MatrixXd cholesky_;


### PR DESCRIPTION
Last one to complete merge. :partying_face: 

Apply clamping to risk factors (nutrients), loaded from the `StaticLinear.json` config file to keep them in range.
