### PR TITLE
Colourise compiler output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,13 @@ else()
     if(WARNINGS_AS_ERRORS)
         add_compile_options(-Werror)
     endif()
+
+    # Colourise compiler output
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        add_compile_options(-fdiagnostics-color=always)
+    elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        add_compile_options(-fcolor-diagnostics)
+    endif()
 endif()
 
 include(CTest)


### PR DESCRIPTION
Normally, the fact that the compiler output is piped through cmake means that colours are turned off by default. Explicitly enable them for the sake of readability.

Handy for spotting warnings/errors on your local machine.