### PR TITLE
Correct calculation of size of `calculated_stats_` vector

### DIFF
--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -63,8 +63,8 @@ void AnalysisModule::initialise_vector(RuntimeContext &context) {
     // `factors` vector.
     size_t num_stats_to_calc = context.mapping().entries().size() - factors_to_calculate_.size();
 
-    // And for each factor, we calculate the stats described in `stats_to_calculate_`, so we
-    // multiply the number of stats to calculate by the number of factors to calculate stats for.
+    // And for each factor, we calculate the stats described in `channels_`, so we
+    // multiply the size of `channels_` by the number of factors to calculate stats for.
     num_stats_to_calc *= channels_.size();
 
     // The product of the number of bins for each factor can be used to calculate the size of the

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -63,20 +63,9 @@ void AnalysisModule::initialise_vector(RuntimeContext &context) {
     // `factors` vector.
     size_t num_stats_to_calc = context.mapping().entries().size() - factors_to_calculate_.size();
 
-    // But we calculate the mean and standard deviation of each factor, so we need to multiply by 2
-    num_stats_to_calc *= 2;
-
-    // We also want to calculate the prevalence and incidence of each disease
-    num_stats_to_calc += 2 * context.diseases().size();
-
-    // We also want to keep the count, deaths, and emigrations
-    num_stats_to_calc += 3;
-
-    // We also want to calculate the normal, overweight, obese, and above weight prevalence
-    num_stats_to_calc += 4;
-
-    // Finally, we want to calculate the mean and standard deviation of YLL, YLD, and DALY
-    num_stats_to_calc += 6;
+    // And for each factor, we calculate the stats described in `stats_to_calculate_`, so we
+    // multiply the number of stats to calculate by the number of factors to calculate stats for.
+    num_stats_to_calc *= stats_to_calculate_.size();
 
     // The product of the number of bins for each factor can be used to calculate the size of the
     // `calculated_stats_` in the next step
@@ -571,6 +560,37 @@ void AnalysisModule::initialise_output_channels(RuntimeContext &context) {
     channels_.emplace_back("std_yld");
     channels_.emplace_back("mean_daly");
     channels_.emplace_back("std_daly");
+}
+
+void AnalysisModule::initialise_stats_to_calc(RuntimeContext &context) {
+    if (!stats_to_calculate_.empty()) {
+        return;
+    }
+
+    stats_to_calculate_.push_back("count");
+    stats_to_calculate_.push_back("deaths");
+    stats_to_calculate_.push_back("emigrations");
+
+    for (const auto &factor : context.mapping().entries()) {
+        stats_to_calculate_.push_back("mean_" + factor.key().to_string());
+        stats_to_calculate_.push_back("std_" + factor.key().to_string());
+    }
+
+    for (const auto &disease : context.diseases()) {
+        stats_to_calculate_.push_back("prevalence_" + disease.code.to_string());
+        stats_to_calculate_.push_back("incidence_" + disease.code.to_string());
+    }
+
+    stats_to_calculate_.push_back("normal_weight");
+    stats_to_calculate_.push_back("over_weight");
+    stats_to_calculate_.push_back("obese_weight");
+    stats_to_calculate_.push_back("above_weight");
+    stats_to_calculate_.push_back("mean_yll");
+    stats_to_calculate_.push_back("std_yll");
+    stats_to_calculate_.push_back("mean_yld");
+    stats_to_calculate_.push_back("std_yld");
+    stats_to_calculate_.push_back("mean_daly");
+    stats_to_calculate_.push_back("std_daly");
 }
 
 std::unique_ptr<AnalysisModule> build_analysis_module(Repository &repository,

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -65,7 +65,7 @@ void AnalysisModule::initialise_vector(RuntimeContext &context) {
 
     // And for each factor, we calculate the stats described in `stats_to_calculate_`, so we
     // multiply the number of stats to calculate by the number of factors to calculate stats for.
-    num_stats_to_calc *= stats_to_calculate_.size();
+    num_stats_to_calc *= channels_.size();
 
     // The product of the number of bins for each factor can be used to calculate the size of the
     // `calculated_stats_` in the next step
@@ -560,37 +560,6 @@ void AnalysisModule::initialise_output_channels(RuntimeContext &context) {
     channels_.emplace_back("std_yld");
     channels_.emplace_back("mean_daly");
     channels_.emplace_back("std_daly");
-}
-
-void AnalysisModule::initialise_stats_to_calc(RuntimeContext &context) {
-    if (!stats_to_calculate_.empty()) {
-        return;
-    }
-
-    stats_to_calculate_.push_back("count");
-    stats_to_calculate_.push_back("deaths");
-    stats_to_calculate_.push_back("emigrations");
-
-    for (const auto &factor : context.mapping().entries()) {
-        stats_to_calculate_.push_back("mean_" + factor.key().to_string());
-        stats_to_calculate_.push_back("std_" + factor.key().to_string());
-    }
-
-    for (const auto &disease : context.diseases()) {
-        stats_to_calculate_.push_back("prevalence_" + disease.code.to_string());
-        stats_to_calculate_.push_back("incidence_" + disease.code.to_string());
-    }
-
-    stats_to_calculate_.push_back("normal_weight");
-    stats_to_calculate_.push_back("over_weight");
-    stats_to_calculate_.push_back("obese_weight");
-    stats_to_calculate_.push_back("above_weight");
-    stats_to_calculate_.push_back("mean_yll");
-    stats_to_calculate_.push_back("std_yll");
-    stats_to_calculate_.push_back("mean_yld");
-    stats_to_calculate_.push_back("std_yld");
-    stats_to_calculate_.push_back("mean_daly");
-    stats_to_calculate_.push_back("std_daly");
 }
 
 std::unique_ptr<AnalysisModule> build_analysis_module(Repository &repository,

--- a/src/HealthGPS/analysis_module.h
+++ b/src/HealthGPS/analysis_module.h
@@ -46,7 +46,6 @@ class AnalysisModule final : public UpdatableModule {
     WeightModel weight_classifier_;
     DoubleAgeGenderTable residual_disability_weight_;
     std::vector<std::string> channels_;
-    std::vector<std::string> stats_to_calculate_;
     unsigned int comorbidities_;
     std::string name_{"Analysis"};
     std::vector<core::Identifier> factors_to_calculate_ = {"Gender"_id, "Age"_id};

--- a/src/HealthGPS/analysis_module.h
+++ b/src/HealthGPS/analysis_module.h
@@ -46,6 +46,7 @@ class AnalysisModule final : public UpdatableModule {
     WeightModel weight_classifier_;
     DoubleAgeGenderTable residual_disability_weight_;
     std::vector<std::string> channels_;
+    std::vector<std::string> stats_to_calculate_;
     unsigned int comorbidities_;
     std::string name_{"Analysis"};
     std::vector<core::Identifier> factors_to_calculate_ = {"Gender"_id, "Age"_id};

--- a/src/HealthGPS/analysis_module.h
+++ b/src/HealthGPS/analysis_module.h
@@ -49,7 +49,7 @@ class AnalysisModule final : public UpdatableModule {
     unsigned int comorbidities_;
     std::string name_{"Analysis"};
     std::vector<core::Identifier> factors_to_calculate_ = {"Gender"_id, "Age"_id};
-    std::vector<double> calculated_factors_;
+    std::vector<double> calculated_stats_;
     std::vector<size_t> factor_bins_;
     std::vector<double> factor_bin_widths_;
     std::vector<double> factor_min_values_;


### PR DESCRIPTION
In #453 I introduced the `calculated_factors_` vector to store the calculated stats for each bin for each factor the user wants to calculate stats for. The size of this vector is calculated and set in `initialise_vector` method, but initially I only allowed one "channel" per factor. This PR fixes this by including the other "channels" in the vector resize calculation, namely those specified in the already-existing `initialise_output_channels` method:

https://github.com/imperialCHEPI/healthgps/blob/46677a62b0f66b650fb57edae14ca2a8688d5ca6/src/HealthGPS/analysis_module.cpp#L530-L559

I have also renamed the vector to `calculated_stats_` as it seems more appropriate.