### PR TITLE
Time trend for expected values

### DIFF
--- a/src/HealthGPS.Input/model_parser.cpp
+++ b/src/HealthGPS.Input/model_parser.cpp
@@ -332,9 +332,9 @@ load_staticlinear_risk_model_definition(const nlohmann::json &opt, const Configu
     const double physical_activity_stddev = opt["PhysicalActivityStdDev"].get<double>();
 
     return std::make_unique<hgps::StaticLinearModelDefinition>(
-        std::move(expected), std::move(names), std::move(models), std::move(ranges),
-        std::move(lambda), std::move(stddev), std::move(cholesky), std::move(policy_models),
-        std::move(policy_ranges), std::move(policy_cholesky), info_speed,
+        std::move(expected), std::move(expected_trend), std::move(names), std::move(models),
+        std::move(ranges), std::move(lambda), std::move(stddev), std::move(cholesky),
+        std::move(policy_models), std::move(policy_ranges), std::move(policy_cholesky), info_speed,
         std::move(rural_prevalence), std::move(income_models), physical_activity_stddev);
 }
 

--- a/src/HealthGPS.Input/model_parser.cpp
+++ b/src/HealthGPS.Input/model_parser.cpp
@@ -178,14 +178,14 @@ load_staticlinear_risk_model_definition(const nlohmann::json &opt, const Configu
                                       policy_covariance_table.num_columns()};
 
     // Risk factor and intervention policy: names, models, parameters and correlation/covariance.
-    std::vector<hgps::core::Identifier> names;
-    std::vector<hgps::LinearModelParams> models;
-    std::vector<hgps::core::DoubleInterval> ranges;
+    std::vector<core::Identifier> names;
+    std::vector<LinearModelParams> models;
+    std::vector<core::DoubleInterval> ranges;
     std::vector<double> lambda;
     std::vector<double> stddev;
-    std::vector<hgps::LinearModelParams> policy_models;
-    std::vector<hgps::core::DoubleInterval> policy_ranges;
-    std::vector<double> expected_trend;
+    std::vector<LinearModelParams> policy_models;
+    std::vector<core::DoubleInterval> policy_ranges;
+    std::unordered_map<core::Identifier, double> expected_trend;
 
     size_t i = 0;
     for (const auto &[key, json_params] : opt["RiskFactorModels"].items()) {
@@ -243,7 +243,7 @@ load_staticlinear_risk_model_definition(const nlohmann::json &opt, const Configu
         }
 
         // Load expected value trends.
-        expected_trend.emplace_back(json_params["ExpectedTrend"].get<double>());
+        expected_trend[key] = json_params["ExpectedTrend"].get<double>();
 
         // Increment table column index.
         i++;

--- a/src/HealthGPS.Input/model_parser.cpp
+++ b/src/HealthGPS.Input/model_parser.cpp
@@ -431,9 +431,11 @@ load_ebhlm_risk_model_definition(const nlohmann::json &opt, const Configuration 
 
     // Risk factor expected values by sex and age.
     std::unique_ptr<hgps::RiskFactorSexAgeTable> expected = load_risk_factor_expected(config);
+    auto expected_trend = std::make_unique<std::unordered_map<core::Identifier, double>>();
 
     return std::make_unique<hgps::DynamicHierarchicalLinearModelDefinition>(
-        std::move(expected), std::move(equations), std::move(variables), percentage);
+        std::move(expected), std::move(expected_trend), std::move(equations), std::move(variables),
+        percentage);
 }
 // NOLINTEND(readability-function-cognitive-complexity)
 
@@ -443,6 +445,7 @@ load_kevinhall_risk_model_definition(const nlohmann::json &opt, const Configurat
 
     // Risk factor expected values by sex and age.
     std::unique_ptr<hgps::RiskFactorSexAgeTable> expected = load_risk_factor_expected(config);
+    auto expected_trend = std::make_unique<std::unordered_map<core::Identifier, double>>();
 
     // Nutrient groups.
     std::unordered_map<hgps::core::Identifier, double> energy_equation;
@@ -512,9 +515,10 @@ load_kevinhall_risk_model_definition(const nlohmann::json &opt, const Configurat
         {hgps::core::Gender::male, opt["HeightSlope"]["Male"].get<double>()}};
 
     return std::make_unique<hgps::KevinHallModelDefinition>(
-        std::move(expected), std::move(energy_equation), std::move(nutrient_ranges),
-        std::move(nutrient_equations), std::move(food_prices), std::move(weight_quantiles),
-        std::move(epa_quantiles), std::move(height_stddev), std::move(height_slope));
+        std::move(expected), std::move(expected_trend), std::move(energy_equation),
+        std::move(nutrient_ranges), std::move(nutrient_equations), std::move(food_prices),
+        std::move(weight_quantiles), std::move(epa_quantiles), std::move(height_stddev),
+        std::move(height_slope));
 }
 
 std::pair<hgps::RiskFactorModelType, std::unique_ptr<hgps::RiskFactorModelDefinition>>

