### PR TITLE
Read zipped input data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 ## Get latest from https://github.com/github/gitignore/blob/main/VisualStudio.gitignore
 
 # ------------ Custom User Options ----------------
+*.zip
 
 # CMake presets, build directories and binary files
 build/

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The code in this repository is licensed under the [BSD 3-Clause](LICENSE.txt) li
 | [nlohmann-json](https://github.com/nlohmann/json)     | MIT          |
 | [rapidcsv](https://github.com/d99kris/rapidcsv)       | BSD 3-Clause |
 | [oneAPI TBB](https://github.com/oneapi-src/oneTBB)    | Apache 2.0   |
+| [libzippp](https://github.com/ctabin/libzippp)        | MIT          |
 
 ### Tools and Frameworks
 

--- a/src/HealthGPS.Datastore/CMakeLists.txt
+++ b/src/HealthGPS.Datastore/CMakeLists.txt
@@ -1,12 +1,21 @@
 find_package(fmt CONFIG REQUIRED)
 find_package(jsoncons CONFIG REQUIRED)
+find_package(libzippp CONFIG REQUIRED)
 
 add_library(HealthGPS.Datastore STATIC "")
 target_compile_features(HealthGPS.Datastore PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
 
-target_sources(HealthGPS.Datastore PRIVATE "api.h" "datamanager.cpp" "datamanager.h" "schema.cpp"
-                                           "schema.h")
+target_sources(
+    HealthGPS.Datastore
+    PRIVATE "api.h"
+            "datamanager.cpp"
+            "datamanager.h"
+            "schema.cpp"
+            "schema.h"
+            "zip_file.cpp"
+            "zip_file.h")
 
-target_link_libraries(HealthGPS.Datastore PRIVATE HealthGPS.Core fmt::fmt jsoncons)
+target_link_libraries(HealthGPS.Datastore PRIVATE HealthGPS.Core fmt::fmt jsoncons
+                                                  libzippp::libzippp)
 
 set(ROOT_NAMESPACE hgps::data)

--- a/src/HealthGPS.Datastore/CMakeLists.txt
+++ b/src/HealthGPS.Datastore/CMakeLists.txt
@@ -4,7 +4,8 @@ find_package(jsoncons CONFIG REQUIRED)
 add_library(HealthGPS.Datastore STATIC "")
 target_compile_features(HealthGPS.Datastore PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
 
-target_sources(HealthGPS.Datastore PRIVATE "datamanager.cpp" "datamanager.h" "api.h")
+target_sources(HealthGPS.Datastore PRIVATE "api.h" "datamanager.cpp" "datamanager.h" "schema.cpp"
+                                           "schema.h")
 
 target_link_libraries(HealthGPS.Datastore PRIVATE HealthGPS.Core fmt::fmt jsoncons)
 

--- a/src/HealthGPS.Datastore/datamanager.cpp
+++ b/src/HealthGPS.Datastore/datamanager.cpp
@@ -45,13 +45,15 @@ nlohmann::json read_input_files_from_directory(const std::filesystem::path &root
 namespace hgps::data {
 DataManager::DataManager(std::filesystem::path path, VerboseMode verbosity)
     : verbosity_{verbosity} {
-    if (std::filesystem::is_regular_file(path)) {
+    if (std::filesystem::is_directory(path)) {
+        root_ = std::move(path);
+    } else if (std::filesystem::is_regular_file(path) && path.extension() == ".zip") {
         // If it's a file, assume it's a zip file
         root_ = create_temporary_directory();
         extract_zip_file(path, root_);
     } else {
-        // Otherwise it's a folder
-        root_ = std::move(path);
+        throw std::runtime_error(
+            fmt::format("Path must either point to a zip file or a directory: {}", path.string()));
     }
 
     index_ = read_input_files_from_directory(root_);

--- a/src/HealthGPS.Datastore/schema.cpp
+++ b/src/HealthGPS.Datastore/schema.cpp
@@ -1,0 +1,51 @@
+#include "schema.h"
+
+#include <fmt/format.h>
+#include <jsoncons/json.hpp>
+#include <jsoncons_ext/jsonschema/jsonschema.hpp>
+
+#include <fstream>
+
+namespace hgps::data {
+using namespace jsoncons;
+
+json resolve_uri(const jsoncons::uri &uri, const std::filesystem::path &schema_directory) {
+    constexpr const char *url_prefix =
+        "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/";
+
+    const auto &uri_str = uri.string();
+    if (!uri_str.starts_with(url_prefix)) {
+        throw std::runtime_error(fmt::format("Unable to load URL: {}", uri_str));
+    }
+
+    // Strip URL prefix and load file from local filesystem
+    const auto filename = std::filesystem::path{uri.path()}.filename();
+    const auto schema_path = schema_directory / filename;
+    auto ifs = std::ifstream{schema_path};
+    if (!ifs) {
+        throw std::runtime_error("Failed to read schema file");
+    }
+
+    return json::parse(ifs);
+}
+
+void validate_index(const std::filesystem::path &schema_directory, std::istream &index_stream) {
+    // **YUCK**: We have to read in the data with jsoncons here rather than reusing
+    // the nlohmann-json representation :-(
+    const auto index = json::parse(index_stream);
+
+    // Load schema
+    auto ifs_schema = std::ifstream{schema_directory / "data_index.json"};
+    if (!ifs_schema) {
+        throw std::runtime_error("Failed to load schema");
+    }
+
+    const auto resolver = [&schema_directory](const auto &uri) {
+        return resolve_uri(uri, schema_directory);
+    };
+    const auto schema = jsonschema::make_json_schema(json::parse(ifs_schema), resolver);
+
+    // Perform validation
+    schema.validate(index);
+}
+} // namespace hgps::data

--- a/src/HealthGPS.Datastore/schema.h
+++ b/src/HealthGPS.Datastore/schema.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <filesystem>
+#include <istream>
+
+namespace hgps::data {
+/// @brief Validate the index.json file
+/// @param schema_directory The root folder for JSON schemas
+/// @param index_stream The input stream for the index.json file
+void validate_index(const std::filesystem::path &schema_directory, std::istream &index_stream);
+} // namespace hgps::data

--- a/src/HealthGPS.Datastore/zip_file.cpp
+++ b/src/HealthGPS.Datastore/zip_file.cpp
@@ -1,0 +1,55 @@
+#include "zip_file.h"
+
+#include <fmt/format.h>
+#include <libzippp.h>
+
+#include <fstream>
+#include <random>
+
+namespace hgps::data {
+std::filesystem::path create_temporary_directory() {
+    auto tmp_dir = std::filesystem::temp_directory_path();
+    std::random_device dev;
+    std::mt19937 prng(dev());
+    std::uniform_int_distribution<unsigned> rand;
+    std::filesystem::path path;
+
+    while (true) {
+        std::stringstream ss;
+        ss << std::hex << rand(prng);
+        path = tmp_dir / ss.str();
+        // true if the directory was created.
+        if (std::filesystem::create_directory(path)) {
+            return path;
+        }
+    }
+}
+
+void extract_zip_file(const std::filesystem::path &file_path,
+                      const std::filesystem::path &output_directory) {
+
+    using namespace libzippp;
+
+    ZipArchive zf(file_path);
+    zf.open();
+
+    std::filesystem::path out_path;
+    for (const auto &entry : zf.getEntries()) {
+        out_path = output_directory / entry.getName();
+        if (entry.isDirectory()) {
+            if (!std::filesystem::create_directories(out_path)) {
+                throw std::runtime_error{
+                    fmt::format("Failed to create directory: {}", out_path.string())};
+            }
+        } else {
+            std::ofstream ofs{out_path};
+            if (!ofs) {
+                throw std::runtime_error{
+                    fmt::format("Failed to create file: {}", out_path.string())};
+            }
+
+            ofs << entry.readAsText();
+        }
+    }
+}
+} // namespace hgps::data

--- a/src/HealthGPS.Datastore/zip_file.cpp
+++ b/src/HealthGPS.Datastore/zip_file.cpp
@@ -30,7 +30,7 @@ void extract_zip_file(const std::filesystem::path &file_path,
 
     using namespace libzippp;
 
-    ZipArchive zf(file_path);
+    ZipArchive zf(file_path.string());
     zf.open();
 
     std::filesystem::path out_path;

--- a/src/HealthGPS.Datastore/zip_file.h
+++ b/src/HealthGPS.Datastore/zip_file.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <filesystem>
+
+namespace hgps::data {
+//! Create a temporary directory with a unique path
+std::filesystem::path create_temporary_directory();
+
+/// @brief Extract a zip file to the specified location
+/// @param file_path The path to the zip file
+/// @param output_directory The path to the output folder
+void extract_zip_file(const std::filesystem::path &file_path,
+                      const std::filesystem::path &output_directory);
+} // namespace hgps::data

--- a/src/HealthGPS.Tests/Datastore.Test.cpp
+++ b/src/HealthGPS.Tests/Datastore.Test.cpp
@@ -19,9 +19,9 @@ TEST_F(DatastoreTest, CreateDataManager) {
 }
 
 TEST_F(DatastoreTest, CreateDataManagerFailWithWrongPath) {
-    EXPECT_THROW(hgps::data::DataManager{"C:\\x\\y"}, std::invalid_argument);
-    EXPECT_THROW(hgps::data::DataManager{"C:/x/y"}, std::invalid_argument);
-    EXPECT_THROW(hgps::data::DataManager{"/home/x/y/z"}, std::invalid_argument);
+    EXPECT_THROW(hgps::data::DataManager{"C:\\x\\y"}, std::runtime_error);
+    EXPECT_THROW(hgps::data::DataManager{"C:/x/y"}, std::runtime_error);
+    EXPECT_THROW(hgps::data::DataManager{"/home/x/y/z"}, std::runtime_error);
 }
 
 TEST_F(DatastoreTest, CountryMissingThrowsException) {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -14,7 +14,8 @@
         "rapidcsv",
         "crossguid",
         "gtest",
-        "tbb"
+        "tbb",
+        "libzippp"
     ],
     "builtin-baseline": "bd2b54836beed96e1efbe9aaf8ee800f5448856d"
 }


### PR DESCRIPTION
This PR adds the option to provide the input data as a path to a zip file rather than to a directory, e.g.:

```
HealthGPS.Console -f example_new/Config.json -s data_file.zip
```

Note that the `index.json` file must be in the root folder of the zip file otherwise it won't work.

While this feature isn't particularly useful by itself, it's a necessary step to being able to automatically download input data from a URL (#364).

I haven't added tests yet because the input files are likely to be moved out of this repo soon (#366), so I'll wait until we know what the final project structure looks like first. I didn't want to commit a zip file to the repo either if its contents are likely to change soon.

I've also broken out the schema-related code into its own `.cpp` file as `datamanager.cpp` was getting a bit bloated.

Closes #363.