### PR TITLE
Implement new `calculate_population_statistics` method.

### DIFF
--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -24,12 +24,11 @@ AnalysisModule::AnalysisModule(AnalysisDefinition &&definition, WeightModel &&cl
 
 // Overload constructor with additional parameter for calculated_factors_
 AnalysisModule::AnalysisModule(AnalysisDefinition &&definition, WeightModel &&classifier,
-                               const core::IntegerInterval age_range, unsigned int comorbidities, std::vector<double> calculated_factors)
+                               const core::IntegerInterval age_range, unsigned int comorbidities,
+                               std::vector<double> calculated_factors)
     : definition_{std::move(definition)}, weight_classifier_{std::move(classifier)},
       residual_disability_weight_{create_age_gender_table<double>(age_range)},
-      comorbidities_{comorbidities},
-        calculated_factors_{std::move(calculated_factors)}
-{}
+      comorbidities_{comorbidities}, calculated_factors_{std::move(calculated_factors)} {}
 SimulationModuleType AnalysisModule::type() const noexcept {
     return SimulationModuleType::Analysis;
 }
@@ -338,14 +337,12 @@ void AnalysisModule::calculate_population_statistics(RuntimeContext &context) co
         // Calculate the index in the calculated_factors_ vector
         auto index = 0;
         for (size_t i = 0; i < bin_indices.size() - 1; i++) {
-            auto accumulated_bins = std::accumulate(std::next(factor_bins_.cbegin(), i + 1), factor_bins_.cend(), 1, std::multiplies<>());
+            auto accumulated_bins = std::accumulate(std::next(factor_bins_.cbegin(), i + 1),
+                                                    factor_bins_.cend(), 1, std::multiplies<>());
             index +=
-                static_cast<size_t>(bin_indices[i] *
-                accumulated_bins *
-                num_factors_to_calculate);
+                static_cast<size_t>(bin_indices[i] * accumulated_bins * num_factors_to_calculate);
         }
