### PR TITLE
Refactor code for parsing command-line arguments

### DIFF
--- a/src/HealthGPS.Console/command_options.cpp
+++ b/src/HealthGPS.Console/command_options.cpp
@@ -23,7 +23,6 @@ std::optional<CommandOptions> parse_arguments(cxxopts::Options &options, int arg
     namespace fs = std::filesystem;
 
     CommandOptions cmd;
-    cmd.verbose = false;
     auto result = options.parse(argc, argv);
 
     if (result.count("help")) {

--- a/src/HealthGPS.Console/command_options.cpp
+++ b/src/HealthGPS.Console/command_options.cpp
@@ -57,7 +57,7 @@ std::optional<CommandOptions> parse_arguments(cxxopts::Options &options, int arg
 
         fmt::print(fmt::fg(fmt::color::yellow),
                    "WARNING: Path to data source specified with command-line argument. "
-                   "This functionality is deprecatated and will be removed in future. You "
+                   "This functionality is deprecated and will be removed in future. You "
                    "should pass the data source via the config file.\n");
         fmt::print("Data source: {}\n", source);
 

--- a/src/HealthGPS.Console/command_options.cpp
+++ b/src/HealthGPS.Console/command_options.cpp
@@ -46,12 +46,10 @@ CommandOptions parse_arguments(cxxopts::Options &options, int &argc, char *argv[
             fmt::print(fg(fmt::color::dark_salmon), "Verbose output enabled\n");
         }
 
-        if (result.count("file")) {
-            cmd.config_file = result["file"].as<std::string>();
-            if (cmd.config_file.is_relative()) {
-                cmd.config_file = std::filesystem::absolute(cmd.config_file);
-                fmt::print("Configuration file..: {}\n", cmd.config_file.string());
-            }
+        cmd.config_file = result["file"].as<std::string>();
+        if (cmd.config_file.is_relative()) {
+            cmd.config_file = std::filesystem::absolute(cmd.config_file);
+            fmt::print("Configuration file..: {}\n", cmd.config_file.string());
         }
 
         if (!fs::exists(cmd.config_file)) {

--- a/src/HealthGPS.Console/command_options.h
+++ b/src/HealthGPS.Console/command_options.h
@@ -14,14 +14,8 @@
 namespace hgps {
 /// @brief Defines the Command Line Interface (CLI) arguments options
 struct CommandOptions {
-    /// @brief Indicates whether the argument parsing succeed
-    bool success{};
-
-    /// @brief The exit code to return, in case of CLI arguments parsing failure
-    int exit_code{};
-
     /// @brief The configuration file argument value
-    std::filesystem::path config_file{};
+    std::filesystem::path config_file;
 
     /// @brief The back-end storage full path or URL argument value
     std::optional<hgps::input::DataSource> data_source;
@@ -41,7 +35,7 @@ cxxopts::Options create_options();
 /// @param options The valid CLI options
 /// @param argc Number of input arguments
 /// @param argv List of input arguments
-/// @return User command-line options
-CommandOptions parse_arguments(cxxopts::Options &options, int &argc, char *argv[]);
+/// @return User command-line options or std::nullopt if program should exit
+std::optional<CommandOptions> parse_arguments(cxxopts::Options &options, int argc, char **argv);
 
 } // namespace hgps

--- a/src/HealthGPS.Console/program.cpp
+++ b/src/HealthGPS.Console/program.cpp
@@ -81,10 +81,22 @@ int main(int argc, char *argv[]) { // NOLINT(bugprone-exception-escape)
 
     // Print application title and parse command line arguments
     print_app_title();
-    auto cmd_args = parse_arguments(options, argc, argv);
-    if (!cmd_args.success) {
-        return cmd_args.exit_code;
+
+    std::optional<CommandOptions> cmd_args_opt;
+    try {
+        cmd_args_opt = parse_arguments(options, argc, argv);
+
+        // We won't get a config if e.g. the user chooses the --help option
+        if (!cmd_args_opt) {
+            return exit_application(EXIT_SUCCESS);
+        }
+    } catch (const std::exception &ex) {
+        fmt::print(fg(fmt::color::red), "\nInvalid command line argument: {}\n", ex.what());
+        fmt::print("\n{}\n", options.help());
+        return exit_application(EXIT_FAILURE);
     }
+
+    const auto &cmd_args = cmd_args_opt.value();
 
     // Parse inputs configuration file, *.json.
     Configuration config;


### PR DESCRIPTION
I was trying to change some of the functionality around parsing command-line args and found that the error handling in `parse_arguments` is a bit messy.

There are three cases the function has to handle:

1. The args are valid and the program should start a simulation
2. The args are valid but the program should abort (e.g. if the user passes the `--help` argument)
3. The args are invalid

Previously, the function returned all this information within a `CommandArgs` struct. I've refactored the code so that the function returns a `std::optional<CommandArgs>` instead:

1. If we want to start a simulation, a `CommandArgs` struct is returned
2. If the args are valid, but we want to abort, `std::nullopt` is returned
3. Else an exception is raised