### PR TITLE
Compute standard deviation in output.

### DIFF
--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -348,9 +348,12 @@ void AnalysisModule::calculate_standard_deviation(RuntimeContext &context, DataS
     int max_age = context.age_range().upper();
 
     for (const auto &person : context.population()) {
+        if (!person.is_active()) {
+            continue;
+        }
+
         unsigned int age = person.age;
         core::Gender sex = person.gender;
-
         for (const auto &factor : context.mapping().entries()) {
             double value = person.get_risk_factor_value(factor.key());
             double mean = series(sex, "mean_" + factor.key().to_string()).at(age);

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -343,8 +343,7 @@ void AnalysisModule::calculate_population_statistics(RuntimeContext &context,
 }
 // NOLINTEND(readability-function-cognitive-complexity)
 
-void AnalysisModule::calculate_standard_deviation(RuntimeContext &context,
-                                                  DataSeries &series) const {
+void AnalysisModule::calculate_standard_deviation(RuntimeContext &context, DataSeries &series) {
     int min_age = context.age_range().lower();
     int max_age = context.age_range().upper();
 

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -344,20 +344,20 @@ void AnalysisModule::calculate_population_statistics(RuntimeContext &context,
 // NOLINTEND(readability-function-cognitive-complexity)
 
 void AnalysisModule::calculate_standard_deviation(RuntimeContext &context, DataSeries &series) {
-    int min_age = context.age_range().lower();
-    int max_age = context.age_range().upper();
+    const int min_age = context.age_range().lower();
+    const int max_age = context.age_range().upper();
 
     for (const auto &person : context.population()) {
         if (!person.is_active()) {
             continue;
         }
 
-        unsigned int age = person.age;
-        core::Gender sex = person.gender;
+        const unsigned int age = person.age;
+        const core::Gender sex = person.gender;
         for (const auto &factor : context.mapping().entries()) {
-            double value = person.get_risk_factor_value(factor.key());
-            double mean = series(sex, "mean_" + factor.key().to_string()).at(age);
-            double diff = value - mean;
+            const double value = person.get_risk_factor_value(factor.key());
+            const double mean = series(sex, "mean_" + factor.key().to_string()).at(age);
+            const double diff = value - mean;
             series(sex, "std_" + factor.key().to_string()).at(age) += diff * diff;
         }
     }
@@ -370,15 +370,15 @@ void AnalysisModule::calculate_standard_deviation(RuntimeContext &context, DataS
             }
 
             // Factor standard deviation for females.
-            double female_count = series(core::Gender::female, "count").at(i);
-            double female_sum = series(core::Gender::female, chan).at(i);
-            double female_std = std::sqrt(female_sum / female_count);
+            const double female_count = series(core::Gender::female, "count").at(i);
+            const double female_sum = series(core::Gender::female, chan).at(i);
+            const double female_std = std::sqrt(female_sum / female_count);
             series(core::Gender::female, chan).at(i) = female_std;
 
             // Factor standard deviation for males.
-            double male_count = series(core::Gender::male, "count").at(i);
-            double male_sum = series(core::Gender::male, chan).at(i);
-            double male_std = std::sqrt(male_sum / male_count);
+            const double male_count = series(core::Gender::male, "count").at(i);
+            const double male_sum = series(core::Gender::male, chan).at(i);
+            const double male_std = std::sqrt(male_sum / male_count);
             series(core::Gender::male, chan).at(i) = male_std;
         }
     }

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -337,6 +337,9 @@ void AnalysisModule::calculate_population_statistics(RuntimeContext &context,
             series(core::Gender::female, chan).at(i) /= female_count;
         }
     }
+
+    // Calculate standard deviation
+    calculate_standard_deviation(context, series);
 }
 // NOLINTEND(readability-function-cognitive-complexity)
 

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -295,7 +295,7 @@ void AnalysisModule::calculate_population_statistics(RuntimeContext &context,
         series(gender, "count").at(age)++;
 
         for (const auto &factor : context.mapping().entries()) {
-            series(gender, factor.key().to_string()).at(age) +=
+            series(gender, "mean_" + factor.key().to_string()).at(age) +=
                 entity.get_risk_factor_value(factor.key());
         }
 
@@ -326,27 +326,58 @@ void AnalysisModule::calculate_population_statistics(RuntimeContext &context,
     // Calculate in-place averages
     for (auto i = min_age; i <= max_age; i++) {
         for (const auto &chan : series.channels()) {
-            if (chan == "count") {
+            if (chan == "count" || chan.starts_with("std_")) {
                 continue;
             }
 
             double male_count = series(core::Gender::male, "count").at(i);
-            if (male_count > 0.0) {
-                series(core::Gender::male, chan).at(i) /= male_count;
-            } else {
-                series(core::Gender::male, chan).at(i) = 0.0;
-            }
+            series(core::Gender::male, chan).at(i) /= male_count;
 
             double female_count = series(core::Gender::female, "count").at(i);
-            if (female_count > 0.0) {
-                series(core::Gender::female, chan).at(i) /= female_count;
-            } else {
-                series(core::Gender::female, chan).at(i) = 0.0;
-            }
+            series(core::Gender::female, chan).at(i) /= female_count;
         }
     }
 }
 // NOLINTEND(readability-function-cognitive-complexity)
+
+void AnalysisModule::calculate_standard_deviation(RuntimeContext &context,
+                                                  DataSeries &series) const {
+    int min_age = context.age_range().lower();
+    int max_age = context.age_range().upper();
+
+    for (const auto &person : context.population()) {
+        unsigned int age = person.age;
+        core::Gender sex = person.gender;
+
+        for (const auto &factor : context.mapping().entries()) {
+            double value = person.get_risk_factor_value(factor.key());
+            double mean = series(sex, "mean_" + factor.key().to_string()).at(age);
+            double diff = value - mean;
+            series(sex, "std_" + factor.key().to_string()).at(age) += diff * diff;
+        }
+    }
+
+    // Calculate in-place standard deviation.
+    for (int i = min_age; i <= max_age; i++) {
+        for (const auto &chan : series.channels()) {
+            if (!chan.starts_with("std_")) {
+                continue;
+            }
+
+            // Factor standard deviation for females.
+            double female_count = series(core::Gender::female, "count").at(i);
+            double female_sum = series(core::Gender::female, chan).at(i);
+            double female_std = std::sqrt(female_sum / female_count);
+            series(core::Gender::female, chan).at(i) = female_std;
+
+            // Factor standard deviation for males.
+            double male_count = series(core::Gender::male, "count").at(i);
+            double male_sum = series(core::Gender::male, chan).at(i);
+            double male_std = std::sqrt(male_sum / male_count);
+            series(core::Gender::male, chan).at(i) = male_std;
+        }
+    }
+}
 
 void AnalysisModule::classify_weight(DataSeries &series, const Person &entity) const {
     auto weight_class = weight_classifier_.classify_weight(entity);
@@ -376,7 +407,8 @@ void AnalysisModule::initialise_output_channels(RuntimeContext &context) {
     channels_.emplace_back("count");
 
     for (const auto &factor : context.mapping().entries()) {
-        channels_.emplace_back(factor.key().to_string());
+        channels_.emplace_back("mean_" + factor.key().to_string());
+        channels_.emplace_back("std_" + factor.key().to_string());
     }
 
     for (const auto &disease : context.diseases()) {

--- a/src/HealthGPS/analysis_module.h
+++ b/src/HealthGPS/analysis_module.h
@@ -51,13 +51,13 @@ class AnalysisModule final : public UpdatableModule {
 
     void calculate_population_statistics(RuntimeContext &context, DataSeries &series) const;
 
+    void classify_weight(hgps::DataSeries &series, const hgps::Person &entity) const;
+    void initialise_output_channels(RuntimeContext &context);
+
     /// @brief Calculates the standard deviation of factors given data series containing means
     /// @param context The runtime context
     /// @param series The data series containing factor means
-    void calculate_standard_deviation(RuntimeContext &context, DataSeries &series) const;
-
-    void classify_weight(hgps::DataSeries &series, const hgps::Person &entity) const;
-    void initialise_output_channels(RuntimeContext &context);
+    static void calculate_standard_deviation(RuntimeContext &context, DataSeries &series);
 };
 
 /// @brief Builds a new instance of the AnalysisModule using the given data infrastructure

--- a/src/HealthGPS/analysis_module.h
+++ b/src/HealthGPS/analysis_module.h
@@ -50,6 +50,12 @@ class AnalysisModule final : public UpdatableModule {
                                    unsigned int death_year) const;
 
     void calculate_population_statistics(RuntimeContext &context, DataSeries &series) const;
+
+    /// @brief Calculates the standard deviation of factors given data series containing means
+    /// @param context The runtime context
+    /// @param series The data series containing factor means
+    void calculate_standard_deviation(RuntimeContext &context, DataSeries &series) const;
+
     void classify_weight(hgps::DataSeries &series, const hgps::Person &entity) const;
     void initialise_output_channels(RuntimeContext &context);
 };


### PR DESCRIPTION
Addresses #326. 

In this change, the standard deviation for each risk factor is computed in the `std_<factor>` columns of the CSV output.

Group means are now in the `mean_<factor>` columns. NB: this probably means scripts need changing to point to the new `mean_` prefixed equivalents.

Note that *ONLY* risk factors have stddev computed for each groups. If more columns are required to have stddev, please let me know here.

@jzhu20, could you please test locally so it works your end if/when you have a moment? Thanks.