### PR TITLE
Fix automerge workflow: use PR author not GitHub actor

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' || github.actor == 'pre-commit-ci[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'pre-commit-ci[bot]' }}
     steps:
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
Currently auto-merge is being automatically enabled for some non-bot PRs.

@AdrianDAlessandro has pointed out that this is because the pre-commit workflow is automatically pushing fixes to our PRs and, in that case, the last committer (the "GitHub actor") will be the pre-commit bot, so this workflow is being erroneously activated.

It seems like the right way to fix this is to use the PR's author instead: https://github.com/orgs/community/discussions/25502

Fixes #443.