### PR TITLE
CI: Reinstate dependabot's permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   release:
     types: [published]
-  pull_request:
+  pull_request_target:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up MSVC (Windows)
         if: matrix.platform == 'windows'


### PR DESCRIPTION
It seems that dependabot no longer has write permissions for GitHub tokens by default. This can be worked around by changing the "on" field from "pull_request" to "pull_request_target".

NB: I haven't actually been able to test this, but according to the upstream developers, this is how you can fix the problem.

Fixes #409.

See: https://github.com/dependabot/dependabot-core/issues/3253