### PR TITLE
Remove pointless `version` property from data `index.json` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The code in this repository is licensed under the [BSD 3-Clause](LICENSE.txt) li
 | [eigen](https://eigen.tuxfamily.org)                  | MPL2         |
 | [fmt](https://github.com/fmtlib/fmt)                  | MIT          |
 | [nlohmann-json](https://github.com/nlohmann/json)     | MIT          |
+| [jsoncons](https://github.com/danielaparker/jsoncons) | Boost        |
 | [rapidcsv](https://github.com/d99kris/rapidcsv)       | BSD 3-Clause |
 | [oneAPI TBB](https://github.com/oneapi-src/oneTBB)    | Apache 2.0   |
 | [libzippp](https://github.com/ctabin/libzippp)        | MIT          |

--- a/data/index.json
+++ b/data/index.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/data_index.json",
     "version": 2,
     "country": {
         "format": "csv",

--- a/data/index.json
+++ b/data/index.json
@@ -1,6 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/data_index.json",
-    "version": 2,
     "country": {
         "format": "csv",
         "delimiter": ",",

--- a/schemas/v1/data_index.json
+++ b/schemas/v1/data_index.json
@@ -5,6 +5,9 @@
     "description": "Metadata and paths for Health-GPS input files",
     "type": "object",
     "properties": {
+        "$schema": {
+            "const": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/data_index.json"
+        },
         "version": { "const": 2 },
         "country": {
             "allOf": [

--- a/schemas/v1/data_index.json
+++ b/schemas/v1/data_index.json
@@ -8,7 +8,6 @@
         "$schema": {
             "const": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/data_index.json"
         },
-        "version": { "const": 2 },
         "country": {
             "allOf": [
                 {

--- a/schemas/v1/data_index.json
+++ b/schemas/v1/data_index.json
@@ -5,9 +5,6 @@
     "description": "Metadata and paths for Health-GPS input files",
     "type": "object",
     "properties": {
-        "$schema": {
-            "const": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/data_index.json"
-        },
         "country": {
             "allOf": [
                 {

--- a/src/HealthGPS.Datastore/datamanager.cpp
+++ b/src/HealthGPS.Datastore/datamanager.cpp
@@ -21,17 +21,8 @@ nlohmann::json read_input_files_from_directory(const std::filesystem::path &root
             fmt::format("File-based store, index file: '{}' not found.", full_filename.string()));
     }
 
+    // Read in JSON file
     auto index = nlohmann::json::parse(ifs);
-
-    if (!index.contains("version")) {
-        throw std::runtime_error("File-based store, invalid definition missing schema version");
-    }
-
-    auto version = index["version"].get<int>();
-    if (version != 2) {
-        throw std::runtime_error(fmt::format(
-            "File-based store, index schema version: {} mismatch, supported: 2", version));
-    }
 
     // Validate against schema
     ifs.seekg(0);

--- a/src/HealthGPS.Datastore/datamanager.cpp
+++ b/src/HealthGPS.Datastore/datamanager.cpp
@@ -24,6 +24,18 @@ nlohmann::json read_input_files_from_directory(const std::filesystem::path &root
     // Read in JSON file
     auto index = nlohmann::json::parse(ifs);
 
+    // Check that the file has a $schema property and that it matches the URL of the
+    // schema version we support
+    if (!index.contains("$schema")) {
+        throw std::runtime_error(fmt::format("Index file missing required $schema property: {}",
+                                             full_filename.string()));
+    }
+    const auto schema_url = index.at("$schema").get<std::string>();
+    if (schema_url != HGPS_DATA_INDEX_SCHEMA_URL) {
+        throw std::runtime_error(fmt::format("Invalid schema URL provided: {} (expected: {})",
+                                             schema_url, HGPS_DATA_INDEX_SCHEMA_URL));
+    }
+
     // Validate against schema
     ifs.seekg(0);
     const auto schema_directory = hgps::get_program_directory() / "schemas" / "v1";

--- a/src/HealthGPS.Datastore/schema.cpp
+++ b/src/HealthGPS.Datastore/schema.cpp
@@ -10,11 +10,8 @@ namespace hgps::data {
 using namespace jsoncons;
 
 json resolve_uri(const jsoncons::uri &uri, const std::filesystem::path &schema_directory) {
-    constexpr const char *url_prefix =
-        "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/";
-
     const auto &uri_str = uri.string();
-    if (!uri_str.starts_with(url_prefix)) {
+    if (!uri_str.starts_with(HGPS_SCHEMA_URL_PREFIX)) {
         throw std::runtime_error(fmt::format("Unable to load URL: {}", uri_str));
     }
 

--- a/src/HealthGPS.Datastore/schema.h
+++ b/src/HealthGPS.Datastore/schema.h
@@ -3,6 +3,16 @@
 #include <filesystem>
 #include <istream>
 
+//! The prefix for Health-GPS schema URLs
+#define HGPS_SCHEMA_URL_PREFIX                                                                     \
+    "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/"
+
+//! The name of the index.json schema file
+#define HGPS_DATA_INDEX_SCHEMA_FILENAME "data_index.json"
+
+//! The schema URL for the data index file
+#define HGPS_DATA_INDEX_SCHEMA_URL (HGPS_SCHEMA_URL_PREFIX HGPS_DATA_INDEX_SCHEMA_FILENAME)
+
 namespace hgps::data {
 /// @brief Validate the index.json file
 /// @param schema_directory The root folder for JSON schemas


### PR DESCRIPTION
This PR removes the pointless `version` property, as discussed.

I've also opted to add a `$schema` property in its place which is the standard way to indicate which schema should be used for a JSON document.

Closes #399.