-        index +=
-            static_cast<size_t>(bin_indices.back() * num_factors_to_calculate);
+        index += static_cast<size_t>(bin_indices.back() * num_factors_to_calculate);
 
         // Now we can add the values of the factors that are not in factors_to_calculate_
         for (const auto &factor : context.mapping().entries()) {

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -319,15 +319,10 @@ void AnalysisModule::calculate_population_statistics(RuntimeContext &context) {
         context.mapping().entries().size() - factors_to_calculate_.size();
 
     for (const auto &person : context.population()) {
-        // Get factors_to_calculate_ values for this entity
-        std::vector<double> person_factors;
-        for (const auto &factor : factors_to_calculate_) {
-            person_factors.push_back(person.get_risk_factor_value(factor));
-        }
         // Get the bin index for each factor
         std::vector<size_t> bin_indices;
         for (size_t i = 0; i < factors_to_calculate_.size(); i++) {
-            auto factor_value = person_factors[i];
+            double factor_value = person.get_risk_factor_value(factors_to_calculate_[i]);
             size_t bin_index =
                 static_cast<size_t>((factor_value - factor_min_values_[i]) / factor_bin_widths_[i]);
             bin_indices.push_back(bin_index);

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -66,7 +66,7 @@ void AnalysisModule::initialise_vector(RuntimeContext &context) {
     // The product of the number of bins for each factor can be used to calculate the size of the
     // `calculated_factors_` in the next step
     size_t total_num_bins =
-        std::accumulate(factor_bins_.cbegin(), factor_bins_.cend(), 1, std::multiplies<>());
+        std::accumulate(factor_bins_.cbegin(), factor_bins_.cend(), 1u, std::multiplies<>());
 
     // Set the vector size and initialise all values to 0.0
     calculated_factors_.resize(total_num_bins * num_factors_to_calc);

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -37,6 +37,7 @@ SimulationModuleType AnalysisModule::type() const noexcept {
 void AnalysisModule::initialise_vector(RuntimeContext &context) {
     factor_bins_.reserve(factors_to_calculate_.size());
     factor_bin_widths_.reserve(factors_to_calculate_.size());
+    factor_min_values_.reserve(factors_to_calculate_.size());
 
     for (const auto &factor : factors_to_calculate_) {
         const auto [min, max] = std::ranges::minmax_element(
@@ -47,6 +48,8 @@ void AnalysisModule::initialise_vector(RuntimeContext &context) {
 
         auto min_factor = min->get_risk_factor_value(factor);
         auto max_factor = max->get_risk_factor_value(factor);
+
+        factor_min_values_.push_back(min_factor);
 
         // The number of bins to use for each factor is the number of integer values of the factor,
         // or 100 bins of equal size, whichever is smaller (100 is an arbitrary number, it could be
@@ -328,7 +331,7 @@ void AnalysisModule::calculate_population_statistics(RuntimeContext &context) co
         for (size_t i = 0; i < factors_to_calculate_.size(); i++) {
             auto factor_value = person_factors[i];
             auto bin_index =
-                static_cast<int>((factor_value - factor_bin_widths_[i]) / factor_bin_widths_[i]);
+                static_cast<int>((factor_value - factor_min_values_[i]) / factor_bin_widths_[i]);
             bin_indices.push_back(bin_index);
         }
 

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -333,7 +333,8 @@ void AnalysisModule::calculate_population_statistics(RuntimeContext &context) co
                                                     factor_bins_.cend(), 1, std::multiplies<>())) *
                 static_cast<size_t>(num_factors_to_calculate);
         }
-        index += static_cast<size_t>(bin_indices.back()) * static_cast<size_t>(num_factors_to_calculate);
+        index +=
+            static_cast<size_t>(bin_indices.back()) * static_cast<size_t>(num_factors_to_calculate);
 
         // Now we can add the values of the factors that are not in factors_to_calculate_
         for (const auto &factor : context.mapping().entries()) {

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -315,7 +315,7 @@ DALYsIndicator AnalysisModule::calculate_dalys(Population &population, unsigned 
                           .disability_adjusted_life_years = yll + yld};
 }
 
-void AnalysisModule::calculate_population_statistics(RuntimeContext &context) const {
+void AnalysisModule::calculate_population_statistics(RuntimeContext &context) {
     auto num_factors_to_calculate =
         context.mapping().entries().size() - factors_to_calculate_.size();
 

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -317,16 +317,16 @@ void AnalysisModule::calculate_population_statistics(RuntimeContext &context) co
     auto num_factors_to_calculate =
         context.mapping().entries().size() - factors_to_calculate_.size();
 
-    for (const auto &entity : context.population()) {
+    for (const auto &person : context.population()) {
         // Get factors_to_calculate_ values for this entity
-        std::vector<double> entity_factors;
+        std::vector<double> person_factors;
         for (const auto &factor : factors_to_calculate_) {
-            entity_factors.push_back(entity.get_risk_factor_value(factor));
+            person_factors.push_back(person.get_risk_factor_value(factor));
         }
         // Get the bin index for each factor
         std::vector<int> bin_indices;
         for (size_t i = 0; i < factors_to_calculate_.size(); i++) {
-            auto factor_value = entity_factors[i];
+            auto factor_value = person_factors[i];
             auto bin_index =
                 static_cast<int>((factor_value - factor_bin_widths_[i]) / factor_bin_widths_[i]);
             bin_indices.push_back(bin_index);
@@ -348,7 +348,7 @@ void AnalysisModule::calculate_population_statistics(RuntimeContext &context) co
         for (const auto &factor : context.mapping().entries()) {
             if (std::find(factors_to_calculate_.cbegin(), factors_to_calculate_.cend(),
                           factor.key()) == factors_to_calculate_.cend()) {
-                calculated_factors_[index++] += entity.get_risk_factor_value(factor.key());
+                calculated_factors_[index++] += person.get_risk_factor_value(factor.key());
             }
         }
     }

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -66,7 +66,7 @@ void AnalysisModule::initialise_vector(RuntimeContext &context) {
     // The product of the number of bins for each factor can be used to calculate the size of the
     // `calculated_factors_` in the next step
     size_t total_num_bins =
-        std::accumulate(factor_bins_.cbegin(), factor_bins_.cend(), 1u, std::multiplies<>());
+        std::accumulate(factor_bins_.cbegin(), factor_bins_.cend(), size_t{1}, std::multiplies<>());
 
     // Set the vector size and initialise all values to 0.0
     calculated_factors_.resize(total_num_bins * num_factors_to_calc);

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -45,8 +45,8 @@ void AnalysisModule::initialise_vector(RuntimeContext &context) {
                        entity2.get_risk_factor_value(factor);
             });
 
-        auto min_factor = min->get_risk_factor_value(factor);
-        auto max_factor = max->get_risk_factor_value(factor);
+        double min_factor = min->get_risk_factor_value(factor);
+        double max_factor = max->get_risk_factor_value(factor);
 
         factor_min_values_.push_back(min_factor);
 
@@ -61,11 +61,11 @@ void AnalysisModule::initialise_vector(RuntimeContext &context) {
 
     // The number of factors to calculate is the number of factors minus the length of the `factors`
     // vector.
-    auto num_factors_to_calc = context.mapping().entries().size() - factors_to_calculate_.size();
+    size_t num_factors_to_calc = context.mapping().entries().size() - factors_to_calculate_.size();
 
     // The product of the number of bins for each factor can be used to calculate the size of the
     // `calculated_factors_` in the next step
-    auto total_num_bins =
+    size_t total_num_bins =
         std::accumulate(factor_bins_.cbegin(), factor_bins_.cend(), 1, std::multiplies<>());
 
     // Set the vector size and initialise all values to 0.0
@@ -315,7 +315,7 @@ DALYsIndicator AnalysisModule::calculate_dalys(Population &population, unsigned 
 }
 
 void AnalysisModule::calculate_population_statistics(RuntimeContext &context) {
-    auto num_factors_to_calculate =
+    size_t num_factors_to_calculate =
         context.mapping().entries().size() - factors_to_calculate_.size();
 
     for (const auto &person : context.population()) {
@@ -325,23 +325,23 @@ void AnalysisModule::calculate_population_statistics(RuntimeContext &context) {
             person_factors.push_back(person.get_risk_factor_value(factor));
         }
         // Get the bin index for each factor
-        std::vector<int> bin_indices;
+        std::vector<size_t> bin_indices;
         for (size_t i = 0; i < factors_to_calculate_.size(); i++) {
             auto factor_value = person_factors[i];
-            auto bin_index =
-                static_cast<int>((factor_value - factor_min_values_[i]) / factor_bin_widths_[i]);
+            size_t bin_index =
+                static_cast<size_t>((factor_value - factor_min_values_[i]) / factor_bin_widths_[i]);
             bin_indices.push_back(bin_index);
         }
 
         // Calculate the index in the calculated_factors_ vector
-        auto index = 0;
+        size_t index = 0;
         for (size_t i = 0; i < bin_indices.size() - 1; i++) {
-            auto accumulated_bins = std::accumulate(std::next(factor_bins_.cbegin(), i + 1),
+            size_t accumulated_bins = std::accumulate(std::next(factor_bins_.cbegin(), i + 1),
                                                     factor_bins_.cend(), 1, std::multiplies<>());
             index +=
-                static_cast<size_t>(bin_indices[i] * accumulated_bins * num_factors_to_calculate);
+                bin_indices[i] * accumulated_bins * num_factors_to_calculate;
         }
-        index += static_cast<size_t>(bin_indices.back() * num_factors_to_calculate);
+        index += bin_indices.back() * num_factors_to_calculate;
 
         // Now we can add the values of the factors that are not in factors_to_calculate_
         for (const auto &factor : context.mapping().entries()) {

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -305,8 +305,7 @@ DALYsIndicator AnalysisModule::calculate_dalys(Population &population, unsigned 
                           .disability_adjusted_life_years = yll + yld};
 }
 
-void AnalysisModule::calculate_population_statistics(
-    RuntimeContext &context) const {
+void AnalysisModule::calculate_population_statistics(RuntimeContext &context) const {
     auto num_factors_to_calculate =
         context.mapping().entries().size() - factors_to_calculate_.size();
 
@@ -328,10 +327,11 @@ void AnalysisModule::calculate_population_statistics(
         // Calculate the index in the calculated_factors_ vector
         auto index = 0;
         for (size_t i = 0; i < bin_indices.size() - 1; i++) {
-            index += static_cast<size_t>(bin_indices[i]) *
-                     static_cast<size_t>(std::accumulate(std::next(factor_bins_.cbegin(), i + 1), factor_bins_.cend(),
-                                     1, std::multiplies<>())) *
-                     static_cast<size_t>(num_factors_to_calculate);
+            index +=
+                static_cast<size_t>(bin_indices[i]) *
+                static_cast<size_t>(std::accumulate(std::next(factor_bins_.cbegin(), i + 1),
+                                                    factor_bins_.cend(), 1, std::multiplies<>())) *
+                static_cast<size_t>(num_factors_to_calculate);
         }
         index += bin_indices.back() * num_factors_to_calculate;
 

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -148,7 +148,6 @@ void AnalysisModule::publish_result_message(RuntimeContext &context) const {
     auto handle = core::run_async(&AnalysisModule::calculate_historical_statistics, this,
                                   std::ref(context), std::ref(result));
 
-    calculate_population_statistics(context);
     calculate_population_statistics(context, result.series);
     handle.get();
 

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -305,9 +305,10 @@ DALYsIndicator AnalysisModule::calculate_dalys(Population &population, unsigned 
                           .disability_adjusted_life_years = yll + yld};
 }
 
-void AnalysisModule::calculate_population_statistics(RuntimeContext &context,
-                                                     std::vector<double> &calculated_factors) const {
-    auto num_factors_to_calculate = context.mapping().entries().size() - factors_to_calculate_.size();
+void AnalysisModule::calculate_population_statistics(
+    RuntimeContext &context, std::vector<double> &calculated_factors) const {
+    auto num_factors_to_calculate =
+        context.mapping().entries().size() - factors_to_calculate_.size();
 
     for (const auto &entity : context.population()) {
         // Get factors_to_calculate_ values for this entity
@@ -319,20 +320,25 @@ void AnalysisModule::calculate_population_statistics(RuntimeContext &context,
         std::vector<int> bin_indices;
         for (size_t i = 0; i < factors_to_calculate_.size(); i++) {
             auto factor_value = entity_factors[i];
-            auto bin_index = static_cast<int>((factor_value - factor_bin_widths_[i]) / factor_bin_widths_[i]);
+            auto bin_index =
+                static_cast<int>((factor_value - factor_bin_widths_[i]) / factor_bin_widths_[i]);
             bin_indices.push_back(bin_index);
         }
 
         // Calculate the index in the calculated_factors_ vector
         auto index = 0;
-        for (size_t i = 0; i < bin_indices.size()-1; i++) {
-            index += bin_indices[i] * std::accumulate(std::next(factor_bins_.cbegin(), i + 1), factor_bins_.cend(), 1, std::multiplies<>()) * num_factors_to_calculate;
+        for (size_t i = 0; i < bin_indices.size() - 1; i++) {
+            index += bin_indices[i] *
+                     std::accumulate(std::next(factor_bins_.cbegin(), i + 1), factor_bins_.cend(),
+                                     1, std::multiplies<>()) *
+                     num_factors_to_calculate;
         }
         index += bin_indices.back() * num_factors_to_calculate;
 
         // Now we can add the values of the factors that are not in factors_to_calculate_
         for (const auto &factor : context.mapping().entries()) {
-            if (std::find(factors_to_calculate_.cbegin(), factors_to_calculate_.cend(), factor.key()) == factors_to_calculate_.cend()) {
+            if (std::find(factors_to_calculate_.cbegin(), factors_to_calculate_.cend(),
+                          factor.key()) == factors_to_calculate_.cend()) {
                 calculated_factors[index++] += entity.get_risk_factor_value(factor.key());
             }
         }

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -332,7 +332,7 @@ void AnalysisModule::calculate_population_statistics(RuntimeContext &context) {
         size_t index = 0;
         for (size_t i = 0; i < bin_indices.size() - 1; i++) {
             size_t accumulated_bins = std::accumulate(std::next(factor_bins_.cbegin(), i + 1),
-                                                      factor_bins_.cend(), 1, std::multiplies<>());
+                                                      factor_bins_.cend(), size_t{1}, std::multiplies<>());
             index += bin_indices[i] * accumulated_bins * num_factors_to_calculate;
         }
         index += bin_indices.back() * num_factors_to_calculate;

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -331,8 +331,9 @@ void AnalysisModule::calculate_population_statistics(RuntimeContext &context) {
         // Calculate the index in the calculated_factors_ vector
         size_t index = 0;
         for (size_t i = 0; i < bin_indices.size() - 1; i++) {
-            size_t accumulated_bins = std::accumulate(std::next(factor_bins_.cbegin(), i + 1),
-                                                      factor_bins_.cend(), size_t{1}, std::multiplies<>());
+            size_t accumulated_bins =
+                std::accumulate(std::next(factor_bins_.cbegin(), i + 1), factor_bins_.cend(),
+                                size_t{1}, std::multiplies<>());
             index += bin_indices[i] * accumulated_bins * num_factors_to_calculate;
         }
         index += bin_indices.back() * num_factors_to_calculate;

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -327,14 +327,14 @@ void AnalysisModule::calculate_population_statistics(RuntimeContext &context) co
         // Calculate the index in the calculated_factors_ vector
         auto index = 0;
         for (size_t i = 0; i < bin_indices.size() - 1; i++) {
+            auto accumulated_bins = std::accumulate(std::next(factor_bins_.cbegin(), i + 1), factor_bins_.cend(), 1, std::multiplies<>());
             index +=
-                static_cast<size_t>(bin_indices[i]) *
-                static_cast<size_t>(std::accumulate(std::next(factor_bins_.cbegin(), i + 1),
-                                                    factor_bins_.cend(), 1, std::multiplies<>())) *
-                static_cast<size_t>(num_factors_to_calculate);
+                static_cast<size_t>(bin_indices[i] *
+                accumulated_bins *
+                num_factors_to_calculate);
         }
         index +=
-            static_cast<size_t>(bin_indices.back()) * static_cast<size_t>(num_factors_to_calculate);
+            static_cast<size_t>(bin_indices.back() * num_factors_to_calculate);
 
         // Now we can add the values of the factors that are not in factors_to_calculate_
         for (const auto &factor : context.mapping().entries()) {

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -332,9 +332,8 @@ void AnalysisModule::calculate_population_statistics(RuntimeContext &context) {
         size_t index = 0;
         for (size_t i = 0; i < bin_indices.size() - 1; i++) {
             size_t accumulated_bins = std::accumulate(std::next(factor_bins_.cbegin(), i + 1),
-                                                    factor_bins_.cend(), 1, std::multiplies<>());
-            index +=
-                bin_indices[i] * accumulated_bins * num_factors_to_calculate;
+                                                      factor_bins_.cend(), 1, std::multiplies<>());
+            index += bin_indices[i] * accumulated_bins * num_factors_to_calculate;
         }
         index += bin_indices.back() * num_factors_to_calculate;
 

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -333,7 +333,7 @@ void AnalysisModule::calculate_population_statistics(RuntimeContext &context) co
                                                     factor_bins_.cend(), 1, std::multiplies<>())) *
                 static_cast<size_t>(num_factors_to_calculate);
         }
-        index += bin_indices.back() * num_factors_to_calculate;
+        index += static_cast<size_t>(bin_indices.back()) * static_cast<size_t>(num_factors_to_calculate);
 
         // Now we can add the values of the factors that are not in factors_to_calculate_
         for (const auto &factor : context.mapping().entries()) {

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -323,7 +323,7 @@ void AnalysisModule::calculate_population_statistics(RuntimeContext &context) {
         std::vector<size_t> bin_indices;
         for (size_t i = 0; i < factors_to_calculate_.size(); i++) {
             double factor_value = person.get_risk_factor_value(factors_to_calculate_[i]);
-            size_t bin_index =
+            auto bin_index =
                 static_cast<size_t>((factor_value - factor_min_values_[i]) / factor_bin_widths_[i]);
             bin_indices.push_back(bin_index);
         }

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -22,6 +22,14 @@ AnalysisModule::AnalysisModule(AnalysisDefinition &&definition, WeightModel &&cl
       residual_disability_weight_{create_age_gender_table<double>(age_range)},
       comorbidities_{comorbidities} {}
 
+// Overload constructor with additional parameter for calculated_factors_
+AnalysisModule::AnalysisModule(AnalysisDefinition &&definition, WeightModel &&classifier,
+                               const core::IntegerInterval age_range, unsigned int comorbidities, std::vector<double> calculated_factors)
+    : definition_{std::move(definition)}, weight_classifier_{std::move(classifier)},
+      residual_disability_weight_{create_age_gender_table<double>(age_range)},
+      comorbidities_{comorbidities},
+        calculated_factors_{std::move(calculated_factors)}
+{}
 SimulationModuleType AnalysisModule::type() const noexcept {
     return SimulationModuleType::Analysis;
 }

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -138,7 +138,7 @@ void AnalysisModule::publish_result_message(RuntimeContext &context) const {
     auto handle = core::run_async(&AnalysisModule::calculate_historical_statistics, this,
                                   std::ref(context), std::ref(result));
 
-    calculate_population_statistics(context, calculated_factors_);
+    calculate_population_statistics(context);
     calculate_population_statistics(context, result.series);
     handle.get();
 
@@ -306,7 +306,7 @@ DALYsIndicator AnalysisModule::calculate_dalys(Population &population, unsigned 
 }
 
 void AnalysisModule::calculate_population_statistics(
-    RuntimeContext &context, std::vector<double> &calculated_factors) const {
+    RuntimeContext &context) const {
     auto num_factors_to_calculate =
         context.mapping().entries().size() - factors_to_calculate_.size();
 
@@ -328,10 +328,10 @@ void AnalysisModule::calculate_population_statistics(
         // Calculate the index in the calculated_factors_ vector
         auto index = 0;
         for (size_t i = 0; i < bin_indices.size() - 1; i++) {
-            index += bin_indices[i] *
-                     std::accumulate(std::next(factor_bins_.cbegin(), i + 1), factor_bins_.cend(),
-                                     1, std::multiplies<>()) *
-                     num_factors_to_calculate;
+            index += static_cast<size_t>(bin_indices[i]) *
+                     static_cast<size_t>(std::accumulate(std::next(factor_bins_.cbegin(), i + 1), factor_bins_.cend(),
+                                     1, std::multiplies<>())) *
+                     static_cast<size_t>(num_factors_to_calculate);
         }
         index += bin_indices.back() * num_factors_to_calculate;
 
@@ -339,7 +339,7 @@ void AnalysisModule::calculate_population_statistics(
         for (const auto &factor : context.mapping().entries()) {
             if (std::find(factors_to_calculate_.cbegin(), factors_to_calculate_.cend(),
                           factor.key()) == factors_to_calculate_.cend()) {
-                calculated_factors[index++] += entity.get_risk_factor_value(factor.key());
+                calculated_factors_[index++] += entity.get_risk_factor_value(factor.key());
             }
         }
     }

--- a/src/HealthGPS/analysis_module.h
+++ b/src/HealthGPS/analysis_module.h
@@ -55,7 +55,8 @@ class AnalysisModule final : public UpdatableModule {
     DALYsIndicator calculate_dalys(Population &population, unsigned int max_age,
                                    unsigned int death_year) const;
 
-    void calculate_population_statistics(RuntimeContext &context, std::vector<double> &calculated_factors) const;
+    void calculate_population_statistics(RuntimeContext &context,
+                                         std::vector<double> &calculated_factors) const;
     void calculate_population_statistics(RuntimeContext &context, DataSeries &series) const;
 
     void classify_weight(hgps::DataSeries &series, const hgps::Person &entity) const;

--- a/src/HealthGPS/analysis_module.h
+++ b/src/HealthGPS/analysis_module.h
@@ -23,6 +23,15 @@ class AnalysisModule final : public UpdatableModule {
     AnalysisModule(AnalysisDefinition &&definition, WeightModel &&classifier,
                    const core::IntegerInterval age_range, unsigned int comorbidities);
 
+    /// @brief Initialises a new instance of the AnalysisModule class.
+    /// @param definition The analysis module definition
+    /// @param classifier Body weight classifier model instance
+    /// @param age_range The experiment valid age range
+    /// @param comorbidities Maximum number of comorbidities to include
+    /// @param calculated_factors The calculated factors to include
+    AnalysisModule(AnalysisDefinition &&definition, WeightModel &&classifier,
+                               const core::IntegerInterval age_range, unsigned int comorbidities, std::vector<double> calculated_factors);
+
     SimulationModuleType type() const noexcept override;
 
     const std::string &name() const noexcept override;

--- a/src/HealthGPS/analysis_module.h
+++ b/src/HealthGPS/analysis_module.h
@@ -51,6 +51,7 @@ class AnalysisModule final : public UpdatableModule {
     mutable std::vector<double> calculated_factors_;
     std::vector<int> factor_bins_;
     std::vector<double> factor_bin_widths_;
+    std::vector<double> factor_min_values_;
 
     void initialise_vector(RuntimeContext &context);
 

--- a/src/HealthGPS/analysis_module.h
+++ b/src/HealthGPS/analysis_module.h
@@ -39,7 +39,7 @@ class AnalysisModule final : public UpdatableModule {
     unsigned int comorbidities_;
     std::string name_{"Analysis"};
     std::vector<core::Identifier> factors_to_calculate_ = {"Gender"_id, "Age"_id};
-    std::vector<double> calculated_factors_;
+    mutable std::vector<double> calculated_factors_;
     std::vector<int> factor_bins_;
     std::vector<double> factor_bin_widths_;
 
@@ -55,8 +55,7 @@ class AnalysisModule final : public UpdatableModule {
     DALYsIndicator calculate_dalys(Population &population, unsigned int max_age,
                                    unsigned int death_year) const;
 
-    void calculate_population_statistics(RuntimeContext &context,
-                                         std::vector<double> &calculated_factors) const;
+    void calculate_population_statistics(RuntimeContext &context) const;
     void calculate_population_statistics(RuntimeContext &context, DataSeries &series) const;
 
     void classify_weight(hgps::DataSeries &series, const hgps::Person &entity) const;

--- a/src/HealthGPS/analysis_module.h
+++ b/src/HealthGPS/analysis_module.h
@@ -66,7 +66,7 @@ class AnalysisModule final : public UpdatableModule {
     DALYsIndicator calculate_dalys(Population &population, unsigned int max_age,
                                    unsigned int death_year) const;
 
-    void calculate_population_statistics(RuntimeContext &context) const;
+    void calculate_population_statistics(RuntimeContext &context);
     void calculate_population_statistics(RuntimeContext &context, DataSeries &series) const;
 
     void classify_weight(hgps::DataSeries &series, const hgps::Person &entity) const;

--- a/src/HealthGPS/analysis_module.h
+++ b/src/HealthGPS/analysis_module.h
@@ -30,7 +30,7 @@ class AnalysisModule final : public UpdatableModule {
     /// @param comorbidities Maximum number of comorbidities to include
     /// @param calculated_factors The calculated factors to include
     AnalysisModule(AnalysisDefinition &&definition, WeightModel &&classifier,
-                   const core::IntegerInterval age_range, unsigned int comorbidities,
+                   core::IntegerInterval age_range, unsigned int comorbidities,
                    std::vector<double> calculated_factors);
 
     SimulationModuleType type() const noexcept override;

--- a/src/HealthGPS/analysis_module.h
+++ b/src/HealthGPS/analysis_module.h
@@ -30,7 +30,8 @@ class AnalysisModule final : public UpdatableModule {
     /// @param comorbidities Maximum number of comorbidities to include
     /// @param calculated_factors The calculated factors to include
     AnalysisModule(AnalysisDefinition &&definition, WeightModel &&classifier,
-                               const core::IntegerInterval age_range, unsigned int comorbidities, std::vector<double> calculated_factors);
+                   const core::IntegerInterval age_range, unsigned int comorbidities,
+                   std::vector<double> calculated_factors);
 
     SimulationModuleType type() const noexcept override;
 

--- a/src/HealthGPS/analysis_module.h
+++ b/src/HealthGPS/analysis_module.h
@@ -38,7 +38,10 @@ class AnalysisModule final : public UpdatableModule {
     std::vector<std::string> channels_;
     unsigned int comorbidities_;
     std::string name_{"Analysis"};
+    std::vector<core::Identifier> factors_to_calculate_ = {"Gender"_id, "Age"_id};
     std::vector<double> calculated_factors_;
+    std::vector<int> factor_bins_;
+    std::vector<double> factor_bin_widths_;
 
     void initialise_vector(RuntimeContext &context);
 
@@ -52,6 +55,7 @@ class AnalysisModule final : public UpdatableModule {
     DALYsIndicator calculate_dalys(Population &population, unsigned int max_age,
                                    unsigned int death_year) const;
 
+    void calculate_population_statistics(RuntimeContext &context, std::vector<double> &calculated_factors) const;
     void calculate_population_statistics(RuntimeContext &context, DataSeries &series) const;
 
     void classify_weight(hgps::DataSeries &series, const hgps::Person &entity) const;

--- a/src/HealthGPS/analysis_module.h
+++ b/src/HealthGPS/analysis_module.h
@@ -49,7 +49,7 @@ class AnalysisModule final : public UpdatableModule {
     unsigned int comorbidities_;
     std::string name_{"Analysis"};
     std::vector<core::Identifier> factors_to_calculate_ = {"Gender"_id, "Age"_id};
-    mutable std::vector<double> calculated_factors_;
+    std::vector<double> calculated_factors_;
     std::vector<int> factor_bins_;
     std::vector<double> factor_bin_widths_;
     std::vector<double> factor_min_values_;

--- a/src/HealthGPS/analysis_module.h
+++ b/src/HealthGPS/analysis_module.h
@@ -50,7 +50,7 @@ class AnalysisModule final : public UpdatableModule {
     std::string name_{"Analysis"};
     std::vector<core::Identifier> factors_to_calculate_ = {"Gender"_id, "Age"_id};
     std::vector<double> calculated_factors_;
-    std::vector<int> factor_bins_;
+    std::vector<size_t> factor_bins_;
     std::vector<double> factor_bin_widths_;
     std::vector<double> factor_min_values_;
 


### PR DESCRIPTION
This begins to tackle #420, but does not completely close that issue because I wanted to keep the PRs at at a reasonably-digestible size. More PRs to come if/when this gets approved. Happy to discuss this PR in person as it's a bit weird.

- Move initialisation of `factors` to the header file as a data member and rename to `factors_to_calculate_`. Eventually this will be set elsewhere anyway.
- Move `factor_bins_` to the header file as a data member. This is because it needs to be accessed elsewhere in the class.
- Introduces `factor_bin_widths_` as a data member. This helps us calculate which bin a given factor value is in later on.
- Overload the `calculate_population_statistics` function with the `calculated_factors_` vector in the signature instead of the `series` object. We can remove the original function when we have completed implementation of this new way of calculating the analysis.

The new, overloaded `calculate_population_statistics` function is the main focus of this PR. At the moment all it is doing is calculating the correct index in the `calculated_factors_` vector for a given entity. This is necessary because we are representing a matrix of arbitrary dimensions in a flat vector. The number of dimensions is equal to the size of `factors_to_calculate_`.

The calculation for fetching the correct index is based on the following idea for calculating the index in a 3D, row-major ordered matrix with dimensions of length `L`, `M`, and `N`.
```
matrix[ i ][ j ][ k ] = vector[ i*(N*M) + j*M + k ]
```
but extended to be able to deal with an arbitrary number of dimensions (I *think* I have done this right, really this is the bit of the PR that I'm most interested in being reviewed). 