### PR TITLE
Time trend models for individuals

### DIFF
--- a/src/HealthGPS.Input/model_parser.cpp
+++ b/src/HealthGPS.Input/model_parser.cpp
@@ -185,8 +185,8 @@ load_staticlinear_risk_model_definition(const nlohmann::json &opt, const Configu
     std::vector<double> stddev;
     std::vector<LinearModelParams> policy_models;
     std::vector<core::DoubleInterval> policy_ranges;
-    std::vector<LinearModelParams> trend_models;
-    std::vector<core::DoubleInterval> trend_ranges;
+    auto trend_models = std::make_unique<std::vector<LinearModelParams>>();
+    auto trend_ranges = std::make_unique<std::vector<core::DoubleInterval>>();
     auto expected_trend = std::make_unique<std::unordered_map<core::Identifier, double>>();
 
     size_t i = 0;
@@ -252,8 +252,8 @@ load_staticlinear_risk_model_definition(const nlohmann::json &opt, const Configu
                                            .get<std::unordered_map<core::Identifier, double>>();
 
         // Write time trend data structures.
-        trend_models.emplace_back(std::move(trend_model));
-        trend_ranges.emplace_back(trend_json_params["Range"].get<core::DoubleInterval>());
+        trend_models->emplace_back(std::move(trend_model));
+        trend_ranges->emplace_back(trend_json_params["Range"].get<core::DoubleInterval>());
 
         // Load expected value trends.
         (*expected_trend)[key] = json_params["ExpectedTrend"].get<double>();

--- a/src/HealthGPS.Input/model_parser.cpp
+++ b/src/HealthGPS.Input/model_parser.cpp
@@ -345,8 +345,9 @@ load_staticlinear_risk_model_definition(const nlohmann::json &opt, const Configu
     return std::make_unique<StaticLinearModelDefinition>(
         std::move(expected), std::move(expected_trend), std::move(names), std::move(models),
         std::move(ranges), std::move(lambda), std::move(stddev), std::move(cholesky),
-        std::move(policy_models), std::move(policy_ranges), std::move(policy_cholesky), info_speed,
-        std::move(rural_prevalence), std::move(income_models), physical_activity_stddev);
+        std::move(policy_models), std::move(policy_ranges), std::move(policy_cholesky),
+        std::move(trend_models), std::move(trend_ranges), info_speed, std::move(rural_prevalence),
+        std::move(income_models), physical_activity_stddev);
 }
 
 std::unique_ptr<hgps::RiskFactorModelDefinition>

--- a/src/HealthGPS/static_linear_model.cpp
+++ b/src/HealthGPS/static_linear_model.cpp
@@ -24,8 +24,9 @@ StaticLinearModel::StaticLinearModel(
     : RiskFactorAdjustableModel{std::move(expected), std::move(expected_trend)}, names_{names},
       models_{models}, ranges_{ranges}, lambda_{lambda}, stddev_{stddev}, cholesky_{cholesky},
       policy_models_{policy_models}, policy_ranges_{policy_ranges},
-      policy_cholesky_{policy_cholesky}, trend_models_{trend_models}, trend_ranges_{trend_ranges},
-      info_speed_{info_speed}, rural_prevalence_{rural_prevalence}, income_models_{income_models},
+      policy_cholesky_{policy_cholesky}, trend_models_{std::move(trend_models)},
+      trend_ranges_{std::move(trend_ranges)}, info_speed_{info_speed},
+      rural_prevalence_{rural_prevalence}, income_models_{income_models},
       physical_activity_stddev_{physical_activity_stddev} {}
 
 RiskFactorModelType StaticLinearModel::type() const noexcept { return RiskFactorModelType::Static; }

--- a/src/HealthGPS/static_linear_model.cpp
+++ b/src/HealthGPS/static_linear_model.cpp
@@ -39,6 +39,7 @@ void StaticLinearModel::generate_risk_factors(RuntimeContext &context) {
         initialise_sector(person, context.random());
         initialise_income(person, context.random());
         initialise_factors(context, person, context.random());
+        initialise_trends(context, person);
         initialise_physical_activity(context, person, context.random());
     }
 
@@ -68,11 +69,13 @@ void StaticLinearModel::update_risk_factors(RuntimeContext &context) {
             initialise_sector(person, context.random());
             initialise_income(person, context.random());
             initialise_factors(context, person, context.random());
+            initialise_trends(context, person);
             initialise_physical_activity(context, person, context.random());
         } else {
             update_sector(person, context.random());
             update_income(person, context.random());
             update_factors(context, person, context.random());
+            update_trends(context, person);
         }
     }
 

--- a/src/HealthGPS/static_linear_model.h
+++ b/src/HealthGPS/static_linear_model.h
@@ -48,8 +48,9 @@ class StaticLinearModel final : public RiskFactorAdjustableModel {
         const std::vector<double> &stddev, const Eigen::MatrixXd &cholesky,
         const std::vector<LinearModelParams> &policy_models,
         const std::vector<core::DoubleInterval> &policy_ranges,
-        const Eigen::MatrixXd &policy_cholesky, const std::vector<LinearModelParams> &trend_models,
-        const std::vector<core::DoubleInterval> &trend_ranges, double info_speed,
+        const Eigen::MatrixXd &policy_cholesky,
+        std::shared_ptr<std::vector<LinearModelParams>> trend_models,
+        std::shared_ptr<std::vector<core::DoubleInterval>> trend_ranges, double info_speed,
         const std::unordered_map<core::Identifier, std::unordered_map<core::Gender, double>>
             &rural_prevalence,
         const std::unordered_map<core::Income, LinearModelParams> &income_models,
@@ -118,8 +119,8 @@ class StaticLinearModel final : public RiskFactorAdjustableModel {
     const std::vector<LinearModelParams> &policy_models_;
     const std::vector<core::DoubleInterval> &policy_ranges_;
     const Eigen::MatrixXd &policy_cholesky_;
-    const std::vector<LinearModelParams> &trend_models_;
-    const std::vector<core::DoubleInterval> &trend_ranges_;
+    std::shared_ptr<std::vector<LinearModelParams>> trend_models_;
+    std::shared_ptr<std::vector<core::DoubleInterval>> trend_ranges_;
     const double info_speed_;
     const std::unordered_map<core::Identifier, std::unordered_map<core::Gender, double>>
         &rural_prevalence_;
@@ -157,8 +158,8 @@ class StaticLinearModelDefinition : public RiskFactorAdjustableModelDefinition {
         std::vector<double> stddev, Eigen::MatrixXd cholesky,
         std::vector<LinearModelParams> policy_models,
         std::vector<core::DoubleInterval> policy_ranges, Eigen::MatrixXd policy_cholesky,
-        std::vector<LinearModelParams> trend_models, std::vector<core::DoubleInterval> trend_ranges,
-        double info_speed,
+        std::unique_ptr<std::vector<LinearModelParams>> trend_models,
+        std::unique_ptr<std::vector<core::DoubleInterval>> trend_ranges, double info_speed,
         std::unordered_map<core::Identifier, std::unordered_map<core::Gender, double>>
             rural_prevalence,
         std::unordered_map<core::Income, LinearModelParams> income_models,
@@ -178,8 +179,8 @@ class StaticLinearModelDefinition : public RiskFactorAdjustableModelDefinition {
     std::vector<LinearModelParams> policy_models_;
     std::vector<core::DoubleInterval> policy_ranges_;
     Eigen::MatrixXd policy_cholesky_;
-    std::vector<LinearModelParams> trend_models_;
-    std::vector<core::DoubleInterval> trend_ranges_;
+    std::shared_ptr<std::vector<LinearModelParams>> trend_models_;
+    std::shared_ptr<std::vector<core::DoubleInterval>> trend_ranges_;
     double info_speed_;
     std::unordered_map<core::Identifier, std::unordered_map<core::Gender, double>>
         rural_prevalence_;

--- a/src/HealthGPS/static_linear_model.h
+++ b/src/HealthGPS/static_linear_model.h
@@ -70,6 +70,10 @@ class StaticLinearModel final : public RiskFactorAdjustableModel {
 
     void update_factors(RuntimeContext &context, Person &person, Random &random) const;
 
+    void initialise_trends(RuntimeContext &context, Person &person) const;
+
+    void update_trends(RuntimeContext &context, Person &person) const;
+
     void initialise_policies(Person &person, Random &random, bool intervene) const;
 
     void update_policies(Person &person, bool intervene) const;

--- a/src/HealthGPS/static_linear_model.h
+++ b/src/HealthGPS/static_linear_model.h
@@ -33,6 +33,8 @@ class StaticLinearModel final : public RiskFactorAdjustableModel {
     /// @param policy_models The linear models used to compute a person's intervention policies
     /// @param policy_ranges The value range of each intervention policy
     /// @param policy_cholesky Cholesky decomposition of the intervention policy covariance matrix
+    /// @param trend_models The linear models used to compute a person's risk factor trends
+    /// @param trend_ranges The value range of each risk factor trend
     /// @param info_speed The information speed of risk factor updates
     /// @param rural_prevalence Rural sector prevalence for age groups and sex
     /// @param income_models The income models for each income category
@@ -46,7 +48,8 @@ class StaticLinearModel final : public RiskFactorAdjustableModel {
         const std::vector<double> &stddev, const Eigen::MatrixXd &cholesky,
         const std::vector<LinearModelParams> &policy_models,
         const std::vector<core::DoubleInterval> &policy_ranges,
-        const Eigen::MatrixXd &policy_cholesky, double info_speed,
+        const Eigen::MatrixXd &policy_cholesky, const std::vector<LinearModelParams> &trend_models,
+        const std::vector<core::DoubleInterval> &trend_ranges, double info_speed,
         const std::unordered_map<core::Identifier, std::unordered_map<core::Gender, double>>
             &rural_prevalence,
         const std::unordered_map<core::Income, LinearModelParams> &income_models,
@@ -111,6 +114,8 @@ class StaticLinearModel final : public RiskFactorAdjustableModel {
     const std::vector<LinearModelParams> &policy_models_;
     const std::vector<core::DoubleInterval> &policy_ranges_;
     const Eigen::MatrixXd &policy_cholesky_;
+    const std::vector<LinearModelParams> &trend_models_;
+    const std::vector<core::DoubleInterval> &trend_ranges_;
     const double info_speed_;
     const std::unordered_map<core::Identifier, std::unordered_map<core::Gender, double>>
         &rural_prevalence_;
@@ -133,6 +138,8 @@ class StaticLinearModelDefinition : public RiskFactorAdjustableModelDefinition {
     /// @param policy_models The linear models used to compute a person's intervention policies
     /// @param policy_ranges The value range of each intervention policy
     /// @param policy_cholesky Cholesky decomposition of the intervention policy covariance matrix
+    /// @param trend_models The linear models used to compute a person's risk factor trends
+    /// @param trend_ranges The value range of each risk factor trend
     /// @param info_speed The information speed of risk factor updates
     /// @param rural_prevalence Rural sector prevalence for age groups and sex
     /// @param income_models The income models for each income category
@@ -146,6 +153,7 @@ class StaticLinearModelDefinition : public RiskFactorAdjustableModelDefinition {
         std::vector<double> stddev, Eigen::MatrixXd cholesky,
         std::vector<LinearModelParams> policy_models,
         std::vector<core::DoubleInterval> policy_ranges, Eigen::MatrixXd policy_cholesky,
+        std::vector<LinearModelParams> trend_models, std::vector<core::DoubleInterval> trend_ranges,
         double info_speed,
         std::unordered_map<core::Identifier, std::unordered_map<core::Gender, double>>
             rural_prevalence,
@@ -166,6 +174,8 @@ class StaticLinearModelDefinition : public RiskFactorAdjustableModelDefinition {
     std::vector<LinearModelParams> policy_models_;
     std::vector<core::DoubleInterval> policy_ranges_;
     Eigen::MatrixXd policy_cholesky_;
+    std::vector<LinearModelParams> trend_models_;
+    std::vector<core::DoubleInterval> trend_ranges_;
     double info_speed_;
     std::unordered_map<core::Identifier, std::unordered_map<core::Gender, double>>
         rural_prevalence_;


### PR DESCRIPTION
Resolves #493 

*REVIEW AFTER #491* 

This PR adds functionality for computing and applying time trends for individuals' nutrient values.

In a nutshell, add these for each nutrients in `StaticLinear.json`:

```
  69             "Trend": {                                                                                            
  70                 "Range": [0.0, 5.0],                                                                              
  71                 "Intercept": 0.0,                                                                                 
  72                 "Coefficients": {                                                                                 
  73                     "Gender": 0.0,                                                                                
  74                     "Age": 0.0,                                                                                   
  75                     "Age2": 0.0,                                                                                  
  76                     "Age3": 0.0,                                                                                  
  77                     "Sector": 0.0,                                                                                
  78                     "Income": 0.0                                                                                 
  79                 },                                                                                                
  80                 "LogCoefficients": {                                                                              
  81                     "FoodCarbohydrate": 1.0,                                                                      
  82                     "FoodFat": 1.0,                                                                               
  83                     "FoodProtein": 1.0,                                                                           
  84                     "FoodSodium": 1.0                                                                             
  85                 }                                                                                                 
  86             },                                                                                                    
  87             "ExpectedTrend": 1.0    
```

The main changes are loading and verifying these values in `model_parser.cpp`, and adding/using new `initialise_trends`/`update_trends` in `static_linear_model.cpp`. These are applied *after* base nutrients are computed, and *before* expected value adjustment occurs.

Both time trend and final nutrient values are clipped with their respective ranges throughout. Any questions or need a walkthrough, please reach me on chat. Please do test this @jzhu20, to make sure it is what you wanted.
