### PR TITLE
Allow HTTP redirects for file downloads

### DIFF
--- a/src/HealthGPS.Datastore/download_file.cpp
+++ b/src/HealthGPS.Datastore/download_file.cpp
@@ -44,6 +44,7 @@ std::filesystem::path download_file(const std::string &url,
     // Our request to be sent
     curlpp::Easy request;
     request.setOpt<curlpp::options::Url>(url);
+    request.setOpt<curlpp::options::FollowLocation>(true);
     request.setOpt<curlpp::options::WriteStream>(&ofs);
 
     // Make request

--- a/src/HealthGPS.Datastore/download_file.cpp
+++ b/src/HealthGPS.Datastore/download_file.cpp
@@ -32,8 +32,7 @@ std::filesystem::path get_temporary_file_path(const std::string &file_prefix,
 } // anonymous namespace
 
 namespace hgps::data {
-std::filesystem::path download_file(const std::string &url,
-                                    const std::filesystem::path &download_path) {
+void download_file(const std::string &url, const std::filesystem::path &download_path) {
     std::ofstream ofs{download_path};
     if (!ofs) {
         throw std::runtime_error(fmt::format("Failed to create file {}", download_path.string()));
@@ -51,14 +50,13 @@ std::filesystem::path download_file(const std::string &url,
 
     // Make request
     request.perform();
-
-    return download_path;
 }
 
 std::filesystem::path download_file_to_temporary(const std::string &url,
                                                  const std::string &file_extension) {
     const auto download_path = get_temporary_file_path("data", file_extension);
-    return download_file(url, download_path);
+    download_file(url, download_path);
+    return download_path;
 }
 
 } // namespace hgps::data

--- a/src/HealthGPS.Datastore/download_file.cpp
+++ b/src/HealthGPS.Datastore/download_file.cpp
@@ -39,6 +39,8 @@ std::filesystem::path download_file(const std::string &url,
         throw std::runtime_error(fmt::format("Failed to create file {}", download_path.string()));
     }
 
+    fmt::println("Downloading data from {}", url);
+
     curlpp::Cleanup cleanup;
 
     // Our request to be sent

--- a/src/HealthGPS.Datastore/download_file.h
+++ b/src/HealthGPS.Datastore/download_file.h
@@ -7,9 +7,7 @@ namespace hgps::data {
 /// @brief Download the file at the specified URL
 /// @param url URL to download from
 /// @param download_path Destination for downloaded files, including filename
-/// @return Path to downloaded file
-std::filesystem::path download_file(const std::string &url,
-                                    const std::filesystem::path &download_path);
+void download_file(const std::string &url, const std::filesystem::path &download_path);
 
 /// @brief Download the file at the specified URL to a temporary folder
 /// @param url URL to download from


### PR DESCRIPTION
It turns out GitHub often redirects file downloads to another URL, which the current code won't handle. Fix by telling libcurl to allow this (it's disabled by default).

Fixes #457.

With this fix, we can finally use data from the `healthgps-data` repo as an input source directly :smile:

See: https://github.com/imperialCHEPI/healthgps-data/releases/tag/20240624