--- a/src/HealthGPS.Input/model_parser.cpp
+++ b/src/HealthGPS.Input/model_parser.cpp
@@ -185,6 +185,7 @@ load_staticlinear_risk_model_definition(const nlohmann::json &opt, const Configu
     std::vector<double> stddev;
     std::vector<hgps::LinearModelParams> policy_models;
     std::vector<hgps::core::DoubleInterval> policy_ranges;
+    std::vector<double> expected_trend;
 
     size_t i = 0;
     for (const auto &[key, json_params] : opt["RiskFactorModels"].items()) {
@@ -240,6 +241,9 @@ load_staticlinear_risk_model_definition(const nlohmann::json &opt, const Configu
             policy_covariance(i, j) =
                 std::any_cast<double>(policy_covariance_table.column(i).value(j));
         }
+
+        // Load expected value trends.
+        expected_trend.emplace_back(json_params["ExpectedTrend"].get<double>());
 
         // Increment table column index.
         i++;

--- a/src/HealthGPS.Input/model_parser.cpp
+++ b/src/HealthGPS.Input/model_parser.cpp
@@ -185,7 +185,7 @@ load_staticlinear_risk_model_definition(const nlohmann::json &opt, const Configu
     std::vector<double> stddev;
     std::vector<LinearModelParams> policy_models;
     std::vector<core::DoubleInterval> policy_ranges;
-    std::unordered_map<core::Identifier, double> expected_trend;
+    auto expected_trend = std::make_unique<std::unordered_map<core::Identifier, double>>();
 
     size_t i = 0;
     for (const auto &[key, json_params] : opt["RiskFactorModels"].items()) {
@@ -243,7 +243,7 @@ load_staticlinear_risk_model_definition(const nlohmann::json &opt, const Configu
         }
 
         // Load expected value trends.
-        expected_trend[key] = json_params["ExpectedTrend"].get<double>();
+        (*expected_trend)[key] = json_params["ExpectedTrend"].get<double>();
 
         // Increment table column index.
         i++;

--- a/src/HealthGPS.Input/model_parser.cpp
+++ b/src/HealthGPS.Input/model_parser.cpp
@@ -273,7 +273,7 @@ load_staticlinear_risk_model_definition(const nlohmann::json &opt, const Configu
         Eigen::MatrixXd{Eigen::LLT<Eigen::MatrixXd>{policy_covariance}.matrixL()};
 
     // Risk factor expected values by sex and age.
-    std::unique_ptr<hgps::RiskFactorSexAgeTable> expected = load_risk_factor_expected(config);
+    auto expected = load_risk_factor_expected(config);
 
     // Check expected values are defined for all risk factors.
     for (const auto &name : names) {
@@ -430,7 +430,7 @@ load_ebhlm_risk_model_definition(const nlohmann::json &opt, const Configuration 
     }
 
     // Risk factor expected values by sex and age.
-    std::unique_ptr<hgps::RiskFactorSexAgeTable> expected = load_risk_factor_expected(config);
+    auto expected = load_risk_factor_expected(config);
     auto expected_trend = std::make_unique<std::unordered_map<core::Identifier, double>>();
 
     return std::make_unique<hgps::DynamicHierarchicalLinearModelDefinition>(
@@ -444,7 +444,7 @@ load_kevinhall_risk_model_definition(const nlohmann::json &opt, const Configurat
     MEASURE_FUNCTION();
 
     // Risk factor expected values by sex and age.
-    std::unique_ptr<hgps::RiskFactorSexAgeTable> expected = load_risk_factor_expected(config);
+    auto expected = load_risk_factor_expected(config);
     auto expected_trend = std::make_unique<std::unordered_map<core::Identifier, double>>();
 
     // Nutrient groups.

--- a/src/HealthGPS.Input/model_parser.h
+++ b/src/HealthGPS.Input/model_parser.h
@@ -17,7 +17,7 @@ namespace hgps::input {
 /// @brief Loads risk factor expected values from a file
 /// @param config The model configuration
 /// @return An instance of the hgps::RiskFactorSexAgeTable type
-hgps::RiskFactorSexAgeTable load_risk_factor_expected(const Configuration &config);
+std::unique_ptr<hgps::RiskFactorSexAgeTable> load_risk_factor_expected(const Configuration &config);
 
 /// @brief Loads either a static or dynamic dummy risk factor model from a JSON file
 /// @param type Model type (static or dynamic)

--- a/src/HealthGPS/dynamic_hierarchical_linear_model.cpp
+++ b/src/HealthGPS/dynamic_hierarchical_linear_model.cpp
@@ -3,6 +3,7 @@
 
 #include "HealthGPS.Core/exception.h"
 
+#include <utility>
 #include <vector>
 
 namespace hgps {
@@ -11,7 +12,7 @@ DynamicHierarchicalLinearModel::DynamicHierarchicalLinearModel(
     std::shared_ptr<RiskFactorSexAgeTable> expected,
     const std::map<core::IntegerInterval, AgeGroupGenderEquation> &equations,
     const std::map<core::Identifier, core::Identifier> &variables, double boundary_percentage)
-    : RiskFactorAdjustableModel{expected}, equations_{equations}, variables_{variables},
+    : RiskFactorAdjustableModel{std::move(expected)}, equations_{equations}, variables_{variables},
       boundary_percentage_{boundary_percentage} {}
 
 RiskFactorModelType DynamicHierarchicalLinearModel::type() const noexcept {

--- a/src/HealthGPS/dynamic_hierarchical_linear_model.cpp
+++ b/src/HealthGPS/dynamic_hierarchical_linear_model.cpp
@@ -10,10 +10,11 @@ namespace hgps {
 
 DynamicHierarchicalLinearModel::DynamicHierarchicalLinearModel(
     std::shared_ptr<RiskFactorSexAgeTable> expected,
+    std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
     const std::map<core::IntegerInterval, AgeGroupGenderEquation> &equations,
     const std::map<core::Identifier, core::Identifier> &variables, double boundary_percentage)
-    : RiskFactorAdjustableModel{std::move(expected)}, equations_{equations}, variables_{variables},
-      boundary_percentage_{boundary_percentage} {}
+    : RiskFactorAdjustableModel{std::move(expected), std::move(expected_trend)},
+      equations_{equations}, variables_{variables}, boundary_percentage_{boundary_percentage} {}
 
 RiskFactorModelType DynamicHierarchicalLinearModel::type() const noexcept {
     return RiskFactorModelType::Dynamic;
@@ -139,10 +140,12 @@ double DynamicHierarchicalLinearModel::sample_normal_with_boundary(Random &rando
 
 DynamicHierarchicalLinearModelDefinition::DynamicHierarchicalLinearModelDefinition(
     std::unique_ptr<RiskFactorSexAgeTable> expected,
+    std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
     std::map<core::IntegerInterval, AgeGroupGenderEquation> equations,
     std::map<core::Identifier, core::Identifier> variables, const double boundary_percentage)
-    : RiskFactorAdjustableModelDefinition{std::move(expected)}, equations_{std::move(equations)},
-      variables_{std::move(variables)}, boundary_percentage_{boundary_percentage} {
+    : RiskFactorAdjustableModelDefinition{std::move(expected), std::move(expected_trend)},
+      equations_{std::move(equations)}, variables_{std::move(variables)},
+      boundary_percentage_{boundary_percentage} {
 
     if (equations_.empty()) {
         throw core::HgpsException("The model equations definition must not be empty");
@@ -153,8 +156,8 @@ DynamicHierarchicalLinearModelDefinition::DynamicHierarchicalLinearModelDefiniti
 }
 
 std::unique_ptr<RiskFactorModel> DynamicHierarchicalLinearModelDefinition::create_model() const {
-    return std::make_unique<DynamicHierarchicalLinearModel>(expected_, equations_, variables_,
-                                                            boundary_percentage_);
+    return std::make_unique<DynamicHierarchicalLinearModel>(expected_, expected_trend_, equations_,
+                                                            variables_, boundary_percentage_);
 }
 
 } // namespace hgps

--- a/src/HealthGPS/dynamic_hierarchical_linear_model.cpp
+++ b/src/HealthGPS/dynamic_hierarchical_linear_model.cpp
@@ -152,8 +152,7 @@ DynamicHierarchicalLinearModelDefinition::DynamicHierarchicalLinearModelDefiniti
 }
 
 std::unique_ptr<RiskFactorModel> DynamicHierarchicalLinearModelDefinition::create_model() const {
-    const auto &expected = get_risk_factor_expected();
-    return std::make_unique<DynamicHierarchicalLinearModel>(expected, equations_, variables_,
+    return std::make_unique<DynamicHierarchicalLinearModel>(expected_, equations_, variables_,
                                                             boundary_percentage_);
 }
 

--- a/src/HealthGPS/dynamic_hierarchical_linear_model.cpp
+++ b/src/HealthGPS/dynamic_hierarchical_linear_model.cpp
@@ -8,7 +8,7 @@
 namespace hgps {
 
 DynamicHierarchicalLinearModel::DynamicHierarchicalLinearModel(
-    const RiskFactorSexAgeTable &expected,
+    std::shared_ptr<RiskFactorSexAgeTable> expected,
     const std::map<core::IntegerInterval, AgeGroupGenderEquation> &equations,
     const std::map<core::Identifier, core::Identifier> &variables, double boundary_percentage)
     : RiskFactorAdjustableModel{expected}, equations_{equations}, variables_{variables},
@@ -137,7 +137,7 @@ double DynamicHierarchicalLinearModel::sample_normal_with_boundary(Random &rando
 }
 
 DynamicHierarchicalLinearModelDefinition::DynamicHierarchicalLinearModelDefinition(
-    RiskFactorSexAgeTable expected,
+    std::unique_ptr<RiskFactorSexAgeTable> expected,
     std::map<core::IntegerInterval, AgeGroupGenderEquation> equations,
     std::map<core::Identifier, core::Identifier> variables, const double boundary_percentage)
     : RiskFactorAdjustableModelDefinition{std::move(expected)}, equations_{std::move(equations)},

--- a/src/HealthGPS/dynamic_hierarchical_linear_model.h
+++ b/src/HealthGPS/dynamic_hierarchical_linear_model.h
@@ -43,7 +43,7 @@ class DynamicHierarchicalLinearModel final : public RiskFactorAdjustableModel {
     /// @param variables The factors delta variables mapping
     /// @param boundary_percentage The boundary percentage to sample
     DynamicHierarchicalLinearModel(
-        const RiskFactorSexAgeTable &expected,
+        std::shared_ptr<RiskFactorSexAgeTable> expected,
         const std::map<core::IntegerInterval, AgeGroupGenderEquation> &equations,
         const std::map<core::Identifier, core::Identifier> &variables,
         const double boundary_percentage);
@@ -85,7 +85,7 @@ class DynamicHierarchicalLinearModelDefinition : public RiskFactorAdjustableMode
     /// @param boundary_percentage The boundary percentage to sample
     /// @throws std::invalid_argument for empty model equations definition
     DynamicHierarchicalLinearModelDefinition(
-        RiskFactorSexAgeTable expected,
+        std::unique_ptr<RiskFactorSexAgeTable> expected,
         std::map<core::IntegerInterval, AgeGroupGenderEquation> equations,
         std::map<core::Identifier, core::Identifier> variables,
         const double boundary_percentage = 0.05);

--- a/src/HealthGPS/dynamic_hierarchical_linear_model.h
+++ b/src/HealthGPS/dynamic_hierarchical_linear_model.h
@@ -39,11 +39,13 @@ class DynamicHierarchicalLinearModel final : public RiskFactorAdjustableModel {
   public:
     /// @brief Initialises a new instance of the DynamicHierarchicalLinearModel class
     /// @param expected The expected values
+    /// @param expected_trend The expected trend of risk factor values
     /// @param equations The linear regression equations
     /// @param variables The factors delta variables mapping
     /// @param boundary_percentage The boundary percentage to sample
     DynamicHierarchicalLinearModel(
         std::shared_ptr<RiskFactorSexAgeTable> expected,
+        std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
         const std::map<core::IntegerInterval, AgeGroupGenderEquation> &equations,
         const std::map<core::Identifier, core::Identifier> &variables,
         const double boundary_percentage);
@@ -80,12 +82,14 @@ class DynamicHierarchicalLinearModelDefinition : public RiskFactorAdjustableMode
   public:
     /// @brief Initialises a new instance of the DynamicHierarchicalLinearModelDefinition class
     /// @param expected The expected values
+    /// @param expected_trend The expected trend of risk factor values
     /// @param equations The linear regression equations
     /// @param variables The factors delta variables mapping
     /// @param boundary_percentage The boundary percentage to sample
     /// @throws std::invalid_argument for empty model equations definition
     DynamicHierarchicalLinearModelDefinition(
         std::unique_ptr<RiskFactorSexAgeTable> expected,
+        std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
         std::map<core::IntegerInterval, AgeGroupGenderEquation> equations,
         std::map<core::Identifier, core::Identifier> variables,
         const double boundary_percentage = 0.05);

--- a/src/HealthGPS/kevin_hall_model.cpp
+++ b/src/HealthGPS/kevin_hall_model.cpp
@@ -33,7 +33,7 @@ KevinHallModel::KevinHallModel(
     const std::vector<double> &epa_quantiles,
     const std::unordered_map<core::Gender, double> &height_stddev,
     const std::unordered_map<core::Gender, double> &height_slope)
-    : RiskFactorAdjustableModel{expected}, energy_equation_{energy_equation},
+    : RiskFactorAdjustableModel{std::move(expected)}, energy_equation_{energy_equation},
       nutrient_ranges_{nutrient_ranges}, nutrient_equations_{nutrient_equations},
       food_prices_{food_prices}, weight_quantiles_{weight_quantiles}, epa_quantiles_{epa_quantiles},
       height_stddev_{height_stddev}, height_slope_{height_slope} {}

--- a/src/HealthGPS/kevin_hall_model.cpp
+++ b/src/HealthGPS/kevin_hall_model.cpp
@@ -24,6 +24,7 @@ namespace hgps {
 
 KevinHallModel::KevinHallModel(
     std::shared_ptr<RiskFactorSexAgeTable> expected,
+    std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
     const std::unordered_map<core::Identifier, double> &energy_equation,
     const std::unordered_map<core::Identifier, core::DoubleInterval> &nutrient_ranges,
     const std::unordered_map<core::Identifier, std::map<core::Identifier, double>>
@@ -33,9 +34,10 @@ KevinHallModel::KevinHallModel(
     const std::vector<double> &epa_quantiles,
     const std::unordered_map<core::Gender, double> &height_stddev,
     const std::unordered_map<core::Gender, double> &height_slope)
-    : RiskFactorAdjustableModel{std::move(expected)}, energy_equation_{energy_equation},
-      nutrient_ranges_{nutrient_ranges}, nutrient_equations_{nutrient_equations},
-      food_prices_{food_prices}, weight_quantiles_{weight_quantiles}, epa_quantiles_{epa_quantiles},
+    : RiskFactorAdjustableModel{std::move(expected), std::move(expected_trend)},
+      energy_equation_{energy_equation}, nutrient_ranges_{nutrient_ranges},
+      nutrient_equations_{nutrient_equations}, food_prices_{food_prices},
+      weight_quantiles_{weight_quantiles}, epa_quantiles_{epa_quantiles},
       height_stddev_{height_stddev}, height_slope_{height_slope} {}
 
 RiskFactorModelType KevinHallModel::type() const noexcept { return RiskFactorModelType::Dynamic; }
@@ -677,6 +679,7 @@ void KevinHallModel::update_height(RuntimeContext &context, Person &person,
 
 KevinHallModelDefinition::KevinHallModelDefinition(
     std::unique_ptr<RiskFactorSexAgeTable> expected,
+    std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
     std::unordered_map<core::Identifier, double> energy_equation,
     std::unordered_map<core::Identifier, core::DoubleInterval> nutrient_ranges,
     std::unordered_map<core::Identifier, std::map<core::Identifier, double>> nutrient_equations,
@@ -684,7 +687,7 @@ KevinHallModelDefinition::KevinHallModelDefinition(
     std::unordered_map<core::Gender, std::vector<double>> weight_quantiles,
     std::vector<double> epa_quantiles, std::unordered_map<core::Gender, double> height_stddev,
     std::unordered_map<core::Gender, double> height_slope)
-    : RiskFactorAdjustableModelDefinition{std::move(expected)},
+    : RiskFactorAdjustableModelDefinition{std::move(expected), std::move(expected_trend)},
       energy_equation_{std::move(energy_equation)}, nutrient_ranges_{std::move(nutrient_ranges)},
       nutrient_equations_{std::move(nutrient_equations)}, food_prices_{std::move(food_prices)},
       weight_quantiles_{std::move(weight_quantiles)}, epa_quantiles_{std::move(epa_quantiles)},
@@ -717,9 +720,9 @@ KevinHallModelDefinition::KevinHallModelDefinition(
 }
 
 std::unique_ptr<RiskFactorModel> KevinHallModelDefinition::create_model() const {
-    return std::make_unique<KevinHallModel>(expected_, energy_equation_, nutrient_ranges_,
-                                            nutrient_equations_, food_prices_, weight_quantiles_,
-                                            epa_quantiles_, height_stddev_, height_slope_);
+    return std::make_unique<KevinHallModel>(
+        expected_, expected_trend_, energy_equation_, nutrient_ranges_, nutrient_equations_,
+        food_prices_, weight_quantiles_, epa_quantiles_, height_stddev_, height_slope_);
 }
 
 } // namespace hgps

--- a/src/HealthGPS/kevin_hall_model.cpp
+++ b/src/HealthGPS/kevin_hall_model.cpp
@@ -248,7 +248,7 @@ void KevinHallModel::send_weight_adjustments(RuntimeContext &context,
 KevinHallAdjustmentTable
 KevinHallModel::compute_weight_adjustments(Population &population,
                                            std::optional<unsigned> age) const {
-    const auto &expected = get_risk_factor_expected();
+    const auto &expected = get_expected();
     auto W_means = compute_mean_weight(population, std::nullopt, age);
 
     // Compute adjustments.
@@ -512,7 +512,7 @@ void KevinHallModel::compute_bmi(Person &person) const {
 }
 
 void KevinHallModel::initialise_weight(Person &person) const {
-    const auto &expected = get_risk_factor_expected();
+    const auto &expected = get_expected();
 
     // Compute E/PA expected.
     double ei_expected = expected.at(person.gender, "EnergyIntake"_id).at(person.age);
@@ -663,7 +663,7 @@ void KevinHallModel::initialise_height(Person &person, double W_power_mean, Rand
 
 void KevinHallModel::update_height(Person &person, double W_power_mean) const {
     double W = person.risk_factors.at("Weight"_id);
-    double H_expected = get_risk_factor_expected().at(person.gender, "Height"_id).at(person.age);
+    double H_expected = get_expected().at(person.gender, "Height"_id).at(person.age);
     double H_residual = person.risk_factors.at("Height_residual"_id);
     double stddev = height_stddev_.at(person.gender);
     double slope = height_slope_.at(person.gender);
@@ -717,8 +717,7 @@ KevinHallModelDefinition::KevinHallModelDefinition(
 }
 
 std::unique_ptr<RiskFactorModel> KevinHallModelDefinition::create_model() const {
-    const auto &expected = get_risk_factor_expected();
-    return std::make_unique<KevinHallModel>(expected, energy_equation_, nutrient_ranges_,
+    return std::make_unique<KevinHallModel>(expected_, energy_equation_, nutrient_ranges_,
                                             nutrient_equations_, food_prices_, weight_quantiles_,
                                             epa_quantiles_, height_stddev_, height_slope_);
 }

--- a/src/HealthGPS/kevin_hall_model.cpp
+++ b/src/HealthGPS/kevin_hall_model.cpp
@@ -23,7 +23,7 @@ using KevinHallAdjustmentMessage =
 namespace hgps {
 
 KevinHallModel::KevinHallModel(
-    const RiskFactorSexAgeTable &expected,
+    std::shared_ptr<RiskFactorSexAgeTable> expected,
     const std::unordered_map<core::Identifier, double> &energy_equation,
     const std::unordered_map<core::Identifier, core::DoubleInterval> &nutrient_ranges,
     const std::unordered_map<core::Identifier, std::map<core::Identifier, double>>
@@ -674,7 +674,8 @@ void KevinHallModel::update_height(Person &person, double W_power_mean) const {
 }
 
 KevinHallModelDefinition::KevinHallModelDefinition(
-    RiskFactorSexAgeTable expected, std::unordered_map<core::Identifier, double> energy_equation,
+    std::unique_ptr<RiskFactorSexAgeTable> expected,
+    std::unordered_map<core::Identifier, double> energy_equation,
     std::unordered_map<core::Identifier, core::DoubleInterval> nutrient_ranges,
     std::unordered_map<core::Identifier, std::map<core::Identifier, double>> nutrient_equations,
     std::unordered_map<core::Identifier, std::optional<double>> food_prices,

--- a/src/HealthGPS/kevin_hall_model.h
+++ b/src/HealthGPS/kevin_hall_model.h
@@ -31,7 +31,7 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     /// @param height_stddev The height model female/male standard deviations
     /// @param height_slope The height female/male model slopes
     KevinHallModel(
-        const RiskFactorSexAgeTable &expected,
+        std::shared_ptr<RiskFactorSexAgeTable> expected,
         const std::unordered_map<core::Identifier, double> &energy_equation,
         const std::unordered_map<core::Identifier, core::DoubleInterval> &nutrient_ranges,
         const std::unordered_map<core::Identifier, std::map<core::Identifier, double>>
@@ -227,7 +227,7 @@ class KevinHallModelDefinition final : public RiskFactorAdjustableModelDefinitio
     /// @param height_slope The height model female/male slopes
     /// @throws std::invalid_argument for empty arguments
     KevinHallModelDefinition(
-        RiskFactorSexAgeTable expected,
+        std::unique_ptr<RiskFactorSexAgeTable> expected,
         std::unordered_map<core::Identifier, double> energy_equation,
         std::unordered_map<core::Identifier, core::DoubleInterval> nutrient_ranges,
         std::unordered_map<core::Identifier, std::map<core::Identifier, double>> nutrient_equations,

--- a/src/HealthGPS/kevin_hall_model.h
+++ b/src/HealthGPS/kevin_hall_model.h
@@ -22,6 +22,7 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
   public:
     /// @brief Initialises a new instance of the KevinHallModel class
     /// @param expected The risk factor expected values by sex and age
+    /// @param expected_trend The expected trend of risk factor values
     /// @param energy_equation The energy coefficients for each nutrient
     /// @param nutrient_ranges The interval boundaries for nutrient values
     /// @param nutrient_equations The nutrient coefficients for each food group
@@ -32,6 +33,7 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     /// @param height_slope The height female/male model slopes
     KevinHallModel(
         std::shared_ptr<RiskFactorSexAgeTable> expected,
+        std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
         const std::unordered_map<core::Identifier, double> &energy_equation,
         const std::unordered_map<core::Identifier, core::DoubleInterval> &nutrient_ranges,
         const std::unordered_map<core::Identifier, std::map<core::Identifier, double>>
@@ -221,6 +223,7 @@ class KevinHallModelDefinition final : public RiskFactorAdjustableModelDefinitio
   public:
     /// @brief Initialises a new instance of the KevinHallModelDefinition class
     /// @param expected The risk factor expected values by sex and age
+    /// @param expected_trend The expected trend of risk factor values
     /// @param energy_equation The energy coefficients for each nutrient
     /// @param nutrient_ranges The interval boundaries for nutrient values
     /// @param nutrient_equations The nutrient coefficients for each food group
@@ -232,6 +235,7 @@ class KevinHallModelDefinition final : public RiskFactorAdjustableModelDefinitio
     /// @throws std::invalid_argument for empty arguments
     KevinHallModelDefinition(
         std::unique_ptr<RiskFactorSexAgeTable> expected,
+        std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
         std::unordered_map<core::Identifier, double> energy_equation,
         std::unordered_map<core::Identifier, core::DoubleInterval> nutrient_ranges,
         std::unordered_map<core::Identifier, std::map<core::Identifier, double>> nutrient_equations,

--- a/src/HealthGPS/kevin_hall_model.h
+++ b/src/HealthGPS/kevin_hall_model.h
@@ -124,8 +124,9 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     void compute_bmi(Person &person) const;
 
     /// @brief Initialises the weight of a person.
+    /// @param context The runtime context
     /// @param person The person fo initialise the weight for.
-    void initialise_weight(Person &person) const;
+    void initialise_weight(RuntimeContext &context, Person &person) const;
 
     /// @brief  Initialise the Kevin Hall state variables of a person
     /// @param person The person to initialise
@@ -154,11 +155,11 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
                                  KevinHallAdjustmentTable &&adjustments) const;
 
     /// @brief Compute weight adjustments for sex and age
-    /// @param population The population to compute the adjustments for
+    /// @param context The runtime context
     /// @param age The (optional) age to compute the adjustments for (default all)
     /// @return The weight adjustments by sex and age
     KevinHallAdjustmentTable
-    compute_weight_adjustments(Population &population,
+    compute_weight_adjustments(RuntimeContext &context,
                                std::optional<unsigned> age = std::nullopt) const;
 
     /// @brief Returns the weight quantile for the given E overPA quantile and sex.
@@ -177,15 +178,18 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
         std::optional<unsigned> age = std::nullopt) const;
 
     /// @brief Initialises the height of a person.
+    /// @param context The runtime context
     /// @param person The person fo initialise the height for.
     /// @param W_power_mean The mean hweight power for the person's sex and age
     /// @param random The random number generator
-    void initialise_height(Person &person, double W_power_mean, Random &random) const;
+    void initialise_height(RuntimeContext &context, Person &person, double W_power_mean,
+                           Random &random) const;
 
     /// @brief Updates the height of a person.
+    /// @param context The runtime context
     /// @param person The person fo update the height for.
     /// @param W_power_mean The mean hweight power for the person's sex and age
-    void update_height(Person &person, double W_power_mean) const;
+    void update_height(RuntimeContext &context, Person &person, double W_power_mean) const;
 
     const std::unordered_map<core::Identifier, double> &energy_equation_;
     const std::unordered_map<core::Identifier, core::DoubleInterval> &nutrient_ranges_;

--- a/src/HealthGPS/risk_factor_adjustable_model.cpp
+++ b/src/HealthGPS/risk_factor_adjustable_model.cpp
@@ -33,8 +33,9 @@ namespace hgps {
 RiskFactorAdjustableModel::RiskFactorAdjustableModel(const RiskFactorSexAgeTable &expected)
     : expected_{expected} {}
 
-const RiskFactorSexAgeTable &RiskFactorAdjustableModel::get_expected() const noexcept {
-    return expected_;
+double RiskFactorAdjustableModel::get_expected(const core::Gender sex, const int age,
+                                               const core::Identifier &factor) const noexcept {
+    return expected_.at(sex, factor).at(age);
 }
 
 void RiskFactorAdjustableModel::adjust_risk_factors(RuntimeContext &context,

--- a/src/HealthGPS/risk_factor_adjustable_model.cpp
+++ b/src/HealthGPS/risk_factor_adjustable_model.cpp
@@ -173,8 +173,4 @@ RiskFactorAdjustableModelDefinition::RiskFactorAdjustableModelDefinition(
     }
 }
 
-const RiskFactorSexAgeTable &RiskFactorAdjustableModelDefinition::get_expected() const noexcept {
-    return expected_;
-}
-
 } // namespace hgps

--- a/src/HealthGPS/risk_factor_adjustable_model.cpp
+++ b/src/HealthGPS/risk_factor_adjustable_model.cpp
@@ -33,15 +33,15 @@ namespace hgps {
 
 RiskFactorAdjustableModel::RiskFactorAdjustableModel(
     std::shared_ptr<RiskFactorSexAgeTable> expected,
-    const std::unordered_map<core::Identifier, double> &expected_trend)
-    : expected_{std::move(expected)}, expected_trend_{expected_trend} {}
+    std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend)
+    : expected_{std::move(expected)}, expected_trend_{std::move(expected_trend)} {}
 
 double RiskFactorAdjustableModel::get_expected(RuntimeContext &context, core::Gender sex, int age,
                                                const core::Identifier &factor) const noexcept {
     double expected = expected_->at(sex, factor).at(age);
-    if (expected_trend_.contains(factor)) {
+    if (expected_trend_->contains(factor)) {
         int elapsed_time = context.time_now() - context.start_time();
-        expected *= pow(expected_trend_.at(factor), elapsed_time);
+        expected *= pow(expected_trend_->at(factor), elapsed_time);
     }
     return expected;
 }
@@ -175,7 +175,7 @@ RiskFactorAdjustableModel::calculate_simulated_mean(Population &population,
 
 RiskFactorAdjustableModelDefinition::RiskFactorAdjustableModelDefinition(
     std::unique_ptr<RiskFactorSexAgeTable> expected,
-    std::unordered_map<core::Identifier, double> expected_trend)
+    std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend)
     : expected_{std::move(expected)}, expected_trend_{std::move(expected_trend)} {
 
     if (expected_->empty()) {

--- a/src/HealthGPS/risk_factor_adjustable_model.cpp
+++ b/src/HealthGPS/risk_factor_adjustable_model.cpp
@@ -4,6 +4,7 @@
 #include "sync_message.h"
 
 #include <oneapi/tbb/parallel_for_each.h>
+#include <utility>
 
 namespace { // anonymous namespace
 
@@ -32,7 +33,7 @@ namespace hgps {
 
 RiskFactorAdjustableModel::RiskFactorAdjustableModel(
     std::shared_ptr<RiskFactorSexAgeTable> expected)
-    : expected_{expected} {}
+    : expected_{std::move(expected)} {}
 
 double RiskFactorAdjustableModel::get_expected(core::Gender sex, int age,
                                                const core::Identifier &factor) const noexcept {

--- a/src/HealthGPS/risk_factor_adjustable_model.cpp
+++ b/src/HealthGPS/risk_factor_adjustable_model.cpp
@@ -30,12 +30,11 @@ struct FirstMoment {
 
 namespace hgps {
 
-RiskFactorAdjustableModel::RiskFactorAdjustableModel(
-    const RiskFactorSexAgeTable &risk_factor_expected)
-    : risk_factor_expected_{risk_factor_expected} {}
+RiskFactorAdjustableModel::RiskFactorAdjustableModel(const RiskFactorSexAgeTable &expected)
+    : expected_{expected} {}
 
-const RiskFactorSexAgeTable &RiskFactorAdjustableModel::get_risk_factor_expected() const noexcept {
-    return risk_factor_expected_;
+const RiskFactorSexAgeTable &RiskFactorAdjustableModel::get_expected() const noexcept {
+    return expected_;
 }
 
 void RiskFactorAdjustableModel::adjust_risk_factors(RuntimeContext &context,
@@ -109,7 +108,7 @@ RiskFactorSexAgeTable RiskFactorAdjustableModel::calculate_adjustments(
         for (const auto &factor : factors) {
             adjustments.emplace(sex, factor, std::vector<double>(age_count));
             for (auto age = age_range.lower(); age <= age_range.upper(); age++) {
-                double expect = risk_factor_expected_.at(sex, factor).at(age);
+                double expect = expected_.at(sex, factor).at(age);
                 double sim_mean = simulated_means_by_sex.at(factor).at(age);
 
                 // Delta should remain zero if simulated mean is NaN.
@@ -166,17 +165,16 @@ RiskFactorAdjustableModel::calculate_simulated_mean(Population &population,
 }
 
 RiskFactorAdjustableModelDefinition::RiskFactorAdjustableModelDefinition(
-    RiskFactorSexAgeTable risk_factor_expected)
-    : RiskFactorModelDefinition{}, risk_factor_expected_{std::move(risk_factor_expected)} {
+    RiskFactorSexAgeTable expected)
+    : RiskFactorModelDefinition{}, expected_{std::move(expected)} {
 
-    if (risk_factor_expected_.empty()) {
+    if (expected_.empty()) {
         throw core::HgpsException("Risk factor expected value mapping is empty");
     }
 }
 
-const RiskFactorSexAgeTable &
-RiskFactorAdjustableModelDefinition::get_risk_factor_expected() const noexcept {
-    return risk_factor_expected_;
+const RiskFactorSexAgeTable &RiskFactorAdjustableModelDefinition::get_expected() const noexcept {
+    return expected_;
 }
 
 } // namespace hgps

--- a/src/HealthGPS/risk_factor_adjustable_model.cpp
+++ b/src/HealthGPS/risk_factor_adjustable_model.cpp
@@ -36,9 +36,14 @@ RiskFactorAdjustableModel::RiskFactorAdjustableModel(
     const std::unordered_map<core::Identifier, double> &expected_trend)
     : expected_{std::move(expected)}, expected_trend_{expected_trend} {}
 
-double RiskFactorAdjustableModel::get_expected(core::Gender sex, int age,
+double RiskFactorAdjustableModel::get_expected(RuntimeContext &context, core::Gender sex, int age,
                                                const core::Identifier &factor) const noexcept {
-    return expected_->at(sex, factor).at(age);
+    double expected = expected_->at(sex, factor).at(age);
+    if (expected_trend_.contains(factor)) {
+        int elapsed_time = context.time_now() - context.start_time();
+        expected *= pow(expected_trend_.at(factor), elapsed_time);
+    }
+    return expected;
 }
 
 void RiskFactorAdjustableModel::adjust_risk_factors(RuntimeContext &context,

--- a/src/HealthGPS/risk_factor_adjustable_model.cpp
+++ b/src/HealthGPS/risk_factor_adjustable_model.cpp
@@ -32,8 +32,9 @@ struct FirstMoment {
 namespace hgps {
 
 RiskFactorAdjustableModel::RiskFactorAdjustableModel(
-    std::shared_ptr<RiskFactorSexAgeTable> expected)
-    : expected_{std::move(expected)} {}
+    std::shared_ptr<RiskFactorSexAgeTable> expected,
+    const std::unordered_map<core::Identifier, double> &expected_trend)
+    : expected_{std::move(expected)}, expected_trend_{expected_trend} {}
 
 double RiskFactorAdjustableModel::get_expected(core::Gender sex, int age,
                                                const core::Identifier &factor) const noexcept {
@@ -168,8 +169,9 @@ RiskFactorAdjustableModel::calculate_simulated_mean(Population &population,
 }
 
 RiskFactorAdjustableModelDefinition::RiskFactorAdjustableModelDefinition(
-    std::unique_ptr<RiskFactorSexAgeTable> expected)
-    : RiskFactorModelDefinition{}, expected_{std::move(expected)} {
+    std::unique_ptr<RiskFactorSexAgeTable> expected,
+    std::unordered_map<core::Identifier, double> expected_trend)
+    : expected_{std::move(expected)}, expected_trend_{std::move(expected_trend)} {
 
     if (expected_->empty()) {
         throw core::HgpsException("Risk factor expected value mapping is empty");

--- a/src/HealthGPS/risk_factor_adjustable_model.cpp
+++ b/src/HealthGPS/risk_factor_adjustable_model.cpp
@@ -38,7 +38,7 @@ RiskFactorAdjustableModel::RiskFactorAdjustableModel(
 
 double RiskFactorAdjustableModel::get_expected(RuntimeContext &context, core::Gender sex, int age,
                                                const core::Identifier &factor,
-                                               OptionalRange expected_range) const noexcept {
+                                               OptionalRange range) const noexcept {
     double expected = expected_->at(sex, factor).at(age);
 
     // Apply trend to expected value.
@@ -48,9 +48,8 @@ double RiskFactorAdjustableModel::get_expected(RuntimeContext &context, core::Ge
     }
 
     // Clamp expected value to an optionally specified range.
-    if (expected_range.has_value()) {
-        const auto &range = expected_range.value().get();
-        expected = range.clamp(expected);
+    if (range.has_value()) {
+        expected = range.value().get().clamp(expected);
     }
 
     return expected;
@@ -63,7 +62,7 @@ void RiskFactorAdjustableModel::adjust_risk_factors(RuntimeContext &context,
 
     // Baseline scenatio: compute adjustments.
     if (context.scenario().type() == ScenarioType::baseline) {
-        adjustments = calculate_adjustments(context, factors);
+        adjustments = calculate_adjustments(context, factors, ranges);
     }
 
     // Intervention scenario: receive adjustments from baseline scenario.
@@ -113,8 +112,10 @@ void RiskFactorAdjustableModel::adjust_risk_factors(RuntimeContext &context,
     }
 }
 
-RiskFactorSexAgeTable RiskFactorAdjustableModel::calculate_adjustments(
-    RuntimeContext &context, const std::vector<core::Identifier> &factors) const {
+RiskFactorSexAgeTable
+RiskFactorAdjustableModel::calculate_adjustments(RuntimeContext &context,
+                                                 const std::vector<core::Identifier> &factors,
+                                                 OptionalRanges ranges) const {
     auto age_range = context.age_range();
     auto age_count = age_range.upper() + 1;
 
@@ -124,10 +125,17 @@ RiskFactorSexAgeTable RiskFactorAdjustableModel::calculate_adjustments(
     // Compute adjustments.
     auto adjustments = RiskFactorSexAgeTable{};
     for (const auto &[sex, simulated_means_by_sex] : simulated_means) {
-        for (const auto &factor : factors) {
+        for (size_t i = 0; i < factors.size(); i++) {
+            const core::Identifier &factor = factors[i];
+
+            OptionalRange range;
+            if (ranges.has_value()) {
+                range = OptionalRange{ranges.value().get().at(i)};
+            }
+
             adjustments.emplace(sex, factor, std::vector<double>(age_count));
             for (auto age = age_range.lower(); age <= age_range.upper(); age++) {
-                double expect = expected_->at(sex, factor).at(age);
+                double expect = get_expected(context, sex, age, factor, range);
                 double sim_mean = simulated_means_by_sex.at(factor).at(age);
 
                 // Delta should remain zero if simulated mean is NaN.

--- a/src/HealthGPS/risk_factor_adjustable_model.h
+++ b/src/HealthGPS/risk_factor_adjustable_model.h
@@ -28,15 +28,14 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
   public:
     /// @brief Constructs a new RiskFactorAdjustableModel instance
     /// @param expected The risk factor expected values by sex and age
-    RiskFactorAdjustableModel(const RiskFactorSexAgeTable &expected);
+    RiskFactorAdjustableModel(std::shared_ptr<RiskFactorSexAgeTable> expected);
 
     /// @brief Gets a person's expected risk factor value
     /// @param sex The sex key to get the expected value
     /// @param age The age key to get the expected value
     /// @param factor The risk factor to get the expected value
     /// @returns The person's expected risk factor value
-    double get_expected(const core::Gender sex, const int age,
-                        const core::Identifier &factor) const noexcept;
+    double get_expected(core::Gender sex, int age, const core::Identifier &factor) const noexcept;
 
     /// @brief Adjust risk factors such that mean sim value matches expected value
     /// @param context The simulation run-time context
@@ -53,7 +52,7 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
     calculate_simulated_mean(Population &population, core::IntegerInterval age_range,
                              const std::vector<core::Identifier> &factors);
 
-    const RiskFactorSexAgeTable &expected_;
+    std::shared_ptr<RiskFactorSexAgeTable> expected_;
 };
 
 /// @brief Risk factor adjustable model definition interface
@@ -62,10 +61,10 @@ class RiskFactorAdjustableModelDefinition : public RiskFactorModelDefinition {
     /// @brief Constructs a new RiskFactorAdjustableModelDefinition instance
     /// @param expected The expected risk factor values by sex and age
     /// @throws HgpsException for invalid arguments
-    RiskFactorAdjustableModelDefinition(RiskFactorSexAgeTable expected);
+    RiskFactorAdjustableModelDefinition(std::unique_ptr<RiskFactorSexAgeTable> expected);
 
   protected:
-    RiskFactorSexAgeTable expected_;
+    std::shared_ptr<RiskFactorSexAgeTable> expected_;
 };
 
 } // namespace hgps

--- a/src/HealthGPS/risk_factor_adjustable_model.h
+++ b/src/HealthGPS/risk_factor_adjustable_model.h
@@ -61,10 +61,6 @@ class RiskFactorAdjustableModelDefinition : public RiskFactorModelDefinition {
     /// @throws HgpsException for invalid arguments
     RiskFactorAdjustableModelDefinition(RiskFactorSexAgeTable expected);
 
-    /// @brief Gets the risk factor expected values by sex and age
-    /// @returns The risk factor expected values by sex and age
-    const RiskFactorSexAgeTable &get_expected() const noexcept;
-
   protected:
     RiskFactorSexAgeTable expected_;
 };

--- a/src/HealthGPS/risk_factor_adjustable_model.h
+++ b/src/HealthGPS/risk_factor_adjustable_model.h
@@ -13,6 +13,8 @@
 
 namespace { // anonymous namespace
 
+using OptionalRange = std::optional<std::reference_wrapper<const hgps::core::DoubleInterval>>;
+
 using OptionalRanges =
     std::optional<std::reference_wrapper<const std::vector<hgps::core::DoubleInterval>>>;
 
@@ -38,9 +40,11 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
     /// @param sex The sex key to get the expected value
     /// @param age The age key to get the expected value
     /// @param factor The risk factor to get the expected value
+    /// @param epected_range An optional expected value range
     /// @returns The person's expected risk factor value
     double get_expected(RuntimeContext &context, core::Gender sex, int age,
-                        const core::Identifier &factor) const noexcept;
+                        const core::Identifier &factor,
+                        OptionalRange epected_range = std::nullopt) const noexcept;
 
     /// @brief Adjust risk factors such that mean sim value matches expected value
     /// @param context The simulation run-time context

--- a/src/HealthGPS/risk_factor_adjustable_model.h
+++ b/src/HealthGPS/risk_factor_adjustable_model.h
@@ -28,7 +28,10 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
   public:
     /// @brief Constructs a new RiskFactorAdjustableModel instance
     /// @param expected The risk factor expected values by sex and age
-    RiskFactorAdjustableModel(std::shared_ptr<RiskFactorSexAgeTable> expected);
+    /// @param expected_trend The expected trend of risk factor values
+    RiskFactorAdjustableModel(
+        std::shared_ptr<RiskFactorSexAgeTable> expected,
+        const std::unordered_map<core::Identifier, double> &expected_trend = {});
 
     /// @brief Gets a person's expected risk factor value
     /// @param sex The sex key to get the expected value
@@ -53,6 +56,7 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
                              const std::vector<core::Identifier> &factors);
 
     std::shared_ptr<RiskFactorSexAgeTable> expected_;
+    const std::unordered_map<core::Identifier, double> &expected_trend_;
 };
 
 /// @brief Risk factor adjustable model definition interface
@@ -60,11 +64,15 @@ class RiskFactorAdjustableModelDefinition : public RiskFactorModelDefinition {
   public:
     /// @brief Constructs a new RiskFactorAdjustableModelDefinition instance
     /// @param expected The expected risk factor values by sex and age
+    /// @param expected_trend The expected trend of risk factor values
     /// @throws HgpsException for invalid arguments
-    RiskFactorAdjustableModelDefinition(std::unique_ptr<RiskFactorSexAgeTable> expected);
+    RiskFactorAdjustableModelDefinition(
+        std::unique_ptr<RiskFactorSexAgeTable> expected,
+        std::unordered_map<core::Identifier, double> expected_trend = {});
 
   protected:
     std::shared_ptr<RiskFactorSexAgeTable> expected_;
+    std::unordered_map<core::Identifier, double> expected_trend_;
 };
 
 } // namespace hgps

--- a/src/HealthGPS/risk_factor_adjustable_model.h
+++ b/src/HealthGPS/risk_factor_adjustable_model.h
@@ -34,11 +34,13 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
         const std::unordered_map<core::Identifier, double> &expected_trend = {});
 
     /// @brief Gets a person's expected risk factor value
+    /// @param context The simulation run-time context
     /// @param sex The sex key to get the expected value
     /// @param age The age key to get the expected value
     /// @param factor The risk factor to get the expected value
     /// @returns The person's expected risk factor value
-    double get_expected(core::Gender sex, int age, const core::Identifier &factor) const noexcept;
+    double get_expected(RuntimeContext &context, core::Gender sex, int age,
+                        const core::Identifier &factor) const noexcept;
 
     /// @brief Adjust risk factors such that mean sim value matches expected value
     /// @param context The simulation run-time context

--- a/src/HealthGPS/risk_factor_adjustable_model.h
+++ b/src/HealthGPS/risk_factor_adjustable_model.h
@@ -30,9 +30,13 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
     /// @param expected The risk factor expected values by sex and age
     RiskFactorAdjustableModel(const RiskFactorSexAgeTable &expected);
 
-    /// @brief Gets the risk factor expected values by sex and age
-    /// @returns The risk factor expected values by sex and age
-    const RiskFactorSexAgeTable &get_expected() const noexcept;
+    /// @brief Gets a person's expected risk factor value
+    /// @param sex The sex key to get the expected value
+    /// @param age The age key to get the expected value
+    /// @param factor The risk factor to get the expected value
+    /// @returns The person's expected risk factor value
+    double get_expected(const core::Gender sex, const int age,
+                        const core::Identifier &factor) const noexcept;
 
     /// @brief Adjust risk factors such that mean sim value matches expected value
     /// @param context The simulation run-time context
@@ -49,7 +53,6 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
     calculate_simulated_mean(Population &population, core::IntegerInterval age_range,
                              const std::vector<core::Identifier> &factors);
 
-  protected:
     const RiskFactorSexAgeTable &expected_;
 };
 

--- a/src/HealthGPS/risk_factor_adjustable_model.h
+++ b/src/HealthGPS/risk_factor_adjustable_model.h
@@ -27,12 +27,12 @@ using RiskFactorSexAgeTable = UnorderedMap2d<core::Gender, core::Identifier, std
 class RiskFactorAdjustableModel : public RiskFactorModel {
   public:
     /// @brief Constructs a new RiskFactorAdjustableModel instance
-    /// @param risk_factor_expected The risk factor expected values by sex and age
-    RiskFactorAdjustableModel(const RiskFactorSexAgeTable &risk_factor_expected);
+    /// @param expected The risk factor expected values by sex and age
+    RiskFactorAdjustableModel(const RiskFactorSexAgeTable &expected);
 
     /// @brief Gets the risk factor expected values by sex and age
     /// @returns The risk factor expected values by sex and age
-    const RiskFactorSexAgeTable &get_risk_factor_expected() const noexcept;
+    const RiskFactorSexAgeTable &get_expected() const noexcept;
 
     /// @brief Adjust risk factors such that mean sim value matches expected value
     /// @param context The simulation run-time context
@@ -49,23 +49,24 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
     calculate_simulated_mean(Population &population, core::IntegerInterval age_range,
                              const std::vector<core::Identifier> &factors);
 
-    const RiskFactorSexAgeTable &risk_factor_expected_;
+  protected:
+    const RiskFactorSexAgeTable &expected_;
 };
 
 /// @brief Risk factor adjustable model definition interface
 class RiskFactorAdjustableModelDefinition : public RiskFactorModelDefinition {
   public:
     /// @brief Constructs a new RiskFactorAdjustableModelDefinition instance
-    /// @param risk_factor_expected The expected risk factor values by sex and age
+    /// @param expected The expected risk factor values by sex and age
     /// @throws HgpsException for invalid arguments
-    RiskFactorAdjustableModelDefinition(RiskFactorSexAgeTable risk_factor_expected);
+    RiskFactorAdjustableModelDefinition(RiskFactorSexAgeTable expected);
 
     /// @brief Gets the risk factor expected values by sex and age
     /// @returns The risk factor expected values by sex and age
-    const RiskFactorSexAgeTable &get_risk_factor_expected() const noexcept;
+    const RiskFactorSexAgeTable &get_expected() const noexcept;
 
-  private:
-    RiskFactorSexAgeTable risk_factor_expected_;
+  protected:
+    RiskFactorSexAgeTable expected_;
 };
 
 } // namespace hgps

--- a/src/HealthGPS/risk_factor_adjustable_model.h
+++ b/src/HealthGPS/risk_factor_adjustable_model.h
@@ -40,11 +40,11 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
     /// @param sex The sex key to get the expected value
     /// @param age The age key to get the expected value
     /// @param factor The risk factor to get the expected value
-    /// @param epected_range An optional expected value range
+    /// @param range An optional expected value range
     /// @returns The person's expected risk factor value
     double get_expected(RuntimeContext &context, core::Gender sex, int age,
                         const core::Identifier &factor,
-                        OptionalRange epected_range = std::nullopt) const noexcept;
+                        OptionalRange range = std::nullopt) const noexcept;
 
     /// @brief Adjust risk factors such that mean sim value matches expected value
     /// @param context The simulation run-time context
@@ -54,8 +54,13 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
                              OptionalRanges ranges = std::nullopt) const;
 
   private:
+    /// @brief Adjust risk factors such that mean sim value matches expected value
+    /// @param context The simulation run-time context
+    /// @param factors A list of risk factors to be adjusted
+    /// @param ranges An optional list of risk factor value boundaries
     RiskFactorSexAgeTable calculate_adjustments(RuntimeContext &context,
-                                                const std::vector<core::Identifier> &factors) const;
+                                                const std::vector<core::Identifier> &factors,
+                                                OptionalRanges ranges) const;
 
     static RiskFactorSexAgeTable
     calculate_simulated_mean(Population &population, core::IntegerInterval age_range,

--- a/src/HealthGPS/risk_factor_adjustable_model.h
+++ b/src/HealthGPS/risk_factor_adjustable_model.h
@@ -31,7 +31,7 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
     /// @param expected_trend The expected trend of risk factor values
     RiskFactorAdjustableModel(
         std::shared_ptr<RiskFactorSexAgeTable> expected,
-        const std::unordered_map<core::Identifier, double> &expected_trend = {});
+        std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend = {});
 
     /// @brief Gets a person's expected risk factor value
     /// @param context The simulation run-time context
@@ -58,7 +58,7 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
                              const std::vector<core::Identifier> &factors);
 
     std::shared_ptr<RiskFactorSexAgeTable> expected_;
-    const std::unordered_map<core::Identifier, double> &expected_trend_;
+    std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend_;
 };
 
 /// @brief Risk factor adjustable model definition interface
@@ -70,11 +70,11 @@ class RiskFactorAdjustableModelDefinition : public RiskFactorModelDefinition {
     /// @throws HgpsException for invalid arguments
     RiskFactorAdjustableModelDefinition(
         std::unique_ptr<RiskFactorSexAgeTable> expected,
-        std::unordered_map<core::Identifier, double> expected_trend = {});
+        std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend = {});
 
   protected:
     std::shared_ptr<RiskFactorSexAgeTable> expected_;
-    std::unordered_map<core::Identifier, double> expected_trend_;
+    std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend_;
 };
 
 } // namespace hgps

--- a/src/HealthGPS/risk_factor_adjustable_model.h
+++ b/src/HealthGPS/risk_factor_adjustable_model.h
@@ -31,7 +31,7 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
     /// @param expected_trend The expected trend of risk factor values
     RiskFactorAdjustableModel(
         std::shared_ptr<RiskFactorSexAgeTable> expected,
-        std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend = {});
+        std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend);
 
     /// @brief Gets a person's expected risk factor value
     /// @param context The simulation run-time context
@@ -70,7 +70,7 @@ class RiskFactorAdjustableModelDefinition : public RiskFactorModelDefinition {
     /// @throws HgpsException for invalid arguments
     RiskFactorAdjustableModelDefinition(
         std::unique_ptr<RiskFactorSexAgeTable> expected,
-        std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend = {});
+        std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend);
 
   protected:
     std::shared_ptr<RiskFactorSexAgeTable> expected_;

--- a/src/HealthGPS/static_linear_model.cpp
+++ b/src/HealthGPS/static_linear_model.cpp
@@ -7,7 +7,7 @@
 namespace hgps {
 
 StaticLinearModel::StaticLinearModel(
-    const RiskFactorSexAgeTable &expected, const std::vector<core::Identifier> &names,
+    std::shared_ptr<RiskFactorSexAgeTable> expected, const std::vector<core::Identifier> &names,
     const std::vector<LinearModelParams> &models, const std::vector<core::DoubleInterval> &ranges,
     const std::vector<double> &lambda, const std::vector<double> &stddev,
     const Eigen::MatrixXd &cholesky, const std::vector<LinearModelParams> &policy_models,
@@ -340,7 +340,7 @@ void StaticLinearModel::initialise_physical_activity(Person &person, Random &ran
 }
 
 StaticLinearModelDefinition::StaticLinearModelDefinition(
-    RiskFactorSexAgeTable expected, std::vector<core::Identifier> names,
+    std::unique_ptr<RiskFactorSexAgeTable> expected, std::vector<core::Identifier> names,
     std::vector<LinearModelParams> models, std::vector<core::DoubleInterval> ranges,
     std::vector<double> lambda, std::vector<double> stddev, Eigen::MatrixXd cholesky,
     std::vector<LinearModelParams> policy_models, std::vector<core::DoubleInterval> policy_ranges,

--- a/src/HealthGPS/static_linear_model.cpp
+++ b/src/HealthGPS/static_linear_model.cpp
@@ -3,6 +3,7 @@
 #include "runtime_context.h"
 
 #include <ranges>
+#include <utility>
 
 namespace hgps {
 
@@ -19,8 +20,8 @@ StaticLinearModel::StaticLinearModel(
         &rural_prevalence,
     const std::unordered_map<core::Income, LinearModelParams> &income_models,
     double physical_activity_stddev)
-    : RiskFactorAdjustableModel{expected, expected_trend}, names_{names}, models_{models},
-      ranges_{ranges}, lambda_{lambda}, stddev_{stddev}, cholesky_{cholesky},
+    : RiskFactorAdjustableModel{std::move(expected), expected_trend}, names_{names},
+      models_{models}, ranges_{ranges}, lambda_{lambda}, stddev_{stddev}, cholesky_{cholesky},
       policy_models_{policy_models}, policy_ranges_{policy_ranges},
       policy_cholesky_{policy_cholesky}, info_speed_{info_speed},
       rural_prevalence_{rural_prevalence}, income_models_{income_models},

--- a/src/HealthGPS/static_linear_model.cpp
+++ b/src/HealthGPS/static_linear_model.cpp
@@ -109,7 +109,7 @@ void StaticLinearModel::initialise_factors(Person &person, Random &random) const
         person.risk_factors[residual_name] = residual;
 
         // Initialise risk factor.
-        double expected = get_expected().at(person.gender, names_[i]).at(person.age);
+        double expected = get_expected(person.gender, person.age, names_[i]);
         double factor = linear[i] + residual * stddev_[i];
         factor = expected * inverse_box_cox(factor, lambda_[i]);
 
@@ -137,7 +137,7 @@ void StaticLinearModel::update_factors(Person &person, Random &random) const {
         person.risk_factors.at(residual_name) = residual;
 
         // Update risk factor.
-        double expected = get_expected().at(person.gender, names_[i]).at(person.age);
+        double expected = get_expected(person.gender, person.age, names_[i]);
         double factor = linear[i] + residual * stddev_[i];
         factor = expected * inverse_box_cox(factor, lambda_[i]);
 
@@ -333,7 +333,7 @@ void StaticLinearModel::update_income(Person &person, Random &random) const {
 
 void StaticLinearModel::initialise_physical_activity(Person &person, Random &random) const {
     auto key = "PhysicalActivity"_id;
-    double expected = get_expected().at(person.gender, key).at(person.age);
+    double expected = get_expected(person.gender, person.age, key);
     double rand = random.next_normal(0.0, physical_activity_stddev_);
     double factor = expected * exp(rand - 0.5 * pow(physical_activity_stddev_, 2));
     person.risk_factors[key] = factor;

--- a/src/HealthGPS/static_linear_model.cpp
+++ b/src/HealthGPS/static_linear_model.cpp
@@ -9,7 +9,7 @@ namespace hgps {
 
 StaticLinearModel::StaticLinearModel(
     std::shared_ptr<RiskFactorSexAgeTable> expected,
-    const std::unordered_map<core::Identifier, double> &expected_trend,
+    std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
     const std::vector<core::Identifier> &names, const std::vector<LinearModelParams> &models,
     const std::vector<core::DoubleInterval> &ranges, const std::vector<double> &lambda,
     const std::vector<double> &stddev, const Eigen::MatrixXd &cholesky,
@@ -20,7 +20,7 @@ StaticLinearModel::StaticLinearModel(
         &rural_prevalence,
     const std::unordered_map<core::Income, LinearModelParams> &income_models,
     double physical_activity_stddev)
-    : RiskFactorAdjustableModel{std::move(expected), expected_trend}, names_{names},
+    : RiskFactorAdjustableModel{std::move(expected), std::move(expected_trend)}, names_{names},
       models_{models}, ranges_{ranges}, lambda_{lambda}, stddev_{stddev}, cholesky_{cholesky},
       policy_models_{policy_models}, policy_ranges_{policy_ranges},
       policy_cholesky_{policy_cholesky}, info_speed_{info_speed},
@@ -348,7 +348,7 @@ void StaticLinearModel::initialise_physical_activity(RuntimeContext &context, Pe
 
 StaticLinearModelDefinition::StaticLinearModelDefinition(
     std::unique_ptr<RiskFactorSexAgeTable> expected,
-    std::unordered_map<core::Identifier, double> expected_trend,
+    std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
     std::vector<core::Identifier> names, std::vector<LinearModelParams> models,
     std::vector<core::DoubleInterval> ranges, std::vector<double> lambda,
     std::vector<double> stddev, Eigen::MatrixXd cholesky,
@@ -399,7 +399,7 @@ StaticLinearModelDefinition::StaticLinearModelDefinition(
         throw core::HgpsException("Income models mapping is empty");
     }
     for (const auto &name : names_) {
-        if (!expected_trend_.contains(name)) {
+        if (!expected_trend_->contains(name)) {
             throw core::HgpsException("One or more risk factor expected trend value is missing");
         }
     }

--- a/src/HealthGPS/static_linear_model.cpp
+++ b/src/HealthGPS/static_linear_model.cpp
@@ -109,7 +109,7 @@ void StaticLinearModel::initialise_factors(Person &person, Random &random) const
         person.risk_factors[residual_name] = residual;
 
         // Initialise risk factor.
-        double expected = get_risk_factor_expected().at(person.gender, names_[i]).at(person.age);
+        double expected = get_expected().at(person.gender, names_[i]).at(person.age);
         double factor = linear[i] + residual * stddev_[i];
         factor = expected * inverse_box_cox(factor, lambda_[i]);
 
@@ -137,7 +137,7 @@ void StaticLinearModel::update_factors(Person &person, Random &random) const {
         person.risk_factors.at(residual_name) = residual;
 
         // Update risk factor.
-        double expected = get_risk_factor_expected().at(person.gender, names_[i]).at(person.age);
+        double expected = get_expected().at(person.gender, names_[i]).at(person.age);
         double factor = linear[i] + residual * stddev_[i];
         factor = expected * inverse_box_cox(factor, lambda_[i]);
 
@@ -333,7 +333,7 @@ void StaticLinearModel::update_income(Person &person, Random &random) const {
 
 void StaticLinearModel::initialise_physical_activity(Person &person, Random &random) const {
     auto key = "PhysicalActivity"_id;
-    double expected = get_risk_factor_expected().at(person.gender, key).at(person.age);
+    double expected = get_expected().at(person.gender, key).at(person.age);
     double rand = random.next_normal(0.0, physical_activity_stddev_);
     double factor = expected * exp(rand - 0.5 * pow(physical_activity_stddev_, 2));
     person.risk_factors[key] = factor;
@@ -392,9 +392,8 @@ StaticLinearModelDefinition::StaticLinearModelDefinition(
 }
 
 std::unique_ptr<RiskFactorModel> StaticLinearModelDefinition::create_model() const {
-    const auto &expected = get_risk_factor_expected();
-    return std::make_unique<StaticLinearModel>(expected, names_, models_, ranges_, lambda_, stddev_,
-                                               cholesky_, policy_models_, policy_ranges_,
+    return std::make_unique<StaticLinearModel>(expected_, names_, models_, ranges_, lambda_,
+                                               stddev_, cholesky_, policy_models_, policy_ranges_,
                                                policy_cholesky_, info_speed_, rural_prevalence_,
                                                income_models_, physical_activity_stddev_);
 }

--- a/src/HealthGPS/static_linear_model.cpp
+++ b/src/HealthGPS/static_linear_model.cpp
@@ -114,7 +114,7 @@ void StaticLinearModel::initialise_factors(RuntimeContext &context, Person &pers
         person.risk_factors[residual_name] = residual;
 
         // Initialise risk factor.
-        double expected = get_expected(context, person.gender, person.age, names_[i]);
+        double expected = get_expected(context, person.gender, person.age, names_[i], ranges_[i]);
         double factor = linear[i] + residual * stddev_[i];
         factor = expected * inverse_box_cox(factor, lambda_[i]);
 
@@ -143,7 +143,7 @@ void StaticLinearModel::update_factors(RuntimeContext &context, Person &person,
         person.risk_factors.at(residual_name) = residual;
 
         // Update risk factor.
-        double expected = get_expected(context, person.gender, person.age, names_[i]);
+        double expected = get_expected(context, person.gender, person.age, names_[i], ranges_[i]);
         double factor = linear[i] + residual * stddev_[i];
         factor = expected * inverse_box_cox(factor, lambda_[i]);
 
@@ -339,11 +339,10 @@ void StaticLinearModel::update_income(Person &person, Random &random) const {
 
 void StaticLinearModel::initialise_physical_activity(RuntimeContext &context, Person &person,
                                                      Random &random) const {
-    auto key = "PhysicalActivity"_id;
-    double expected = get_expected(context, person.gender, person.age, key);
+    double expected = get_expected(context, person.gender, person.age, "PhysicalActivity"_id);
     double rand = random.next_normal(0.0, physical_activity_stddev_);
     double factor = expected * exp(rand - 0.5 * pow(physical_activity_stddev_, 2));
-    person.risk_factors[key] = factor;
+    person.risk_factors["PhysicalActivity"_id] = factor;
 }
 
 StaticLinearModelDefinition::StaticLinearModelDefinition(

--- a/src/HealthGPS/static_linear_model.h
+++ b/src/HealthGPS/static_linear_model.h
@@ -63,9 +63,9 @@ class StaticLinearModel final : public RiskFactorAdjustableModel {
   private:
     static double inverse_box_cox(double factor, double lambda);
 
-    void initialise_factors(Person &person, Random &random) const;
+    void initialise_factors(RuntimeContext &context, Person &person, Random &random) const;
 
-    void update_factors(Person &person, Random &random) const;
+    void update_factors(RuntimeContext &context, Person &person, Random &random) const;
 
     void initialise_policies(Person &person, Random &random, bool intervene) const;
 
@@ -99,7 +99,8 @@ class StaticLinearModel final : public RiskFactorAdjustableModel {
     /// @brief Initialise the physical activity of a person
     /// @param person The person to initialise sector for
     /// @param random The random number generator from the runtime context
-    void initialise_physical_activity(Person &person, Random &random) const;
+    void initialise_physical_activity(RuntimeContext &context, Person &person,
+                                      Random &random) const;
 
     const std::vector<core::Identifier> &names_;
     const std::vector<LinearModelParams> &models_;

--- a/src/HealthGPS/static_linear_model.h
+++ b/src/HealthGPS/static_linear_model.h
@@ -39,7 +39,7 @@ class StaticLinearModel final : public RiskFactorAdjustableModel {
     /// @param phycical_activity_stddev The standard deviation of the physical activity
     /// @throws HgpsException for invalid arguments
     StaticLinearModel(
-        const RiskFactorSexAgeTable &expected, const std::vector<core::Identifier> &names,
+        std::shared_ptr<RiskFactorSexAgeTable> expected, const std::vector<core::Identifier> &names,
         const std::vector<LinearModelParams> &models,
         const std::vector<core::DoubleInterval> &ranges, const std::vector<double> &lambda,
         const std::vector<double> &stddev, const Eigen::MatrixXd &cholesky,
@@ -136,7 +136,7 @@ class StaticLinearModelDefinition : public RiskFactorAdjustableModelDefinition {
     /// @param phycical_activity_stddev The standard deviation of the physical activity
     /// @throws HgpsException for invalid arguments
     StaticLinearModelDefinition(
-        RiskFactorSexAgeTable expected, std::vector<core::Identifier> names,
+        std::unique_ptr<RiskFactorSexAgeTable> expected, std::vector<core::Identifier> names,
         std::vector<LinearModelParams> models, std::vector<core::DoubleInterval> ranges,
         std::vector<double> lambda, std::vector<double> stddev, Eigen::MatrixXd cholesky,
         std::vector<LinearModelParams> policy_models,

--- a/src/HealthGPS/static_linear_model.h
+++ b/src/HealthGPS/static_linear_model.h
@@ -18,12 +18,12 @@ struct LinearModelParams {
 };
 
 /// @brief Implements the static linear model type
-///
 /// @details The static model is used to initialise the virtual population.
 class StaticLinearModel final : public RiskFactorAdjustableModel {
   public:
     /// @brief Initialises a new instance of the StaticLinearModel class
-    /// @param expected The risk factor expected values by sex and age
+    /// @param expected The expected risk factor values by sex and age
+    /// @param expected_trend The expected trend of risk factor values
     /// @param names The risk factor names
     /// @param models The linear models used to compute a person's risk factor values
     /// @param ranges The value range of each risk factor
@@ -39,8 +39,9 @@ class StaticLinearModel final : public RiskFactorAdjustableModel {
     /// @param phycical_activity_stddev The standard deviation of the physical activity
     /// @throws HgpsException for invalid arguments
     StaticLinearModel(
-        std::shared_ptr<RiskFactorSexAgeTable> expected, const std::vector<core::Identifier> &names,
-        const std::vector<LinearModelParams> &models,
+        std::shared_ptr<RiskFactorSexAgeTable> expected,
+        const std::unordered_map<core::Identifier, double> &expected_trend,
+        const std::vector<core::Identifier> &names, const std::vector<LinearModelParams> &models,
         const std::vector<core::DoubleInterval> &ranges, const std::vector<double> &lambda,
         const std::vector<double> &stddev, const Eigen::MatrixXd &cholesky,
         const std::vector<LinearModelParams> &policy_models,
@@ -120,7 +121,8 @@ class StaticLinearModel final : public RiskFactorAdjustableModel {
 class StaticLinearModelDefinition : public RiskFactorAdjustableModelDefinition {
   public:
     /// @brief Initialises a new instance of the StaticLinearModelDefinition class
-    /// @param expected The risk factor expected values by sex and age
+    /// @param expected The expected risk factor values by sex and age
+    /// @param expected_trend The expected trend of risk factor values
     /// @param names The risk factor names
     /// @param models The linear models used to compute a person's risk factors
     /// @param ranges The value range of each risk factor
@@ -136,9 +138,11 @@ class StaticLinearModelDefinition : public RiskFactorAdjustableModelDefinition {
     /// @param phycical_activity_stddev The standard deviation of the physical activity
     /// @throws HgpsException for invalid arguments
     StaticLinearModelDefinition(
-        std::unique_ptr<RiskFactorSexAgeTable> expected, std::vector<core::Identifier> names,
-        std::vector<LinearModelParams> models, std::vector<core::DoubleInterval> ranges,
-        std::vector<double> lambda, std::vector<double> stddev, Eigen::MatrixXd cholesky,
+        std::unique_ptr<RiskFactorSexAgeTable> expected,
+        std::unordered_map<core::Identifier, double> expected_trend,
+        std::vector<core::Identifier> names, std::vector<LinearModelParams> models,
+        std::vector<core::DoubleInterval> ranges, std::vector<double> lambda,
+        std::vector<double> stddev, Eigen::MatrixXd cholesky,
         std::vector<LinearModelParams> policy_models,
         std::vector<core::DoubleInterval> policy_ranges, Eigen::MatrixXd policy_cholesky,
         double info_speed,

--- a/src/HealthGPS/static_linear_model.h
+++ b/src/HealthGPS/static_linear_model.h
@@ -40,7 +40,7 @@ class StaticLinearModel final : public RiskFactorAdjustableModel {
     /// @throws HgpsException for invalid arguments
     StaticLinearModel(
         std::shared_ptr<RiskFactorSexAgeTable> expected,
-        const std::unordered_map<core::Identifier, double> &expected_trend,
+        std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
         const std::vector<core::Identifier> &names, const std::vector<LinearModelParams> &models,
         const std::vector<core::DoubleInterval> &ranges, const std::vector<double> &lambda,
         const std::vector<double> &stddev, const Eigen::MatrixXd &cholesky,
@@ -140,7 +140,7 @@ class StaticLinearModelDefinition : public RiskFactorAdjustableModelDefinition {
     /// @throws HgpsException for invalid arguments
     StaticLinearModelDefinition(
         std::unique_ptr<RiskFactorSexAgeTable> expected,
-        std::unordered_map<core::Identifier, double> expected_trend,
+        std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
         std::vector<core::Identifier> names, std::vector<LinearModelParams> models,
         std::vector<core::DoubleInterval> ranges, std::vector<double> lambda,
         std::vector<double> stddev, Eigen::MatrixXd cholesky,


### PR DESCRIPTION
Resolves #492 

This change adds new `StaticLinear.json` params: `ExpectedTrend`, which are raised to the power of the iteration number and used to multiply risk factor expected values, to simulate (exponentially) changing population average of nutrients over time.

These are passed into adjustable models as shared pointers rather than references -- see https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-const-or-ref-data-members.html

All adjustable RF model code is updated to use the new trends.
