### PR TITLE
Fix new `clang-tidy` warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,6 +25,7 @@ Checks: >
     -readability-magic-numbers,
     -readability-isolate-declaration,
     -misc-const-correctness,
+    -misc-include-cleaner,
     -misc-no-recursion,
     -misc-non-private-member-variables-in-classes,
     -cppcoreguidelines-avoid-magic-numbers,

--- a/src/HealthGPS.Console/command_options.cpp
+++ b/src/HealthGPS.Console/command_options.cpp
@@ -30,7 +30,7 @@ CommandOptions parse_arguments(cxxopts::Options &options, int &argc, char *argv[
         cmd.verbose = false;
         auto result = options.parse(argc, argv);
         if (result.count("help")) {
-            std::cout << options.help() << std::endl;
+            std::cout << options.help() << '\n';
             cmd.success = false;
             return cmd;
         }

--- a/src/HealthGPS.Console/configuration.cpp
+++ b/src/HealthGPS.Console/configuration.cpp
@@ -258,8 +258,8 @@ create_intervention_scenario(SyncChannel &channel, const poco::PolicyScenarioInf
     auto period = PolicyInterval(info.active_period.start_time, info.active_period.finish_time);
     auto risk_impacts = std::vector<PolicyImpact>{};
     for (const auto &item : info.impacts) {
-        risk_impacts.emplace_back(PolicyImpact{core::Identifier{item.risk_factor},
-                                               item.impact_value, item.from_age, item.to_age});
+        risk_impacts.emplace_back(core::Identifier{item.risk_factor}, item.impact_value,
+                                  item.from_age, item.to_age);
     }
 
     // TODO: Validate intervention JSON definitions!!!

--- a/src/HealthGPS.Console/program.cpp
+++ b/src/HealthGPS.Console/program.cpp
@@ -59,7 +59,7 @@ int main(int argc, char *argv[]) { // NOLINT(bugprone-exception-escape)
     // Create CLI options and validate minimum arguments
     auto options = create_options();
     if (argc < 2) {
-        std::cout << options.help() << std::endl;
+        std::cout << options.help() << '\n';
         return exit_application(EXIT_FAILURE);
     }
 

--- a/src/HealthGPS.Datastore/datamanager.cpp
+++ b/src/HealthGPS.Datastore/datamanager.cpp
@@ -51,7 +51,6 @@ DataManager::DataManager(std::filesystem::path path, VerboseMode verbosity)
     if (std::filesystem::is_directory(path)) {
         root_ = std::move(path);
     } else if (std::filesystem::is_regular_file(path) && path.extension() == ".zip") {
-        // If it's a file, assume it's a zip file
         root_ = create_temporary_directory();
         extract_zip_file(path, root_);
     } else {

--- a/src/HealthGPS.Datastore/datamanager.h
+++ b/src/HealthGPS.Datastore/datamanager.h
@@ -26,12 +26,11 @@ class DataManager : public Datastore {
     DataManager() = delete;
 
     /// @brief Initialises a new instance of the hgps::data::DataManager class.
-    /// @param root_directory The store root folder containing the index.json file.
+    /// @param path The path to store root folder containing the index.json file or a zip file.
     /// @param verbosity The terminal logging verbosity mode to use.
     /// @throws std::invalid_argument if the root directory or index.json is missing.
     /// @throws std::runtime_error for invalid or unsupported index.json file schema version.
-    explicit DataManager(std::filesystem::path root_directory,
-                         VerboseMode verbosity = VerboseMode::none);
+    explicit DataManager(std::filesystem::path path, VerboseMode verbosity = VerboseMode::none);
 
     std::vector<Country> get_countries() const override;
 

--- a/src/HealthGPS.Tests/TestMain.cpp
+++ b/src/HealthGPS.Tests/TestMain.cpp
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
     auto result = options.parse(argc, argv);
     auto storage_path = std::filesystem::path{};
     if (result.count("help")) {
-        std::cout << options.help() << std::endl;
+        std::cout << options.help() << '\n';
         return EXIT_SUCCESS;
     }
     if (result.count("storage")) {

--- a/src/HealthGPS/event_aggregator.h
+++ b/src/HealthGPS/event_aggregator.h
@@ -82,7 +82,7 @@ class EventAggregator {
     /// @return The event subscriber instance
     [[nodiscard]] virtual std::unique_ptr<EventSubscriber>
     subscribe(EventType event_id,
-              std::function<void(std::shared_ptr<EventMessage> message)> &&handler) = 0;
+              std::function<void(std::shared_ptr<EventMessage> message)> handler) = 0;
 
     /// @brief Unsubscribes from an event notification
     /// @param subscriber The event subscriber instance

--- a/src/HealthGPS/event_bus.cpp
+++ b/src/HealthGPS/event_bus.cpp
@@ -6,12 +6,12 @@ namespace hgps {
 
 std::unique_ptr<EventSubscriber>
 DefaultEventBus::subscribe(EventType event_id,
-                           std::function<void(std::shared_ptr<EventMessage> message)> &&function) {
+                           std::function<void(std::shared_ptr<EventMessage> message)> function) {
     auto handle_id = std::string{};
     exclusive_access([&]() {
         auto event_key = static_cast<int>(event_id);
         handle_id = xg::newGuid().str();
-        subscribers_.emplace(handle_id, function);
+        subscribers_.emplace(handle_id, std::move(function));
         registry_.emplace(event_key, handle_id);
     });
 

--- a/src/HealthGPS/event_bus.h
+++ b/src/HealthGPS/event_bus.h
@@ -14,7 +14,7 @@ class DefaultEventBus final : public EventAggregator {
   public:
     [[nodiscard]] std::unique_ptr<EventSubscriber>
     subscribe(EventType event_id,
-              std::function<void(std::shared_ptr<EventMessage> message)> &&function) override;
+              std::function<void(std::shared_ptr<EventMessage> message)> function) override;
 
     void publish(std::unique_ptr<EventMessage> message) override;
 

--- a/src/HealthGPS/healthgps.cpp
+++ b/src/HealthGPS/healthgps.cpp
@@ -47,11 +47,11 @@ void HealthGPS::initialize() {
     }
 
     end_time_ = adevs::Time(definition_.inputs().stop_time(), 0);
-    std::cout << "Microsimulation algorithm initialised: " << name() << std::endl;
+    std::cout << "Microsimulation algorithm initialised: " << name() << '\n';
 }
 
 void HealthGPS::terminate() {
-    std::cout << "Microsimulation algorithm terminate: " << name() << std::endl;
+    std::cout << "Microsimulation algorithm terminate: " << name() << '\n';
 }
 
 void HealthGPS::setup_run(unsigned int run_number) noexcept {

--- a/src/HealthGPS/population.cpp
+++ b/src/HealthGPS/population.cpp
@@ -23,14 +23,13 @@ Person &Population::at(std::size_t index) { return people_.at(index); }
 
 const Person &Population::at(std::size_t index) const { return people_.at(index); }
 
-void Population::add(Person &&person, unsigned int time) noexcept {
-    auto recycle = find_index_of_recyclables(time, 1);
+void Population::add(Person person, unsigned int time) noexcept {
+    const auto recycle = find_index_of_recyclables(time, 1);
     if (!recycle.empty()) {
-        people_.at(recycle.at(0)) = person;
-        return;
+        people_.at(recycle.at(0)) = std::move(person);
+    } else {
+        people_.emplace_back(std::move(person));
     }
-
-    people_.emplace_back(person);
 }
 
 void Population::add_newborn_babies(std::size_t number, core::Gender gender,

--- a/src/HealthGPS/population.h
+++ b/src/HealthGPS/population.h
@@ -60,7 +60,7 @@ class Population {
     /// @brief Adds a Person to the virtual population
     /// @param person The new Person instance
     /// @param time Current simulation time
-    void add(Person &&person, unsigned int time) noexcept;
+    void add(Person person, unsigned int time) noexcept;
 
     /// @brief Adds newborn babies of gender to the virtual population, age = 0
     /// @param number The number of newborn babies to add


### PR DESCRIPTION
It seems that the newer version of `clang-tidy` is finding some more issues with the code base. One of those, `misc-include-cleaner`, is a bit overzealous and PRs are being spammed with comments from the `clang-tidy` bot about them, so I've just suppressed it.

Besides that, I've fixed up other various `clang-tidy` warnings, some with auto-fixes and some manually.