### PR TITLE
Fix race conditions when extracting zip files

### DIFF
--- a/src/HealthGPS.Datastore/zip_file.cpp
+++ b/src/HealthGPS.Datastore/zip_file.cpp
@@ -96,11 +96,9 @@ void extract_zip_file(const std::filesystem::path &file_path,
 std::filesystem::path extract_zip_file_or_load_from_cache(const std::filesystem::path &file_path) {
     const auto file_hash = compute_sha256_for_file(file_path);
     auto cache_path = get_zip_cache_directory(file_hash);
-    if (std::filesystem::exists(cache_path)) {
-        return cache_path;
+    if (!std::filesystem::exists(cache_path)) {
+        extract_zip_file(file_path, cache_path);
     }
-
-    extract_zip_file(file_path, cache_path);
 
     return cache_path;
 }


### PR DESCRIPTION
Before extracting a zip file, we check whether we already have the contents of that file extracted to a cache folder and, if so, skip the extraction.

While this is safe to do if there is only one HealthGPS process running, if there are multiple processes attempting to extract the zip file at the same time, there is a potential race condition (#454):

1. Process A observes that the cache folder doesn't exist, creates it and begins extraction
2. Process B observes that the cache folder exists, tries to use it before extraction is complete and crashes
3. Process A completes extraction

Note that while this sounds unlikely, it is entirely possible that this could happen with multiple jobs running on the HPC (particularly given that filesystem access is often slow on the Imperial HPC).

Another possible bug is that a HealthGPS could terminate before extraction is complete, in which case, again, the cache folder will exist, but only contain a subset of the data files. In this case, the only remedy would be to delete the cache folder -- not particularly user friendly.

This PR solves both of these problems by performing extraction to a temporary folder (with a unique name) before renaming the folder. While moving a folder is not guaranteed to be atomic because it may involve copying data between devices, it seems that renaming them *should* be (or at least it is on POSIX, which will fix the HPC case).

Fixes #454.