### PR TITLE
Make properties required for JSON schema

### DIFF
--- a/schemas/v1/data_index.json
+++ b/schemas/v1/data_index.json
@@ -12,9 +12,8 @@
                 },
                 {
                     "type": "object",
-                    "properties": {
-                        "file_name": { "type": "string" }
-                    }
+                    "properties": { "file_name": { "type": "string" } },
+                    "required": ["file_name"]
                 }
             ]
         },
@@ -51,7 +50,8 @@
                                 "description": { "type": "string" },
                                 "path": { "type": "string" },
                                 "file_name": { "type": "string" }
-                            }
+                            },
+                            "required": ["description", "path", "file_name"]
                         },
                         "mortality": {
                             "type": "object",
@@ -59,9 +59,17 @@
                                 "description": { "type": "string" },
                                 "path": { "type": "string" },
                                 "file_name": { "type": "string" }
-                            }
+                            },
+                            "required": ["description", "path", "file_name"]
                         }
-                    }
+                    },
+                    "required": [
+                        "age_limits",
+                        "time_limits",
+                        "projections",
+                        "population",
+                        "mortality"
+                    ]
                 }
             ]
         },
@@ -102,7 +110,12 @@
                                                 "default_value": {
                                                     "type": "number"
                                                 }
-                                            }
+                                            },
+                                            "required": [
+                                                "path",
+                                                "file_name",
+                                                "default_value"
+                                            ]
                                         },
                                         "to_risk_factor": {
                                             "type": "object",
@@ -111,7 +124,8 @@
                                                 "file_name": {
                                                     "type": "string"
                                                 }
-                                            }
+                                            },
+                                            "required": ["path", "file_name"]
                                         },
                                         "parameters": {
                                             "type": "object",
@@ -129,13 +143,26 @@
                                                         "death_weight": {
                                                             "type": "string"
                                                         }
-                                                    }
+                                                    },
+                                                    "required": [
+                                                        "distribution",
+                                                        "survival_rate",
+                                                        "death_weight"
+                                                    ]
                                                 }
-                                            }
+                                            },
+                                            "required": ["path", "files"]
                                         }
-                                    }
+                                    },
+                                    "required": [
+                                        "path",
+                                        "to_disease",
+                                        "to_risk_factor",
+                                        "parameters"
+                                    ]
                                 }
-                            }
+                            },
+                            "required": ["path", "file_name", "relative_risk"]
                         },
                         "registry": {
                             "type": "array",
@@ -145,10 +172,17 @@
                                     "group": { "enum": ["other", "cancer"] },
                                     "id": { "type": "string" },
                                     "name": { "type": "string" }
-                                }
+                                },
+                                "required": ["group", "id", "name"]
                             }
                         }
-                    }
+                    },
+                    "required": [
+                        "age_limits",
+                        "time_year",
+                        "disease",
+                        "registry"
+                    ]
                 }
             ]
         },
@@ -177,11 +211,20 @@
                             "properties": {
                                 "path": { "type": "string" },
                                 "file_name": { "type": "string" }
-                            }
+                            },
+                            "required": ["path", "file_name"]
                         }
-                    }
+                    },
+                    "required": [
+                        "age_limits",
+                        "time_year",
+                        "disability_file_name",
+                        "lms_file_name",
+                        "cost_of_disease"
+                    ]
                 }
             ]
         }
-    }
+    },
+    "required": ["country", "demographic", "diseases", "analysis"]
 }

--- a/schemas/v1/data_index.json
+++ b/schemas/v1/data_index.json
@@ -126,43 +126,47 @@
                                                 }
                                             },
                                             "required": ["path", "file_name"]
-                                        },
-                                        "parameters": {
-                                            "type": "object",
-                                            "properties": {
-                                                "path": { "type": "string" },
-                                                "files": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "distribution": {
-                                                            "type": "string"
-                                                        },
-                                                        "survival_rate": {
-                                                            "type": "string"
-                                                        },
-                                                        "death_weight": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "distribution",
-                                                        "survival_rate",
-                                                        "death_weight"
-                                                    ]
-                                                }
-                                            },
-                                            "required": ["path", "files"]
                                         }
                                     },
                                     "required": [
                                         "path",
                                         "to_disease",
-                                        "to_risk_factor",
-                                        "parameters"
+                                        "to_risk_factor"
                                     ]
+                                },
+                                "parameters": {
+                                    "type": "object",
+                                    "properties": {
+                                        "path": { "type": "string" },
+                                        "files": {
+                                            "type": "object",
+                                            "properties": {
+                                                "distribution": {
+                                                    "type": "string"
+                                                },
+                                                "survival_rate": {
+                                                    "type": "string"
+                                                },
+                                                "death_weight": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "distribution",
+                                                "survival_rate",
+                                                "death_weight"
+                                            ]
+                                        }
+                                    },
+                                    "required": ["path", "files"]
                                 }
                             },
-                            "required": ["path", "file_name", "relative_risk"]
+                            "required": [
+                                "path",
+                                "file_name",
+                                "relative_risk",
+                                "parameters"
+                            ]
                         },
                         "registry": {
                             "type": "array",

--- a/schemas/v1/file_info.json
+++ b/schemas/v1/file_info.json
@@ -11,5 +11,6 @@
         "url": { "type": "string", "format": "uri" },
         "license": { "type": "string" },
         "path": { "type": "string" }
-    }
+    },
+    "required": ["path"]
 }


### PR DESCRIPTION
For `file_info.json` I made only the `path` property required, because we don't actually use the others anywhere in the code (though they may be useful metadata).

In the process, I discovered that one field was in the wrong section (it's hard to keep track of all those curly brackets!), so I've fixed that too.

I used the following script to make all properties for `data_index.json` required:

```py
import json
import sys


def add_required(d: dict):
    required = []
    for key, value in d.items():
        if isinstance(value, dict):
            add_required(value)
        if isinstance(value, list):
            for v in value:
                if isinstance(v, dict):
                    add_required(v)
        if key == "properties":
            required = list(k for k in d['properties'].keys() if k != "$schema")
    
    if required:
        d['required'] = required
        # d['additionalProperties'] = False


def process_file(path):
    with open(path) as f:
        d = json.load(f)
    
    add_required(d)

    with open(path, 'w') as f:
        json.dump(d, f)


if __name__ == '__main__':
    for path in sys.argv[1:]:
        process_file(path)
```

Making `additionalProperties` `false` seemed to break validation for some reason, so I've omitted it for now because it's less important.

Closes #403.