### PR TITLE
create_intervention_scenario: std::move risk_impacts to avoid copying

### DIFF
--- a/src/HealthGPS.Input/configuration.cpp
+++ b/src/HealthGPS.Input/configuration.cpp
@@ -278,18 +278,18 @@ create_intervention_scenario(SyncChannel &channel, const PolicyScenarioInfo &inf
             throw std::logic_error(fmt::format("Unknown policy impact type: {}", info.impact_type));
         }
 
-        auto definition = SimplePolicyDefinition(impact_type, risk_impacts, period);
+        auto definition = SimplePolicyDefinition(impact_type, std::move(risk_impacts), period);
         return std::make_unique<SimplePolicyScenario>(channel, std::move(definition));
     }
 
     if (info.identifier == "marketing") {
-        auto definition = MarketingPolicyDefinition(period, risk_impacts);
+        auto definition = MarketingPolicyDefinition(period, std::move(risk_impacts));
         return std::make_unique<MarketingPolicyScenario>(channel, std::move(definition));
     }
 
     if (info.identifier == "dynamic_marketing") {
         auto dynamic = PolicyDynamic{info.dynamics};
-        auto definition = MarketingDynamicDefinition{period, risk_impacts, dynamic};
+        auto definition = MarketingDynamicDefinition{period, std::move(risk_impacts), dynamic};
         return std::make_unique<MarketingDynamicScenario>(channel, std::move(definition));
     }
 
@@ -303,7 +303,7 @@ create_intervention_scenario(SyncChannel &channel, const PolicyScenarioInfo &inf
         const auto &adjustment = info.adjustments.at(0);
         auto definition = FoodLabellingDefinition{
             .active_period = period,
-            .impacts = risk_impacts,
+            .impacts = std::move(risk_impacts),
             .adjustment_risk_factor = AdjustmentFactor{adjustment.risk_factor, adjustment.value},
             .coverage = PolicyCoverage{info.coverage_rates, cutoff_time},
             .transfer_coefficient = TransferCoefficient{info.coefficients, cutoff_age}};
@@ -313,7 +313,7 @@ create_intervention_scenario(SyncChannel &channel, const PolicyScenarioInfo &inf
 
     if (info.identifier == "physical_activity") {
         auto definition = PhysicalActivityDefinition{.active_period = period,
-                                                     .impacts = risk_impacts,
+                                                     .impacts = std::move(risk_impacts),
                                                      .coverage_rate = info.coverage_rates.at(0)};
 
         return std::make_unique<PhysicalActivityScenario>(channel, std::move(definition));
@@ -321,7 +321,7 @@ create_intervention_scenario(SyncChannel &channel, const PolicyScenarioInfo &inf
 
     if (info.identifier == "fiscal") {
         auto impact_type = parse_fiscal_impact_type(info.impact_type);
-        auto definition = FiscalPolicyDefinition(impact_type, period, risk_impacts);
+        auto definition = FiscalPolicyDefinition(impact_type, period, std::move(risk_impacts));
         return std::make_unique<FiscalPolicyScenario>(channel, std::move(definition));
     }
 

--- a/src/HealthGPS/fiscal_scenario.h
+++ b/src/HealthGPS/fiscal_scenario.h
@@ -26,8 +26,8 @@ struct FiscalPolicyDefinition {
     /// @param period The intervention implementation period
     /// @param sorted_impacts The impacts on risk factors
     FiscalPolicyDefinition(const FiscalImpactType type_of_impact, const PolicyInterval &period,
-                           const std::vector<PolicyImpact> &sorted_impacts)
-        : impact_type{type_of_impact}, active_period{period}, impacts{sorted_impacts} {}
+                           std::vector<PolicyImpact> sorted_impacts)
+        : impact_type{type_of_impact}, active_period{period}, impacts{std::move(sorted_impacts)} {}
 
     /// @brief The fiscal impact type
     FiscalImpactType impact_type;

--- a/src/HealthGPS/marketing_dynamic_scenario.h
+++ b/src/HealthGPS/marketing_dynamic_scenario.h
@@ -16,9 +16,8 @@ struct MarketingDynamicDefinition {
     /// @param sorted_impacts The impacts on risk factors
     /// @param dynamic The population dynamic parameters
     MarketingDynamicDefinition(const PolicyInterval &period,
-                               const std::vector<PolicyImpact> &sorted_impacts,
-                               PolicyDynamic dynamic)
-        : active_period{period}, impacts{sorted_impacts}, dynamic{std::move(dynamic)} {}
+                               std::vector<PolicyImpact> sorted_impacts, PolicyDynamic dynamic)
+        : active_period{period}, impacts{std::move(sorted_impacts)}, dynamic{std::move(dynamic)} {}
 
     /// @brief Intervention active period
     PolicyInterval active_period;

--- a/src/HealthGPS/marketing_dynamic_scenario.h
+++ b/src/HealthGPS/marketing_dynamic_scenario.h
@@ -17,7 +17,7 @@ struct MarketingDynamicDefinition {
     /// @param dynamic The population dynamic parameters
     MarketingDynamicDefinition(const PolicyInterval &period,
                                std::vector<PolicyImpact> sorted_impacts, PolicyDynamic dynamic)
-        : active_period{period}, impacts{std::move(sorted_impacts)}, dynamic{std::move(dynamic)} {}
+        : active_period{period}, impacts{std::move(sorted_impacts)}, dynamic{dynamic} {}
 
     /// @brief Intervention active period
     PolicyInterval active_period;

--- a/src/HealthGPS/marketing_scenario.h
+++ b/src/HealthGPS/marketing_scenario.h
@@ -13,8 +13,8 @@ struct MarketingPolicyDefinition {
     /// @param period The implementation period
     /// @param sorted_impacts The impacts on risk factors
     MarketingPolicyDefinition(const PolicyInterval &period,
-                              const std::vector<PolicyImpact> &sorted_impacts)
-        : active_period{period}, impacts{sorted_impacts} {}
+                              std::vector<PolicyImpact> sorted_impacts)
+        : active_period{period}, impacts{std::move(sorted_impacts)} {}
 
     /// @brief Intervention active period
     PolicyInterval active_period;

--- a/src/HealthGPS/simple_policy_scenario.h
+++ b/src/HealthGPS/simple_policy_scenario.h
@@ -25,9 +25,8 @@ struct SimplePolicyDefinition {
     /// @param sorted_impacts The impact on risk factors
     /// @param period The implementation period
     SimplePolicyDefinition(const PolicyImpactType &type_of_impact,
-                           const std::vector<PolicyImpact> &sorted_impacts,
-                           const PolicyInterval &period)
-        : impact_type{type_of_impact}, impacts{sorted_impacts}, active_period{period} {}
+                           std::vector<PolicyImpact> sorted_impacts, const PolicyInterval &period)
+        : impact_type{type_of_impact}, impacts{std::move(sorted_impacts)}, active_period{period} {}
 
     /// @brief Intervention impact type
     PolicyImpactType impact_type;


### PR DESCRIPTION
While I was mucking about in the code base, I noticed that we were missing an opportunity to `std::move` something in `create_intervention_scenario()`, so I've fixed it up.