### PR TITLE
Purge unnecessary `DataManager` checks

### DIFF
--- a/src/HealthGPS.Core/datastore.h
+++ b/src/HealthGPS.Core/datastore.h
@@ -57,9 +57,10 @@ class Datastore {
     /// @brief Gets the relative risk effects for disease to disease interactions
     /// @param source The source disease information
     /// @param target The target disease information
-    /// @return The disease-disease effects
-    virtual RelativeRiskEntity get_relative_risk_to_disease(const DiseaseInfo &source,
-                                                            const DiseaseInfo &target) const = 0;
+    /// @return The disease-disease effects or std::nullopt if file doesn't exist or only contains
+    ///         default values
+    virtual std::optional<RelativeRiskEntity>
+    get_relative_risk_to_disease(const DiseaseInfo &source, const DiseaseInfo &target) const = 0;
 
     /// @brief Gets the relative risk effects for risk factor to disease interactions
     /// @param source The disease information

--- a/src/HealthGPS.Core/datastore.h
+++ b/src/HealthGPS.Core/datastore.h
@@ -2,6 +2,8 @@
 
 #include "interval.h"
 #include "poco.h"
+
+#include <optional>
 #include <vector>
 
 namespace hgps::core {
@@ -63,8 +65,8 @@ class Datastore {
     /// @param source The disease information
     /// @param gender The gender enumeration
     /// @param risk_factor_key The risk factor identifier
-    /// @return The risk factor-disease effects, check empty() = true for missing data.
-    virtual RelativeRiskEntity
+    /// @return The risk factor-disease effects or std::nullopt if data missing
+    virtual std::optional<RelativeRiskEntity>
     get_relative_risk_to_risk_factor(const DiseaseInfo &source, Gender gender,
                                      const Identifier &risk_factor_key) const = 0;
 

--- a/src/HealthGPS.Core/datastore.h
+++ b/src/HealthGPS.Core/datastore.h
@@ -51,13 +51,13 @@ class Datastore {
     /// @brief Gets a disease full definition by identifier for a country
     /// @param info The target disease information
     /// @param country The target country definition
-    /// @return The disease definition, check empty() = true for missing data.
+    /// @return The disease definition
     virtual DiseaseEntity get_disease(const DiseaseInfo &info, const Country &country) const = 0;
 
     /// @brief Gets the relative risk effects for disease to disease interactions
     /// @param source The source disease information
     /// @param target The target disease information
-    /// @return The disease-disease effects, check empty() = true for missing data.
+    /// @return The disease-disease effects
     virtual RelativeRiskEntity get_relative_risk_to_disease(const DiseaseInfo &source,
                                                             const DiseaseInfo &target) const = 0;
 
@@ -73,13 +73,13 @@ class Datastore {
     /// @brief Gets the parameters required by cancer type diseases for a country
     /// @param info The disease of type cancer information
     /// @param country The target country definition
-    /// @return The cancer parameters, check empty() = true for missing data.
+    /// @return The cancer parameters
     virtual CancerParameterEntity get_disease_parameter(const DiseaseInfo &info,
                                                         const Country &country) const = 0;
 
     /// @brief Gets the Burden of Diseases (BoD) analysis dataset for a country
     /// @param country The target country definition
-    /// @return The BoD analysis data, check empty() = true for missing data.
+    /// @return The BoD analysis data
     virtual DiseaseAnalysisEntity get_disease_analysis(const Country &country) const = 0;
 
     /// @brief Gets the population birth indicators for a country filtered by time

--- a/src/HealthGPS.Core/disease.h
+++ b/src/HealthGPS.Core/disease.h
@@ -70,9 +70,6 @@ struct DiseaseEntity {
 
 /// @brief Diseases relative risk effect table data structure
 struct RelativeRiskEntity {
-    /// @brief Value indicating whether the rows contain default value only.
-    bool is_default_value{};
-
     /// @brief The table column identifiers
     std::vector<std::string> columns;
 

--- a/src/HealthGPS.Datastore/datamanager.cpp
+++ b/src/HealthGPS.Datastore/datamanager.cpp
@@ -17,7 +17,7 @@ nlohmann::json read_input_files_from_directory(const std::filesystem::path &root
     auto full_filename = root_directory / "index.json";
     auto ifs = std::ifstream{full_filename};
     if (!ifs) {
-        throw std::invalid_argument(
+        throw std::runtime_error(
             fmt::format("File-based store, index file: '{}' not found.", full_filename.string()));
     }
 
@@ -104,7 +104,7 @@ Country DataManager::get_country(const std::string &alpha) const {
         return *country;
     }
 
-    throw std::invalid_argument(fmt::format("Target country: '{}' not found.", alpha));
+    throw std::runtime_error(fmt::format("Target country: '{}' not found.", alpha));
 }
 
 std::vector<PopulationItem> DataManager::get_population(const Country &country) const {
@@ -257,7 +257,7 @@ DiseaseInfo DataManager::get_disease_info(const core::Identifier &code) const {
             }
         }
 
-        throw std::invalid_argument(fmt::format("Disease code: '{}' not found.", code.to_string()));
+        throw std::runtime_error(fmt::format("Disease code: '{}' not found.", code.to_string()));
     }
 
     throw std::runtime_error("Index has no 'diseases' entry.");

--- a/src/HealthGPS.Datastore/datamanager.cpp
+++ b/src/HealthGPS.Datastore/datamanager.cpp
@@ -393,13 +393,12 @@ RelativeRiskEntity DataManager::get_relative_risk_to_disease(const DiseaseInfo &
     return {};
 }
 
-RelativeRiskEntity
+std::optional<RelativeRiskEntity>
 DataManager::get_relative_risk_to_risk_factor(const DiseaseInfo &source, Gender gender,
                                               const core::Identifier &risk_factor_key) const {
-    auto table = RelativeRiskEntity();
     if (!index_.contains("diseases")) {
         notify_warning("index has no 'diseases' entry.");
-        return table;
+        return std::nullopt;
     }
 
     // Creates full file name from store configuration
@@ -425,12 +424,12 @@ DataManager::get_relative_risk_to_risk_factor(const DiseaseInfo &source, Gender 
     if (!std::filesystem::exists(filename)) {
         notify_warning(fmt::format("{} to {} relative risk file not found, disabled.",
                                    source_code_str, factor_key_str));
-        return table;
+        return std::nullopt;
     }
 
     rapidcsv::Document doc(filename);
-    table.is_default_value = false;
-    table.columns = doc.GetColumnNames();
+    auto table =
+        RelativeRiskEntity{.is_default_value = false, .columns = doc.GetColumnNames(), .rows = {}};
     auto row_size = table.columns.size();
     for (size_t i = 0; i < doc.GetRowCount(); i++) {
         auto row = doc.GetRow<std::string>(i);

--- a/src/HealthGPS.Datastore/datamanager.cpp
+++ b/src/HealthGPS.Datastore/datamanager.cpp
@@ -64,30 +64,26 @@ DataManager::DataManager(std::filesystem::path path, VerboseMode verbosity)
 
 std::vector<Country> DataManager::get_countries() const {
     auto results = std::vector<Country>();
-    if (index_.contains("country")) {
-        auto filepath = index_["country"]["path"].get<std::string>();
-        auto filename = index_["country"]["file_name"].get<std::string>();
-        filename = (root_ / filepath / filename).string();
+    auto filepath = index_["country"]["path"].get<std::string>();
+    auto filename = index_["country"]["file_name"].get<std::string>();
+    filename = (root_ / filepath / filename).string();
 
-        if (std::filesystem::exists(filename)) {
-            rapidcsv::Document doc(filename);
-            auto mapping = create_fields_index_mapping(doc.GetColumnNames(),
-                                                       {"Code", "Name", "Alpha2", "Alpha3"});
-            for (size_t i = 0; i < doc.GetRowCount(); i++) {
-                auto row = doc.GetRow<std::string>(i);
-                results.push_back(Country{.code = std::stoi(row[mapping["Code"]]),
-                                          .name = row[mapping["Name"]],
-                                          .alpha2 = row[mapping["Alpha2"]],
-                                          .alpha3 = row[mapping["Alpha3"]]});
-            }
-
-            std::sort(results.begin(), results.end());
-        } else {
-            notify_warning(fmt::format("countries file: '{}' not found.", filename));
-        }
-    } else {
-        notify_warning("index has no 'country' entry.");
+    if (!std::filesystem::exists(filename)) {
+        throw std::runtime_error(fmt::format("countries file: '{}' not found.", filename));
     }
+
+    rapidcsv::Document doc(filename);
+    auto mapping =
+        create_fields_index_mapping(doc.GetColumnNames(), {"Code", "Name", "Alpha2", "Alpha3"});
+    for (size_t i = 0; i < doc.GetRowCount(); i++) {
+        auto row = doc.GetRow<std::string>(i);
+        results.push_back(Country{.code = std::stoi(row[mapping["Code"]]),
+                                  .name = row[mapping["Name"]],
+                                  .alpha2 = row[mapping["Alpha2"]],
+                                  .alpha3 = row[mapping["Alpha3"]]});
+    }
+
+    std::sort(results.begin(), results.end());
 
     return results;
 }
@@ -100,11 +96,11 @@ Country DataManager::get_country(const std::string &alpha) const {
     };
 
     auto country = std::find_if(c.begin(), c.end(), is_target);
-    if (country != c.end()) {
-        return *country;
+    if (country == c.end()) {
+        throw std::runtime_error(fmt::format("Target country: '{}' not found.", alpha));
     }
 
-    throw std::runtime_error(fmt::format("Target country: '{}' not found.", alpha));
+    return *country;
 }
 
 std::vector<PopulationItem> DataManager::get_population(const Country &country) const {
@@ -116,44 +112,40 @@ DataManager::get_population(const Country &country,
                             std::function<bool(unsigned int)> time_filter) const {
     auto results = std::vector<PopulationItem>();
 
-    if (index_.contains("demographic")) {
-        auto nodepath = index_["demographic"]["path"].get<std::string>();
-        auto filepath = index_["demographic"]["population"]["path"].get<std::string>();
-        auto filename = index_["demographic"]["population"]["file_name"].get<std::string>();
+    auto nodepath = index_["demographic"]["path"].get<std::string>();
+    auto filepath = index_["demographic"]["population"]["path"].get<std::string>();
+    auto filename = index_["demographic"]["population"]["file_name"].get<std::string>();
 
-        // Tokenized file names X{country.code}X.xxx
-        filename = replace_string_tokens(filename, {std::to_string(country.code)});
-        filename = (root_ / nodepath / filepath / filename).string();
+    // Tokenized file names X{country.code}X.xxx
+    filename = replace_string_tokens(filename, {std::to_string(country.code)});
+    filename = (root_ / nodepath / filepath / filename).string();
 
-        // LocID,Location,VarID,Variant,Time,MidPeriod,AgeGrp,AgeGrpStart,AgeGrpSpan,PopMale,PopFemale,PopTotal
-        if (std::filesystem::exists(filename)) {
-            rapidcsv::Document doc(filename);
-            auto mapping = create_fields_index_mapping(
-                doc.GetColumnNames(), {"LocID", "Time", "Age", "PopMale", "PopFemale", "PopTotal"});
-
-            for (size_t i = 0; i < doc.GetRowCount(); i++) {
-                auto row = doc.GetRow<std::string>(i);
-                auto row_time = std::stoi(row[mapping["Time"]]);
-                if (!time_filter(row_time)) {
-                    continue;
-                }
-
-                results.push_back(PopulationItem{.location_id = std::stoi(row[mapping["LocID"]]),
-                                                 .at_time = row_time,
-                                                 .with_age = std::stoi(row[mapping["Age"]]),
-                                                 .males = std::stof(row[mapping["PopMale"]]),
-                                                 .females = std::stof(row[mapping["PopFemale"]]),
-                                                 .total = std::stof(row[mapping["PopTotal"]])});
-            }
-
-            std::sort(results.begin(), results.end());
-        } else {
-            notify_warning(
-                fmt::format("{} population file: '{}' not found.", country.name, filename));
-        }
-    } else {
-        notify_warning("index has no 'demographic' entry.");
+    // LocID,Location,VarID,Variant,Time,MidPeriod,AgeGrp,AgeGrpStart,AgeGrpSpan,PopMale,PopFemale,PopTotal
+    if (!std::filesystem::exists(filename)) {
+        throw std::runtime_error(
+            fmt::format("{} population file: '{}' not found.", country.name, filename));
     }
+
+    rapidcsv::Document doc(filename);
+    auto mapping = create_fields_index_mapping(
+        doc.GetColumnNames(), {"LocID", "Time", "Age", "PopMale", "PopFemale", "PopTotal"});
+
+    for (size_t i = 0; i < doc.GetRowCount(); i++) {
+        auto row = doc.GetRow<std::string>(i);
+        auto row_time = std::stoi(row[mapping["Time"]]);
+        if (!time_filter(row_time)) {
+            continue;
+        }
+
+        results.push_back(PopulationItem{.location_id = std::stoi(row[mapping["LocID"]]),
+                                         .at_time = row_time,
+                                         .with_age = std::stoi(row[mapping["Age"]]),
+                                         .males = std::stof(row[mapping["PopMale"]]),
+                                         .females = std::stof(row[mapping["PopFemale"]]),
+                                         .total = std::stof(row[mapping["PopTotal"]])});
+    }
+
+    std::sort(results.begin(), results.end());
 
     return results;
 }
@@ -166,101 +158,89 @@ std::vector<MortalityItem>
 DataManager::get_mortality(const Country &country,
                            std::function<bool(unsigned int)> time_filter) const {
     auto results = std::vector<MortalityItem>();
-    if (index_.contains("demographic")) {
-        auto nodepath = index_["demographic"]["path"].get<std::string>();
-        auto filepath = index_["demographic"]["mortality"]["path"].get<std::string>();
-        auto filename = index_["demographic"]["mortality"]["file_name"].get<std::string>();
+    auto nodepath = index_["demographic"]["path"].get<std::string>();
+    auto filepath = index_["demographic"]["mortality"]["path"].get<std::string>();
+    auto filename = index_["demographic"]["mortality"]["file_name"].get<std::string>();
 
-        // Tokenized file names X{country.code}X.xxx
-        filename = replace_string_tokens(filename, {std::to_string(country.code)});
-        filename = (root_ / nodepath / filepath / filename).string();
+    // Tokenized file names X{country.code}X.xxx
+    filename = replace_string_tokens(filename, {std::to_string(country.code)});
+    filename = (root_ / nodepath / filepath / filename).string();
 
-        if (std::filesystem::exists(filename)) {
-            rapidcsv::Document doc(filename);
-            auto mapping = create_fields_index_mapping(
-                doc.GetColumnNames(),
-                {"LocID", "Time", "Age", "DeathMale", "DeathFemale", "DeathTotal"});
-            for (size_t i = 0; i < doc.GetRowCount(); i++) {
-                auto row = doc.GetRow<std::string>(i);
-                auto row_time = std::stoi(row[mapping["Time"]]);
-                if (!time_filter(row_time)) {
-                    continue;
-                }
-
-                results.push_back(MortalityItem{.location_id = std::stoi(row[mapping["LocID"]]),
-                                                .at_time = row_time,
-                                                .with_age = std::stoi(row[mapping["Age"]]),
-                                                .males = std::stof(row[mapping["DeathMale"]]),
-                                                .females = std::stof(row[mapping["DeathFemale"]]),
-                                                .total = std::stof(row[mapping["DeathTotal"]])});
-            }
-
-            std::sort(results.begin(), results.end());
-        } else {
-            notify_warning(
-                fmt::format("{} mortality file: '{}' not found.", country.name, filename));
-        }
-    } else {
-        notify_warning("index has no 'demographic' entry.");
+    if (!std::filesystem::exists(filename)) {
+        throw std::runtime_error(
+            fmt::format("{} mortality file: '{}' not found.", country.name, filename));
     }
+
+    rapidcsv::Document doc(filename);
+    auto mapping = create_fields_index_mapping(
+        doc.GetColumnNames(), {"LocID", "Time", "Age", "DeathMale", "DeathFemale", "DeathTotal"});
+    for (size_t i = 0; i < doc.GetRowCount(); i++) {
+        auto row = doc.GetRow<std::string>(i);
+        auto row_time = std::stoi(row[mapping["Time"]]);
+        if (!time_filter(row_time)) {
+            continue;
+        }
+
+        results.push_back(MortalityItem{.location_id = std::stoi(row[mapping["LocID"]]),
+                                        .at_time = row_time,
+                                        .with_age = std::stoi(row[mapping["Age"]]),
+                                        .males = std::stof(row[mapping["DeathMale"]]),
+                                        .females = std::stof(row[mapping["DeathFemale"]]),
+                                        .total = std::stof(row[mapping["DeathTotal"]])});
+    }
+
+    std::sort(results.begin(), results.end());
 
     return results;
 }
 
 std::vector<DiseaseInfo> DataManager::get_diseases() const {
     auto result = std::vector<DiseaseInfo>();
-    if (index_.contains("diseases")) {
-        const auto &registry = index_["diseases"]["registry"];
-        for (const auto &item : registry) {
-            auto info = DiseaseInfo{};
-            auto group_str = std::string{};
-            auto code_srt = std::string{};
-            item["group"].get_to(group_str);
-            item["id"].get_to(code_srt);
-            item["name"].get_to(info.name);
-            info.group = DiseaseGroup::other;
-            info.code = Identifier{code_srt};
-            if (core::case_insensitive::equals(group_str, "cancer")) {
-                info.group = DiseaseGroup::cancer;
-            }
 
-            result.emplace_back(info);
+    const auto &registry = index_["diseases"]["registry"];
+    for (const auto &item : registry) {
+        auto info = DiseaseInfo{};
+        auto group_str = std::string{};
+        auto code_srt = std::string{};
+        item["group"].get_to(group_str);
+        item["id"].get_to(code_srt);
+        item["name"].get_to(info.name);
+        info.group = DiseaseGroup::other;
+        info.code = Identifier{code_srt};
+        if (core::case_insensitive::equals(group_str, "cancer")) {
+            info.group = DiseaseGroup::cancer;
         }
 
-        std::sort(result.begin(), result.end());
-    } else {
-        notify_warning("index has no 'diseases' entry.");
+        result.emplace_back(info);
     }
+
+    std::sort(result.begin(), result.end());
 
     return result;
 }
 
 DiseaseInfo DataManager::get_disease_info(const core::Identifier &code) const {
-    if (index_.contains("diseases")) {
-        const auto &registry = index_["diseases"]["registry"];
-        const auto &disease_code_str = code.to_string();
-        auto info = DiseaseInfo{};
-        for (const auto &item : registry) {
-            auto item_code_str = std::string{};
-            item["id"].get_to(item_code_str);
-            if (item_code_str == disease_code_str) {
-                auto group_str = std::string{};
-                item["group"].get_to(group_str);
-                item["name"].get_to(info.name);
-                info.code = code;
-                info.group = DiseaseGroup::other;
-                if (core::case_insensitive::equals(group_str, "cancer")) {
-                    info.group = DiseaseGroup::cancer;
-                }
-
-                return info;
+    const auto &registry = index_["diseases"]["registry"];
+    const auto &disease_code_str = code.to_string();
+    auto info = DiseaseInfo{};
+    for (const auto &item : registry) {
+        auto item_code_str = std::string{};
+        item["id"].get_to(item_code_str);
+        if (item_code_str == disease_code_str) {
+            auto group_str = std::string{};
+            item["group"].get_to(group_str);
+            item["name"].get_to(info.name);
+            info.code = code;
+            info.group = DiseaseGroup::other;
+            if (core::case_insensitive::equals(group_str, "cancer")) {
+                info.group = DiseaseGroup::cancer;
             }
-        }
 
-        throw std::runtime_error(fmt::format("Disease code: '{}' not found.", code.to_string()));
+            return info;
+        }
     }
 
-    throw std::runtime_error("Index has no 'diseases' entry.");
+    throw std::runtime_error(fmt::format("Disease code: '{}' not found.", code.to_string()));
 }
 
 DiseaseEntity DataManager::get_disease(const DiseaseInfo &info, const Country &country) const {
@@ -268,140 +248,123 @@ DiseaseEntity DataManager::get_disease(const DiseaseInfo &info, const Country &c
     result.info = info;
     result.country = country;
 
-    if (index_.contains("diseases")) {
-        auto diseases_path = index_["diseases"]["path"].get<std::string>();
-        auto disease_folder = index_["diseases"]["disease"]["path"].get<std::string>();
-        auto filename = index_["diseases"]["disease"]["file_name"].get<std::string>();
+    auto diseases_path = index_["diseases"]["path"].get<std::string>();
+    auto disease_folder = index_["diseases"]["disease"]["path"].get<std::string>();
+    auto filename = index_["diseases"]["disease"]["file_name"].get<std::string>();
 
-        // Tokenized folder name X{info.code}X
-        disease_folder = replace_string_tokens(disease_folder, {info.code.to_string()});
+    // Tokenized folder name X{info.code}X
+    disease_folder = replace_string_tokens(disease_folder, {info.code.to_string()});
 
-        // Tokenized file names X{country.code}X.xxx
-        filename = replace_string_tokens(filename, {std::to_string(country.code)});
+    // Tokenized file names X{country.code}X.xxx
+    filename = replace_string_tokens(filename, {std::to_string(country.code)});
 
-        filename = (root_ / diseases_path / disease_folder / filename).string();
-        if (std::filesystem::exists(filename)) {
-            rapidcsv::Document doc(filename);
-
-            auto table =
-                std::unordered_map<int, std::unordered_map<core::Gender, std::map<int, double>>>();
-
-            auto mapping = create_fields_index_mapping(
-                doc.GetColumnNames(), {"age", "gender_id", "measure_id", "measure", "mean"});
-            for (size_t i = 0; i < doc.GetRowCount(); i++) {
-                auto row = doc.GetRow<std::string>(i);
-                auto age = std::stoi(row[mapping["age"]]);
-                auto gender = static_cast<core::Gender>(std::stoi(row[mapping["gender_id"]]));
-                auto measure_id = std::stoi(row[mapping["measure_id"]]);
-                auto measure_name = core::to_lower(row[mapping["measure"]]);
-                auto measure_value = std::stod(row[mapping["mean"]]);
-
-                if (!result.measures.contains(measure_name)) {
-                    result.measures.emplace(measure_name, measure_id);
-                }
-
-                if (!table[age].contains(gender)) {
-                    table[age].emplace(gender, std::map<int, double>{});
-                }
-
-                table[age][gender][measure_id] = measure_value;
-            }
-
-            for (auto &pair : table) {
-                for (auto &child : pair.second) {
-                    result.items.emplace_back(DiseaseItem{
-                        .with_age = pair.first, .gender = child.first, .measures = child.second});
-                }
-            }
-
-            result.items.shrink_to_fit();
-        } else {
-            notify_warning(
-                fmt::format("{}, {} file: '{}' not found.", country.name, info.name, filename));
-        }
-    } else {
-        notify_warning("index has no 'diseases' entry.");
+    filename = (root_ / diseases_path / disease_folder / filename).string();
+    if (!std::filesystem::exists(filename)) {
+        throw std::runtime_error(
+            fmt::format("{}, {} file: '{}' not found.", country.name, info.name, filename));
     }
+
+    rapidcsv::Document doc(filename);
+
+    auto table = std::unordered_map<int, std::unordered_map<core::Gender, std::map<int, double>>>();
+
+    auto mapping = create_fields_index_mapping(
+        doc.GetColumnNames(), {"age", "gender_id", "measure_id", "measure", "mean"});
+    for (size_t i = 0; i < doc.GetRowCount(); i++) {
+        auto row = doc.GetRow<std::string>(i);
+        auto age = std::stoi(row[mapping["age"]]);
+        auto gender = static_cast<core::Gender>(std::stoi(row[mapping["gender_id"]]));
+        auto measure_id = std::stoi(row[mapping["measure_id"]]);
+        auto measure_name = core::to_lower(row[mapping["measure"]]);
+        auto measure_value = std::stod(row[mapping["mean"]]);
+
+        if (!result.measures.contains(measure_name)) {
+            result.measures.emplace(measure_name, measure_id);
+        }
+
+        if (!table[age].contains(gender)) {
+            table[age].emplace(gender, std::map<int, double>{});
+        }
+
+        table[age][gender][measure_id] = measure_value;
+    }
+
+    for (auto &pair : table) {
+        for (auto &child : pair.second) {
+            result.items.emplace_back(DiseaseItem{
+                .with_age = pair.first, .gender = child.first, .measures = child.second});
+        }
+    }
+
+    result.items.shrink_to_fit();
 
     return result;
 }
 
 RelativeRiskEntity DataManager::get_relative_risk_to_disease(const DiseaseInfo &source,
                                                              const DiseaseInfo &target) const {
-    if (index_.contains("diseases")) {
-        auto diseases_path = index_["diseases"]["path"].get<std::string>();
-        auto disease_folder = index_["diseases"]["disease"]["path"].get<std::string>();
-        const auto &risk_node = index_["diseases"]["disease"]["relative_risk"];
-        auto default_value = risk_node["to_disease"]["default_value"].get<float>();
+    auto diseases_path = index_["diseases"]["path"].get<std::string>();
+    auto disease_folder = index_["diseases"]["disease"]["path"].get<std::string>();
+    const auto &risk_node = index_["diseases"]["disease"]["relative_risk"];
+    auto default_value = risk_node["to_disease"]["default_value"].get<float>();
 
-        auto risk_folder = risk_node["path"].get<std::string>();
-        auto file_folder = risk_node["to_disease"]["path"].get<std::string>();
-        auto filename = risk_node["to_disease"]["file_name"].get<std::string>();
+    auto risk_folder = risk_node["path"].get<std::string>();
+    auto file_folder = risk_node["to_disease"]["path"].get<std::string>();
+    auto filename = risk_node["to_disease"]["file_name"].get<std::string>();
 
-        // Tokenized folder name X{info.code}X
-        auto source_code_str = source.code.to_string();
-        disease_folder =
-            replace_string_tokens(disease_folder, std::vector<std::string>{source_code_str});
+    // Tokenized folder name X{info.code}X
+    auto source_code_str = source.code.to_string();
+    disease_folder =
+        replace_string_tokens(disease_folder, std::vector<std::string>{source_code_str});
 
-        // Tokenized file name{ DISEASE_TYPE }_{ DISEASE_TYPE }.xxx
-        auto target_code_str = target.code.to_string();
-        auto tokens = {source_code_str, target_code_str};
-        filename = replace_string_tokens(filename, tokens);
+    // Tokenized file name{ DISEASE_TYPE }_{ DISEASE_TYPE }.xxx
+    auto target_code_str = target.code.to_string();
+    auto tokens = {source_code_str, target_code_str};
+    filename = replace_string_tokens(filename, tokens);
 
-        filename = (root_ / diseases_path / disease_folder / risk_folder / file_folder / filename)
-                       .string();
-        if (std::filesystem::exists(filename)) {
-            rapidcsv::Document doc(filename);
-
-            auto table = RelativeRiskEntity();
-            table.is_default_value = false;
-            table.columns = doc.GetColumnNames();
-
-            auto row_size = table.columns.size();
-            auto non_default_count = std::size_t{0};
-            for (size_t i = 0; i < doc.GetRowCount(); i++) {
-                auto row = doc.GetRow<std::string>(i);
-
-                auto row_data = std::vector<float>(row_size);
-                for (size_t col = 0; col < row_size; col++) {
-                    row_data[col] = std::stof(row[col]);
-                }
-
-                non_default_count += std::count_if(
-                    std::next(row_data.cbegin()), row_data.cend(),
-                    [&default_value](auto &v) { return !MathHelper::equal(v, default_value); });
-
-                table.rows.emplace_back(row_data);
-            }
-
-            if (non_default_count < 1) {
-                table.is_default_value = true;
-                notify_warning(fmt::format("{} to {} relative risk file has only default values.",
-                                           source_code_str, target_code_str));
-            }
-
-            return table;
-        }
-        notify_warning(fmt::format("{} to {} relative risk file not found, using default.",
-                                   source_code_str, target_code_str));
-
-        return generate_default_relative_risk_to_disease();
+    filename =
+        (root_ / diseases_path / disease_folder / risk_folder / file_folder / filename).string();
+    if (!std::filesystem::exists(filename)) {
+        throw std::runtime_error(
+            fmt::format("{} to {} relative risk file not found", source_code_str, target_code_str));
     }
 
-    notify_warning("index has no 'diseases' entry.");
+    rapidcsv::Document doc(filename);
 
-    return {};
+    auto table = RelativeRiskEntity();
+    table.is_default_value = false;
+    table.columns = doc.GetColumnNames();
+
+    auto row_size = table.columns.size();
+    auto non_default_count = std::size_t{0};
+    for (size_t i = 0; i < doc.GetRowCount(); i++) {
+        auto row = doc.GetRow<std::string>(i);
+
+        auto row_data = std::vector<float>(row_size);
+        for (size_t col = 0; col < row_size; col++) {
+            row_data[col] = std::stof(row[col]);
+        }
+
+        non_default_count +=
+            std::count_if(std::next(row_data.cbegin()), row_data.cend(), [&default_value](auto &v) {
+                return !MathHelper::equal(v, default_value);
+            });
+
+        table.rows.emplace_back(row_data);
+    }
+
+    if (non_default_count < 1) {
+        table.is_default_value = true;
+        notify_warning(fmt::format("{} to {} relative risk file has only default values.",
+                                   source_code_str, target_code_str));
+    }
+
+    return table;
 }
 
 std::optional<RelativeRiskEntity>
 DataManager::get_relative_risk_to_risk_factor(const DiseaseInfo &source, Gender gender,
                                               const core::Identifier &risk_factor_key) const {
-    if (!index_.contains("diseases")) {
-        notify_warning("index has no 'diseases' entry.");
-        return std::nullopt;
-    }
-
-    // Creates full file name from store configuration
     auto diseases_path = index_["diseases"]["path"].get<std::string>();
     auto disease_folder = index_["diseases"]["disease"]["path"].get<std::string>();
     const auto &risk_node = index_["diseases"]["disease"]["relative_risk"];
@@ -449,12 +412,6 @@ DataManager::get_relative_risk_to_risk_factor(const DiseaseInfo &source, Gender 
 
 CancerParameterEntity DataManager::get_disease_parameter(const DiseaseInfo &info,
                                                          const Country &country) const {
-    auto table = CancerParameterEntity();
-    if (!index_.contains("diseases")) {
-        notify_warning("index has no 'diseases' entry.");
-        return table;
-    }
-
     // Creates full file name from store configuration
     auto disease_path = index_["diseases"]["path"].get<std::string>();
     auto disease_folder = index_["diseases"]["disease"]["path"].get<std::string>();
@@ -472,17 +429,16 @@ CancerParameterEntity DataManager::get_disease_parameter(const DiseaseInfo &info
     params_folder = replace_string_tokens(params_folder, tokens);
     auto files_folder = (root_ / disease_path / disease_folder / params_folder);
     if (!std::filesystem::exists(files_folder)) {
-        notify_warning(fmt::format("{}, {} parameters folder: '{}' not found.", info_code_str,
-                                   country.name, files_folder.string()));
-        return table;
+        throw std::runtime_error(fmt::format("{}, {} parameters folder: '{}' not found.",
+                                             info_code_str, country.name, files_folder.string()));
     }
 
+    auto table = CancerParameterEntity();
     for (const auto &file : params_files.items()) {
         auto file_name = (files_folder / file.value().get<std::string>());
         if (!std::filesystem::exists(file_name)) {
-            notify_warning(fmt::format("{}, {} parameters file: '{}' not found.", info_code_str,
-                                       country.name, file_name.string()));
-            continue;
+            throw std::runtime_error(fmt::format("{}, {} parameters file: '{}' not found.",
+                                                 info_code_str, country.name, file_name.string()));
         }
 
         auto lookup = std::vector<LookupGenderValue>{};
@@ -521,60 +477,50 @@ std::vector<BirthItem> DataManager::get_birth_indicators(const Country &country)
 std::vector<BirthItem>
 DataManager::get_birth_indicators(const Country &country,
                                   std::function<bool(unsigned int)> time_filter) const {
+    auto nodepath = index_["demographic"]["path"].get<std::string>();
+    auto filefolder = index_["demographic"]["indicators"]["path"].get<std::string>();
+    auto filename = index_["demographic"]["indicators"]["file_name"].get<std::string>();
+
+    // Tokenized file name Pi{COUNTRY_CODE}.xxx
+    auto tokens = std::vector<std::string>{std::to_string(country.code)};
+    filename = replace_string_tokens(filename, tokens);
+    filename = (root_ / nodepath / filefolder / filename).string();
+    if (!std::filesystem::exists(filename)) {
+        throw std::runtime_error(fmt::format("{}, demographic indicators file: '{}' not found.",
+                                             country.name, filename));
+    }
+
+    rapidcsv::Document doc(filename);
+    auto mapping = create_fields_index_mapping(doc.GetColumnNames(), {"Time", "Births", "SRB"});
     std::vector<BirthItem> result;
-    if (index_.contains("demographic")) {
-        auto nodepath = index_["demographic"]["path"].get<std::string>();
-        auto filefolder = index_["demographic"]["indicators"]["path"].get<std::string>();
-        auto filename = index_["demographic"]["indicators"]["file_name"].get<std::string>();
-
-        // Tokenized file name Pi{COUNTRY_CODE}.xxx
-        auto tokens = std::vector<std::string>{std::to_string(country.code)};
-        filename = replace_string_tokens(filename, tokens);
-        filename = (root_ / nodepath / filefolder / filename).string();
-        if (!std::filesystem::exists(filename)) {
-            notify_warning(fmt::format("{}, demographic indicators file: '{}' not found.",
-                                       country.name, filename));
-            return result;
+    for (size_t i = 0; i < doc.GetRowCount(); i++) {
+        auto row = doc.GetRow<std::string>(i);
+        auto row_time = std::stoi(row[mapping["Time"]]);
+        if (!time_filter(row_time)) {
+            continue;
         }
 
-        rapidcsv::Document doc(filename);
-        auto mapping = create_fields_index_mapping(doc.GetColumnNames(), {"Time", "Births", "SRB"});
-        for (size_t i = 0; i < doc.GetRowCount(); i++) {
-            auto row = doc.GetRow<std::string>(i);
-            auto row_time = std::stoi(row[mapping["Time"]]);
-            if (!time_filter(row_time)) {
-                continue;
-            }
-
-            result.push_back(BirthItem{.at_time = row_time,
-                                       .number = std::stof(row[mapping["Births"]]),
-                                       .sex_ratio = std::stof(row[mapping["SRB"]])});
-        }
-    } else {
-        notify_warning("index has no 'demographic' entry.");
+        result.push_back(BirthItem{.at_time = row_time,
+                                   .number = std::stof(row[mapping["Births"]]),
+                                   .sex_ratio = std::stof(row[mapping["SRB"]])});
     }
 
     return result;
 }
 
 std::vector<LmsDataRow> DataManager::get_lms_parameters() const {
-    auto parameters = std::vector<LmsDataRow>{};
-    if (!index_.contains("analysis")) {
-        notify_warning("index has no 'analysis' entry.");
-        return parameters;
-    }
-
     auto analysis_folder = index_["analysis"]["path"].get<std::string>();
     auto lms_filename = index_["analysis"]["lms_file_name"].get<std::string>();
     auto full_filename = (root_ / analysis_folder / lms_filename);
     if (!std::filesystem::exists(full_filename)) {
-        notify_warning(fmt::format("LMS parameters file: '{}' not found.", full_filename.string()));
-        return parameters;
+        throw std::runtime_error(
+            fmt::format("LMS parameters file: '{}' not found.", full_filename.string()));
     }
 
     rapidcsv::Document doc(full_filename.string());
     auto mapping = create_fields_index_mapping(doc.GetColumnNames(),
                                                {"age", "gender_id", "lambda", "mu", "sigma"});
+    auto parameters = std::vector<LmsDataRow>{};
     for (size_t i = 0; i < doc.GetRowCount(); i++) {
         auto row = doc.GetRow<std::string>(i);
         if (row.size() < 6) {
@@ -593,12 +539,6 @@ std::vector<LmsDataRow> DataManager::get_lms_parameters() const {
 }
 
 DiseaseAnalysisEntity DataManager::get_disease_analysis(const Country &country) const {
-    DiseaseAnalysisEntity entity;
-    if (!index_.contains("analysis")) {
-        notify_warning("index has no 'analysis' entry.");
-        return entity;
-    }
-
     auto analysis_folder = index_["analysis"]["path"].get<std::string>();
     auto disability_filename = index_["analysis"]["disability_file_name"].get<std::string>();
     const auto &cost_node = index_["analysis"]["cost_of_disease"];
@@ -606,12 +546,12 @@ DiseaseAnalysisEntity DataManager::get_disease_analysis(const Country &country) 
     auto local_root_path = (root_ / analysis_folder);
     disability_filename = (local_root_path / disability_filename).string();
     if (!std::filesystem::exists(disability_filename)) {
-        notify_warning(
-            fmt::format("disease disability weights file: '{}' not found.", disability_filename));
-        return entity;
+        throw std::runtime_error(
+            fmt::format("Disease disability weights file: '{}' not found.", disability_filename));
     }
 
     rapidcsv::Document doc(disability_filename);
+    DiseaseAnalysisEntity entity;
     for (size_t i = 0; i < doc.GetRowCount(); i++) {
         auto row = doc.GetRow<std::string>(i);
         if (row.size() < 2) {
@@ -626,31 +566,9 @@ DiseaseAnalysisEntity DataManager::get_disease_analysis(const Country &country) 
     return entity;
 }
 
-RelativeRiskEntity DataManager::generate_default_relative_risk_to_disease() const {
-    if (index_.contains("diseases")) {
-        auto age_limits = index_["diseases"]["age_limits"].get<std::vector<int>>();
-        const auto &to_disease = index_["diseases"]["disease"]["relative_risk"]["to_disease"];
-        auto default_value = to_disease["default_value"].get<float>();
-
-        auto table = RelativeRiskEntity();
-        table.is_default_value = true;
-        table.columns = {"age", "male", "female"};
-        for (int age = age_limits[0]; age <= age_limits[1]; age++) {
-            table.rows.emplace_back(
-                std::vector<float>{static_cast<float>(age), default_value, default_value});
-        }
-
-        return table;
-    }
-    notify_warning("index has no 'diseases' entry.");
-
-    return {};
-}
-
 std::map<int, std::map<Gender, double>>
 DataManager::load_cost_of_diseases(const Country &country, const nlohmann::json &node,
                                    const std::filesystem::path &parent_path) const {
-    std::map<int, std::map<Gender, double>> result;
     auto cost_path = node["path"].get<std::string>();
     auto filename = node["file_name"].get<std::string>();
 
@@ -659,12 +577,12 @@ DataManager::load_cost_of_diseases(const Country &country, const nlohmann::json 
     filename = replace_string_tokens(filename, tokens);
     filename = (parent_path / cost_path / filename).string();
     if (!std::filesystem::exists(filename)) {
-        notify_warning(
+        throw std::runtime_error(
             fmt::format("{} cost of disease file: '{}' not found.", country.name, filename));
-        return result;
     }
 
     rapidcsv::Document doc(filename);
+    std::map<int, std::map<Gender, double>> result;
     for (size_t i = 0; i < doc.GetRowCount(); i++) {
         auto row = doc.GetRow<std::string>(i);
         if (row.size() < 13) {
@@ -680,36 +598,33 @@ DataManager::load_cost_of_diseases(const Country &country, const nlohmann::json 
 }
 
 std::vector<LifeExpectancyItem> DataManager::load_life_expectancy(const Country &country) const {
+    auto nodepath = index_["demographic"]["path"].get<std::string>();
+    auto filefolder = index_["demographic"]["indicators"]["path"].get<std::string>();
+    auto filename = index_["demographic"]["indicators"]["file_name"].get<std::string>();
+
+    // Tokenized file name Pi{COUNTRY_CODE}.xxx
+    auto tokens = std::vector<std::string>{std::to_string(country.code)};
+    filename = replace_string_tokens(filename, tokens);
+    filename = (root_ / nodepath / filefolder / filename).string();
+    if (!std::filesystem::exists(filename)) {
+        throw std::runtime_error(fmt::format("{}, demographic indicators file: '{}' not found.",
+                                             country.name, filename));
+    }
+
+    rapidcsv::Document doc(filename);
+    auto mapping =
+        create_fields_index_mapping(doc.GetColumnNames(), {"Time", "LEx", "LExMale", "LExFemale"});
     std::vector<LifeExpectancyItem> result;
-    if (index_.contains("demographic")) {
-        auto nodepath = index_["demographic"]["path"].get<std::string>();
-        auto filefolder = index_["demographic"]["indicators"]["path"].get<std::string>();
-        auto filename = index_["demographic"]["indicators"]["file_name"].get<std::string>();
-
-        // Tokenized file name Pi{COUNTRY_CODE}.xxx
-        auto tokens = std::vector<std::string>{std::to_string(country.code)};
-        filename = replace_string_tokens(filename, tokens);
-        filename = (root_ / nodepath / filefolder / filename).string();
-        if (!std::filesystem::exists(filename)) {
-            notify_warning(fmt::format("{}, demographic indicators file: '{}' not found.",
-                                       country.name, filename));
-            return result;
+    for (size_t i = 0; i < doc.GetRowCount(); i++) {
+        auto row = doc.GetRow<std::string>(i);
+        if (row.size() < 4) {
+            continue;
         }
 
-        rapidcsv::Document doc(filename);
-        auto mapping = create_fields_index_mapping(doc.GetColumnNames(),
-                                                   {"Time", "LEx", "LExMale", "LExFemale"});
-        for (size_t i = 0; i < doc.GetRowCount(); i++) {
-            auto row = doc.GetRow<std::string>(i);
-            if (row.size() < 4) {
-                continue;
-            }
-
-            result.emplace_back(LifeExpectancyItem{.at_time = std::stoi(row[mapping["Time"]]),
-                                                   .both = std::stof(row[mapping["LEx"]]),
-                                                   .male = std::stof(row[mapping["LExMale"]]),
-                                                   .female = std::stof(row[mapping["LExFemale"]])});
-        }
+        result.emplace_back(LifeExpectancyItem{.at_time = std::stoi(row[mapping["Time"]]),
+                                               .both = std::stof(row[mapping["LEx"]]),
+                                               .male = std::stof(row[mapping["LExMale"]]),
+                                               .female = std::stof(row[mapping["LExFemale"]])});
     }
 
     return result;

--- a/src/HealthGPS.Datastore/datamanager.h
+++ b/src/HealthGPS.Datastore/datamanager.h
@@ -55,8 +55,9 @@ class DataManager : public Datastore {
 
     DiseaseEntity get_disease(const DiseaseInfo &info, const Country &country) const override;
 
-    RelativeRiskEntity get_relative_risk_to_disease(const DiseaseInfo &source,
-                                                    const DiseaseInfo &target) const override;
+    std::optional<RelativeRiskEntity>
+    get_relative_risk_to_disease(const DiseaseInfo &source,
+                                 const DiseaseInfo &target) const override;
 
     std::optional<RelativeRiskEntity>
     get_relative_risk_to_risk_factor(const DiseaseInfo &source, Gender gender,

--- a/src/HealthGPS.Datastore/datamanager.h
+++ b/src/HealthGPS.Datastore/datamanager.h
@@ -58,7 +58,7 @@ class DataManager : public Datastore {
     RelativeRiskEntity get_relative_risk_to_disease(const DiseaseInfo &source,
                                                     const DiseaseInfo &target) const override;
 
-    RelativeRiskEntity
+    std::optional<RelativeRiskEntity>
     get_relative_risk_to_risk_factor(const DiseaseInfo &source, Gender gender,
                                      const core::Identifier &risk_factor_key) const override;
 

--- a/src/HealthGPS.Datastore/datamanager.h
+++ b/src/HealthGPS.Datastore/datamanager.h
@@ -82,8 +82,6 @@ class DataManager : public Datastore {
     VerboseMode verbosity_;
     nlohmann::json index_;
 
-    RelativeRiskEntity generate_default_relative_risk_to_disease() const;
-
     std::map<int, std::map<Gender, double>>
     load_cost_of_diseases(const Country &country, const nlohmann::json &node,
                           const std::filesystem::path &parent_path) const;

--- a/src/HealthGPS.Tests/Datastore.Test.cpp
+++ b/src/HealthGPS.Tests/Datastore.Test.cpp
@@ -25,7 +25,7 @@ TEST_F(DatastoreTest, CreateDataManagerFailWithWrongPath) {
 }
 
 TEST_F(DatastoreTest, CountryMissingThrowsException) {
-    ASSERT_THROW(manager.get_country("FAKE"), std::invalid_argument);
+    ASSERT_THROW(manager.get_country("FAKE"), std::runtime_error);
 }
 
 TEST_F(DatastoreTest, CountryIsCaseInsensitive) {
@@ -137,7 +137,7 @@ TEST_F(DatastoreTest, GetDiseaseInfoMatchesGetDisases) {
 }
 
 TEST_F(DatastoreTest, GetDiseaseInfoMissingThrowsException) {
-    EXPECT_THROW(manager.get_disease_info("FAKE"), std::invalid_argument);
+    EXPECT_THROW(manager.get_disease_info("FAKE"), std::runtime_error);
 }
 
 TEST_F(DatastoreTest, RetrieveDiseasesTypeInInfo) {

--- a/src/HealthGPS.Tests/Datastore.Test.cpp
+++ b/src/HealthGPS.Tests/Datastore.Test.cpp
@@ -189,9 +189,12 @@ TEST_F(DatastoreTest, DiseaseRelativeRiskToDisease) {
     EXPECT_FALSE(table_self.has_value());
 
     ASSERT_TRUE(table_other.has_value());
+
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
     EXPECT_EQ(3, table_other->columns.size());
     EXPECT_GT(table_other->rows.size(), 0);
     EXPECT_EQ(table_other->rows[0][1], table_other->rows[0][2]);
+    // NOLINTEND(bugprone-unchecked-optional-access)
 }
 
 TEST_F(DatastoreTest, MissingDiseaseRelativeRiskToDisease) {
@@ -213,8 +216,10 @@ TEST_F(DatastoreTest, DiseaseRelativeRiskToRiskFactor) {
 
     auto col_size = 8;
 
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
     auto table_male = manager.get_relative_risk_to_risk_factor(diabetes, Gender::male, risk_factor);
     ASSERT_TRUE(table_male.has_value());
+
     EXPECT_EQ(col_size, table_male->columns.size());
     EXPECT_FALSE(table_male->rows.empty());
     EXPECT_EQ(table_male->rows[0][1], table_male->rows[0][2]);
@@ -223,10 +228,12 @@ TEST_F(DatastoreTest, DiseaseRelativeRiskToRiskFactor) {
     auto table_female =
         manager.get_relative_risk_to_risk_factor(diabetes, Gender::female, risk_factor);
     ASSERT_TRUE(table_female.has_value());
+
     EXPECT_EQ(col_size, table_female->columns.size());
     EXPECT_FALSE(table_female->rows.empty());
     EXPECT_EQ(table_female->rows[0][1], table_female->rows[0][2]);
     EXPECT_NE(table_female->rows[0][1], table_female->rows[0][3]);
+    // NOLINTEND(bugprone-unchecked-optional-access)
 }
 
 TEST_F(DatastoreTest, RetrieveAnalysisEntity) {

--- a/src/HealthGPS.Tests/Datastore.Test.cpp
+++ b/src/HealthGPS.Tests/Datastore.Test.cpp
@@ -186,15 +186,12 @@ TEST_F(DatastoreTest, DiseaseRelativeRiskToDisease) {
     auto table_other = manager.get_relative_risk_to_disease(diabetes, asthma);
 
     // diabetes to diabetes files-based default values
-    ASSERT_EQ(3, table_self.columns.size());
-    ASSERT_GT(table_self.rows.size(), 0);
-    ASSERT_EQ(table_self.rows[0][1], table_self.rows[0][2]);
-    ASSERT_TRUE(table_self.is_default_value);
+    EXPECT_FALSE(table_self.has_value());
 
-    ASSERT_EQ(3, table_other.columns.size());
-    ASSERT_GT(table_other.rows.size(), 0);
-    ASSERT_EQ(table_other.rows[0][1], table_other.rows[0][2]);
-    ASSERT_FALSE(table_other.is_default_value);
+    ASSERT_TRUE(table_other.has_value());
+    EXPECT_EQ(3, table_other->columns.size());
+    EXPECT_GT(table_other->rows.size(), 0);
+    EXPECT_EQ(table_other->rows[0][1], table_other->rows[0][2]);
 }
 
 TEST_F(DatastoreTest, MissingDiseaseRelativeRiskToDisease) {
@@ -205,7 +202,7 @@ TEST_F(DatastoreTest, MissingDiseaseRelativeRiskToDisease) {
                             .code = Identifier{"ghost369"},
                             .name = "Look at the flowers."};
 
-    EXPECT_THROW(manager.get_relative_risk_to_disease(diabetes, info), std::runtime_error);
+    ASSERT_FALSE(manager.get_relative_risk_to_disease(diabetes, info).has_value());
 }
 
 TEST_F(DatastoreTest, DiseaseRelativeRiskToRiskFactor) {
@@ -216,25 +213,20 @@ TEST_F(DatastoreTest, DiseaseRelativeRiskToRiskFactor) {
 
     auto col_size = 8;
 
-    // NOLINTBEGIN(bugprone-unchecked-optional-access)
-    auto table_male =
-        *manager.get_relative_risk_to_risk_factor(diabetes, Gender::male, risk_factor);
+    auto table_male = manager.get_relative_risk_to_risk_factor(diabetes, Gender::male, risk_factor);
+    ASSERT_TRUE(table_male.has_value());
+    EXPECT_EQ(col_size, table_male->columns.size());
+    EXPECT_FALSE(table_male->rows.empty());
+    EXPECT_EQ(table_male->rows[0][1], table_male->rows[0][2]);
+    EXPECT_NE(table_male->rows[0][1], table_male->rows[0][3]);
+
     auto table_female =
-        *manager.get_relative_risk_to_risk_factor(diabetes, Gender::female, risk_factor);
-    // NOLINTEND(bugprone-unchecked-optional-access)
-
-    ASSERT_EQ(col_size, table_male.columns.size());
-    ASSERT_GT(table_male.rows.size(), 0);
-    ASSERT_EQ(table_male.rows[0][1], table_male.rows[0][2]);
-    ASSERT_NE(table_male.rows[0][1], table_male.rows[0][3]);
-
-    ASSERT_FALSE(table_male.is_default_value);
-
-    ASSERT_EQ(col_size, table_female.columns.size());
-    ASSERT_GT(table_female.rows.size(), 0);
-    ASSERT_EQ(table_female.rows[0][1], table_female.rows[0][2]);
-    ASSERT_NE(table_female.rows[0][1], table_female.rows[0][3]);
-    ASSERT_FALSE(table_female.is_default_value);
+        manager.get_relative_risk_to_risk_factor(diabetes, Gender::female, risk_factor);
+    ASSERT_TRUE(table_female.has_value());
+    EXPECT_EQ(col_size, table_female->columns.size());
+    EXPECT_FALSE(table_female->rows.empty());
+    EXPECT_EQ(table_female->rows[0][1], table_female->rows[0][2]);
+    EXPECT_NE(table_female->rows[0][1], table_female->rows[0][3]);
 }
 
 TEST_F(DatastoreTest, RetrieveAnalysisEntity) {

--- a/src/HealthGPS.Tests/Datastore.Test.cpp
+++ b/src/HealthGPS.Tests/Datastore.Test.cpp
@@ -227,9 +227,10 @@ TEST_F(DatastoreTest, DiseaseRelativeRiskToRiskFactor) {
 
     auto col_size = 8;
 
-    auto table_male = manager.get_relative_risk_to_risk_factor(diabetes, Gender::male, risk_factor);
-    auto table_feme =
-        manager.get_relative_risk_to_risk_factor(diabetes, Gender::female, risk_factor);
+    auto table_male =
+        *manager.get_relative_risk_to_risk_factor(diabetes, Gender::male, risk_factor);
+    auto table_female =
+        *manager.get_relative_risk_to_risk_factor(diabetes, Gender::female, risk_factor);
 
     ASSERT_EQ(col_size, table_male.columns.size());
     ASSERT_GT(table_male.rows.size(), 0);
@@ -238,11 +239,11 @@ TEST_F(DatastoreTest, DiseaseRelativeRiskToRiskFactor) {
 
     ASSERT_FALSE(table_male.is_default_value);
 
-    ASSERT_EQ(col_size, table_feme.columns.size());
-    ASSERT_GT(table_feme.rows.size(), 0);
-    ASSERT_EQ(table_feme.rows[0][1], table_feme.rows[0][2]);
-    ASSERT_NE(table_feme.rows[0][1], table_feme.rows[0][3]);
-    ASSERT_FALSE(table_feme.is_default_value);
+    ASSERT_EQ(col_size, table_female.columns.size());
+    ASSERT_GT(table_female.rows.size(), 0);
+    ASSERT_EQ(table_female.rows[0][1], table_female.rows[0][2]);
+    ASSERT_NE(table_female.rows[0][1], table_female.rows[0][3]);
+    ASSERT_FALSE(table_female.is_default_value);
 }
 
 TEST_F(DatastoreTest, RetrieveAnalysisEntity) {

--- a/src/HealthGPS.Tests/Datastore.Test.cpp
+++ b/src/HealthGPS.Tests/Datastore.Test.cpp
@@ -175,13 +175,7 @@ TEST_F(DatastoreTest, RetrieveDiseaseDefinitionIsEmpty) {
                             .code = Identifier{"ghost369"},
                             .name = "Look at the flowers."};
 
-    auto entity = manager.get_disease(info, india);
-
-    ASSERT_TRUE(entity.empty());
-    ASSERT_EQ(0, entity.items.size());
-    ASSERT_EQ(0, entity.measures.size());
-    EXPECT_EQ(info.code, entity.info.code);
-    EXPECT_EQ(india.code, entity.country.code);
+    EXPECT_THROW(manager.get_disease(info, india), std::runtime_error);
 }
 
 TEST_F(DatastoreTest, DiseaseRelativeRiskToDisease) {
@@ -203,7 +197,7 @@ TEST_F(DatastoreTest, DiseaseRelativeRiskToDisease) {
     ASSERT_FALSE(table_other.is_default_value);
 }
 
-TEST_F(DatastoreTest, DefaultDiseaseRelativeRiskToDisease) {
+TEST_F(DatastoreTest, MissingDiseaseRelativeRiskToDisease) {
     using namespace hgps::core;
 
     auto diabetes = manager.get_disease_info("diabetes");
@@ -211,12 +205,7 @@ TEST_F(DatastoreTest, DefaultDiseaseRelativeRiskToDisease) {
                             .code = Identifier{"ghost369"},
                             .name = "Look at the flowers."};
 
-    auto default_table = manager.get_relative_risk_to_disease(diabetes, info);
-    ASSERT_EQ(3, default_table.columns.size());
-    ASSERT_GT(default_table.rows.size(), 0);
-    ASSERT_EQ(1.0, default_table.rows[0][1]);
-    ASSERT_EQ(1.0, default_table.rows[0][2]);
-    ASSERT_TRUE(default_table.is_default_value);
+    EXPECT_THROW(manager.get_relative_risk_to_disease(diabetes, info), std::runtime_error);
 }
 
 TEST_F(DatastoreTest, DiseaseRelativeRiskToRiskFactor) {

--- a/src/HealthGPS.Tests/Datastore.Test.cpp
+++ b/src/HealthGPS.Tests/Datastore.Test.cpp
@@ -216,10 +216,12 @@ TEST_F(DatastoreTest, DiseaseRelativeRiskToRiskFactor) {
 
     auto col_size = 8;
 
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
     auto table_male =
         *manager.get_relative_risk_to_risk_factor(diabetes, Gender::male, risk_factor);
     auto table_female =
         *manager.get_relative_risk_to_risk_factor(diabetes, Gender::female, risk_factor);
+    // NOLINTEND(bugprone-unchecked-optional-access)
 
     ASSERT_EQ(col_size, table_male.columns.size());
     ASSERT_GT(table_male.rows.size(), 0);

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -401,8 +401,7 @@ std::unique_ptr<AnalysisModule> build_analysis_module(Repository &repository,
     auto analysis_entity = repository.manager().get_disease_analysis(config.settings().country());
     auto &lms_definition = repository.get_lms_definition();
     if (lms_definition.empty()) {
-        throw std::logic_error(
-            "Failed to create analysis module: invalid LMS model definition.");
+        throw std::logic_error("Failed to create analysis module: invalid LMS model definition.");
     }
 
     auto definition = detail::StoreConverter::to_analysis_definition(analysis_entity);

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -402,7 +402,7 @@ std::unique_ptr<AnalysisModule> build_analysis_module(Repository &repository,
     auto &lms_definition = repository.get_lms_definition();
     if (lms_definition.empty()) {
         throw std::logic_error(
-            "Failed to create analysis module, invalid disease analysis definition.");
+            "Failed to create analysis module: invalid LMS model definition.");
     }
 
     auto definition = detail::StoreConverter::to_analysis_definition(analysis_entity);

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -400,7 +400,7 @@ std::unique_ptr<AnalysisModule> build_analysis_module(Repository &repository,
                                                       const ModelInput &config) {
     auto analysis_entity = repository.manager().get_disease_analysis(config.settings().country());
     auto &lms_definition = repository.get_lms_definition();
-    if (analysis_entity.empty() || lms_definition.empty()) {
+    if (lms_definition.empty()) {
         throw std::logic_error(
             "Failed to create analysis module, invalid disease analysis definition.");
     }

--- a/src/HealthGPS/converter.cpp
+++ b/src/HealthGPS/converter.cpp
@@ -78,9 +78,8 @@ RelativeRiskLookup StoreConverter::to_relative_risk_lookup(const core::RelativeR
 RelativeRisk create_relative_risk(const RelativeRiskInfo &info) {
     RelativeRisk result;
     for (const auto &item : info.inputs.diseases()) {
-        const auto table = info.manager.get_relative_risk_to_disease(info.disease, item);
-        if (!table.is_default_value) {
-            result.diseases.emplace(item.code, StoreConverter::to_relative_risk_table(table));
+        if (const auto table = info.manager.get_relative_risk_to_disease(info.disease, item)) {
+            result.diseases.emplace(item.code, StoreConverter::to_relative_risk_table(*table));
         }
     }
 

--- a/src/HealthGPS/converter.cpp
+++ b/src/HealthGPS/converter.cpp
@@ -78,8 +78,8 @@ RelativeRiskLookup StoreConverter::to_relative_risk_lookup(const core::RelativeR
 RelativeRisk create_relative_risk(const RelativeRiskInfo &info) {
     RelativeRisk result;
     for (const auto &item : info.inputs.diseases()) {
-        auto table = info.manager.get_relative_risk_to_disease(info.disease, item);
-        if (!table.empty() && !table.is_default_value) {
+        const auto table = info.manager.get_relative_risk_to_disease(info.disease, item);
+        if (!table.is_default_value) {
             result.diseases.emplace(item.code, StoreConverter::to_relative_risk_table(table));
         }
     }

--- a/src/HealthGPS/converter.cpp
+++ b/src/HealthGPS/converter.cpp
@@ -85,19 +85,15 @@ RelativeRisk create_relative_risk(const RelativeRiskInfo &info) {
     }
 
     for (auto &factor : info.risk_factors) {
-        auto table_male = info.manager.get_relative_risk_to_risk_factor(
-            info.disease, core::Gender::male, factor.key());
-        auto table_feme = info.manager.get_relative_risk_to_risk_factor(
-            info.disease, core::Gender::female, factor.key());
-
-        if (!table_male.empty()) {
+        if (const auto table_male = info.manager.get_relative_risk_to_risk_factor(
+                info.disease, core::Gender::male, factor.key())) {
             result.risk_factors[factor.key()].emplace(
-                core::Gender::male, StoreConverter::to_relative_risk_lookup(table_male));
+                core::Gender::male, StoreConverter::to_relative_risk_lookup(*table_male));
         }
-
-        if (!table_feme.empty()) {
+        if (const auto table_female = info.manager.get_relative_risk_to_risk_factor(
+                info.disease, core::Gender::female, factor.key())) {
             result.risk_factors[factor.key()].emplace(
-                core::Gender::female, StoreConverter::to_relative_risk_lookup(table_feme));
+                core::Gender::female, StoreConverter::to_relative_risk_lookup(*table_female));
         }
     }
 


### PR DESCRIPTION
Currently, many of the methods in `DataManager` check whether a certain field is present and, if it isn't, return an empty data structure. Those checks are now unnecessary because we enforce the presence of all required fields with a JSON schema, so they can be removed. In turn, this means some of the callers of these methods no longer need to check the return value.

Additionally, many methods return an empty data structure if a given CSV file is not found. In most cases, I've changed things to throw an exception if the file isn't present, because the files are in the `data/` folder, so this problem shouldn't arise. The one exception is `get_relative_risk_to_risk_factor`, where we actually don't have CSV files for all possible combinations of inputs (HealthGPS will tell you which ones are missing, but you have to run it with the `--verbose` flag to see). In that case, I changed the return type to be `std::optional<RelativeRiskEntity>`, with `std::nullopt` indicating that a file is missing (which is a safer approach).

Closes #401.