### PR TITLE
CMake: Make VS Code use same formatter as we use with `pre-commit`

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
     "recommendations": [
         "ms-vscode.cpptools-extension-pack",
+        "cheshirekow.cmake-format",
         "davidanson.vscode-markdownlint",
         "streetsidesoftware.code-spell-checker"
     ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
     },
     "[cmake]": {
         "editor.formatOnSave": true,
+        "editor.defaultFormatter": "cheshirekow.cmake-format",
         "editor.rulers": [100],
     },
     "[json]": {


### PR DESCRIPTION
I changed the VS Code settings to auto-format CMake files, but unfortunately the default formatter doesn't use the same `cmake-format` tools as the `pre-commit` hook uses, so they're fighting one another. Fix this by changing the VS Code settings to use a compatible extension for formatting CMake files.