### PR TITLE
Fix rebasing of relative data paths

### DIFF
--- a/src/HealthGPS.Core/math_util.cpp
+++ b/src/HealthGPS.Core/math_util.cpp
@@ -1,4 +1,6 @@
 #include "math_util.h"
+
+#include <algorithm>
 #include <cmath>
 
 namespace hgps::core {

--- a/src/HealthGPS.Input/data_source.cpp
+++ b/src/HealthGPS.Input/data_source.cpp
@@ -6,9 +6,10 @@
 #include <fmt/format.h>
 
 namespace {
-// If source is a relative path to a directory, rebase it on root_path, else just return source
+// If source is a relative path, rebase it on root_path, else just return source
 std::string try_rebase_path(std::string source, const std::filesystem::path &root_path) {
-    if (!std::filesystem::is_directory(source)) {
+    // If source is a URL, leave it alone
+    if (source.starts_with("http://") || source.starts_with("https://")) {
         return source;
     }
 
@@ -17,7 +18,7 @@ std::string try_rebase_path(std::string source, const std::filesystem::path &roo
         return source;
     }
 
-    return (root_path / path).string();
+    return std::filesystem::absolute(root_path / path).string();
 }
 
 // Get a path to a zip file; if source is a URL it will be downloaded first


### PR DESCRIPTION
Users are able to specify a path to a zip file or directory via the config file, as well as a URL. If the path is a relative path, we treat it as relative to the folder the config file is in, but currently this doesn't work.

The logic of `try_rebase_path()` is currently broken, as it returns early if `std::filesystem::is_directory()` returns false. There are a couple of things wrong with this:

1. If it is a relative path, then false will be returned anyway, because non-existent paths also cause false to be returned
2. We don't actually need to distinguish between whether the path is to a zip file or a directory, just whether or not it is a URL