### PR TITLE
Fix YLL/Y:D/DALY and death

### DIFF
--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -329,7 +329,7 @@ void AnalysisModule::calculate_population_statistics(RuntimeContext &context,
             }
 
             if (entity.has_emigrated() && entity.time_of_migration() == current_time) {
-                series(gender, "migrations").at(age)++;
+                series(gender, "emigrations").at(age)++;
             }
 
             continue;
@@ -474,6 +474,10 @@ void AnalysisModule::initialise_output_channels(RuntimeContext &context) {
         return;
     }
 
+    channels_.emplace_back("count");
+    channels_.emplace_back("deaths");
+    channels_.emplace_back("emigrations");
+
     for (const auto &factor : context.mapping().entries()) {
         channels_.emplace_back("mean_" + factor.key().to_string());
         channels_.emplace_back("std_" + factor.key().to_string());
@@ -484,9 +488,6 @@ void AnalysisModule::initialise_output_channels(RuntimeContext &context) {
         channels_.emplace_back("incidence_" + disease.code.to_string());
     }
 
-    channels_.emplace_back("count");
-    channels_.emplace_back("deaths");
-    channels_.emplace_back("migrations");
     channels_.emplace_back("normal_weight");
     channels_.emplace_back("over_weight");
     channels_.emplace_back("obese_weight");

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -427,7 +427,7 @@ void AnalysisModule::calculate_standard_deviation(RuntimeContext &context,
     }
 
     // Calculate in-place standard deviation.
-    auto divide_by_count = [&series](const std::string &chan, core::Gender sex, int age) {
+    auto divide_by_count_sqrt = [&series](const std::string &chan, core::Gender sex, int age) {
         const double count = series(sex, "count").at(age);
         const double sum = series(sex, chan).at(age);
         const double std = std::sqrt(sum / count);
@@ -442,10 +442,10 @@ void AnalysisModule::calculate_standard_deviation(RuntimeContext &context,
             }
 
             // Factor standard deviation for females.
-            divide_by_count(chan, core::Gender::female, age);
+            divide_by_count_sqrt(chan, core::Gender::female, age);
 
             // Factor standard deviation for males.
-            divide_by_count(chan, core::Gender::male, age);
+            divide_by_count_sqrt(chan, core::Gender::male, age);
         }
     }
 }

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -352,7 +352,6 @@ void AnalysisModule::calculate_population_statistics(RuntimeContext &context,
         }
 
         auto dw = calculate_disability_weight(entity);
-        series(gender, "disability_weight").at(age) += dw;
         series(gender, "mean_yld").at(age) += (dw * DALY_UNITS);
 
         classify_weight(series, entity);
@@ -475,8 +474,6 @@ void AnalysisModule::initialise_output_channels(RuntimeContext &context) {
         return;
     }
 
-    channels_.emplace_back("count");
-
     for (const auto &factor : context.mapping().entries()) {
         channels_.emplace_back("mean_" + factor.key().to_string());
         channels_.emplace_back("std_" + factor.key().to_string());
@@ -487,7 +484,7 @@ void AnalysisModule::initialise_output_channels(RuntimeContext &context) {
         channels_.emplace_back("incidence_" + disease.code.to_string());
     }
 
-    channels_.emplace_back("disability_weight");
+    channels_.emplace_back("count");
     channels_.emplace_back("deaths");
     channels_.emplace_back("migrations");
     channels_.emplace_back("normal_weight");


### PR DESCRIPTION
Fixes #442. 

The loops for mean and std have been tidied up, and are now 'opt-in', so no unwanted surprises in other columns that don't opt in.

YLL/YLD/DALY are now correctly computed by dividing by active *PLUS* deceased population.

Everything that should be an integer, such as deaths, migrations, weight classifications, is now an integer. Update your scripts accordingly.