### PR TITLE
Add some basic VS Code settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -399,6 +399,7 @@ FodyWeavers.xsd
 # VS Code files for those working on multiple tools
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 *.code-workspace
 
 # Local History for Visual Studio Code

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,12 @@ repos:
       - id: fix-byte-order-marker
       - id: check-merge-conflict
       - id: check-json
+        exclude: .vscode/settings.json
       - id: check-yaml
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: pretty-format-json
+        exclude: .vscode/settings.json
         args: [--autofix, --indent, '4', --no-sort]
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
     rev: v2.14.0

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
     "recommendations": [
         "ms-vscode.cpptools-extension-pack",
-        "davidanson.vscode-markdownlint"
+        "davidanson.vscode-markdownlint",
+        "streetsidesoftware.code-spell-checker"
     ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
     "recommendations": [
-        "ms-vscode.cpptools",
+        "ms-vscode.cpptools-extension-pack",
         "davidanson.vscode-markdownlint"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+    "[cpp]": {
+        "editor.formatOnSave": true,
+        "editor.rulers": [100],
+    },
+    "[cmake]": {
+        "editor.formatOnSave": true,
+        "editor.rulers": [100],
+    },
+    "[json]": {
+        "editor.formatOnSave": false
+    },
+    "[jsonc]": {
+        "editor.formatOnSave": false
+    },
+    "[yaml]": {
+        "editor.formatOnSave": false
+    }
+}


### PR DESCRIPTION
It periodically annoys me when I find that files aren't being autoformatted in VS Code or the rulers are in the wrong place for HGPS. Let's add these settings for VS Code users.

I've also added the C++ extension pack (which includes CMake support) and a spellchecker to the extension recommendations.