### PR TITLE
CI: Don't run clang-tidy checks for dependabot PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,21 @@
+name: Dependabot and Pre-commit auto-merge
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write # Needed if in a private repository
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' || github.actor == 'pre-commit-ci[bot]' }}
+    steps:
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          # GitHub provides this variable in the CI env. You don't
+          # need to add anything to the secrets vault.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,18 +80,18 @@ jobs:
           cmake --preset=${{ matrix.platform }}-debug -DWARNINGS_AS_ERRORS=ON -DGENERATE_COVERAGE=ON
 
       - uses: ZedThree/clang-tidy-review@v0.13.1
-        if: matrix.compiler == 'gcc-default' && github.event_name == 'pull_request'
+        if: matrix.compiler == 'gcc-default' && github.event_name == 'pull_request' && !(github.actor == 'dependabot[bot]' && github.actor == 'pre-commit-ci[bot]')
         id: review
         with:
           build_dir: out/build/linux-debug
 
       # Uploads an artefact containing clang_fixes.json
       - uses: ZedThree/clang-tidy-review/upload@v0.13.1
-        if: matrix.compiler == 'gcc-default' && github.event_name == 'pull_request'
+        if: matrix.compiler == 'gcc-default' && github.event_name == 'pull_request' && !(github.actor == 'dependabot[bot]' && github.actor == 'pre-commit-ci[bot]')
         id: upload-review
 
       # If there are any comments, fail the check
-      - if: steps.review.outputs.total_comments > 0 && matrix.compiler == 'gcc-default' && github.event_name == 'pull_request'
+      - if: steps.review.outputs.total_comments > 0 && matrix.compiler == 'gcc-default' && !(github.actor == 'dependabot[bot]' && github.actor == 'pre-commit-ci[bot]')
         run: exit 1
 
       - uses: ammaraskar/gcc-problem-matcher@master


### PR DESCRIPTION
Ok, here's my less horribly insecure attempt at fixing this. If we just don't run the `clang-tidy` checks for PRs from bots, that should fix things.

While I was at it, I borrowed Adrian's workflow for auto-merging bot PRs, because I thought that would be useful.

Fixes #409. Closes #410.