### PR TITLE
CI: Add caching of vcpkg artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
     env:
       VCPKG_ROOT: "vcpkg"
-      VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
       # Update when there is a new version of gcc available
       LATEST_GCC_VERSION: 13
@@ -62,6 +62,13 @@ jobs:
 
           # Use environment variable to tell CMake to compile with this version of gcc
           echo CXX=g++-$LATEST_GCC_VERSION >> "$GITHUB_ENV"
+
+      - name: Export GitHub Actions cache environment variables
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Install VCPKG
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
   release:
     types: [published]
-    branches: [main]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
I followed Microsoft's guide here: https://learn.microsoft.com/en-us/vcpkg/consume/binary-caching-github-actions-cache

I've confirmed that it works by looking at the workflow logs. It seems to reduce the time taken for the CI jobs to run from ~20 mins to ~10 mins, so it's def a win!

Closes #411.