### PR TITLE
Allow for specifying output folder via command-line argument

### DIFF
--- a/schemas/v1/config/output.json
+++ b/schemas/v1/config/output.json
@@ -15,7 +15,6 @@
     },
     "required": [
         "comorbidities",
-        "folder",
         "file_name"
     ],
     "additionalProperties": false

--- a/src/HealthGPS.Console/command_options.cpp
+++ b/src/HealthGPS.Console/command_options.cpp
@@ -11,6 +11,7 @@ cxxopts::Options create_options() {
     cxxopts::Options options("HealthGPS.Console", "Health-GPS microsimulation for policy options.");
     options.add_options()("f,file", "Configuration file full name.", cxxopts::value<std::string>())(
         "s,storage", "Path to root folder of the data storage.", cxxopts::value<std::string>())(
+        "o,output", "Path to output folder", cxxopts::value<std::string>())(
         "j,jobid", "The batch execution job identifier.",
         cxxopts::value<int>())("verbose", "Print more information about progress",
                                cxxopts::value<bool>()->default_value("false"))(
@@ -61,6 +62,10 @@ std::optional<CommandOptions> parse_arguments(cxxopts::Options &options, int arg
         fmt::print("Data source: {}\n", source);
 
         cmd.data_source = hgps::input::DataSource(std::move(source));
+    }
+
+    if (result.count("output")) {
+        cmd.output_folder = result["output"].as<std::string>();
     }
 
     if (result.count("jobid")) {

--- a/src/HealthGPS.Console/command_options.h
+++ b/src/HealthGPS.Console/command_options.h
@@ -20,6 +20,9 @@ struct CommandOptions {
     /// @brief The back-end storage full path or URL argument value
     std::optional<hgps::input::DataSource> data_source;
 
+    /// @brief The output folder where results will be saved
+    std::optional<std::string> output_folder;
+
     /// @brief Indicates whether the application logging is verbose
     bool verbose{};
 

--- a/src/HealthGPS.Console/program.cpp
+++ b/src/HealthGPS.Console/program.cpp
@@ -101,7 +101,8 @@ int main(int argc, char *argv[]) { // NOLINT(bugprone-exception-escape)
     // Parse inputs configuration file, *.json.
     Configuration config;
     try {
-        config = get_configuration(cmd_args.config_file, cmd_args.job_id, cmd_args.verbose);
+        config = get_configuration(cmd_args.config_file, cmd_args.output_folder, cmd_args.job_id,
+                                   cmd_args.verbose);
     } catch (const std::exception &ex) {
         fmt::print(fg(fmt::color::red), "\n\nInvalid configuration - {}.\n", ex.what());
         return exit_application(EXIT_FAILURE);

--- a/src/HealthGPS.Input/configuration.cpp
+++ b/src/HealthGPS.Input/configuration.cpp
@@ -59,7 +59,8 @@ using json = nlohmann::json;
 
 ConfigurationError::ConfigurationError(const std::string &msg) : std::runtime_error{msg} {}
 
-Configuration get_configuration(const std::filesystem::path &config_file, int job_id,
+Configuration get_configuration(const std::filesystem::path &config_file,
+                                const std::optional<std::string> &output_folder, int job_id,
                                 bool verbose) {
     MEASURE_FUNCTION();
     bool success = true;
@@ -111,10 +112,10 @@ Configuration get_configuration(const std::filesystem::path &config_file, int jo
     }
 
     try {
-        load_output_info(opt, config);
-    } catch (const ConfigurationError &) {
+        load_output_info(opt, config, output_folder);
+    } catch (const ConfigurationError &e) {
         success = false;
-        fmt::print(fg(fmt::color::red), "Could not load output info");
+        fmt::print(fg(fmt::color::red), e.what());
     }
 
     if (!success) {

--- a/src/HealthGPS.Input/configuration.h
+++ b/src/HealthGPS.Input/configuration.h
@@ -87,10 +87,13 @@ class ConfigurationError : public std::runtime_error {
 
 /// @brief Loads the input configuration file, *.json, information
 /// @param config_file Path to config file
+/// @param output_folder Path to output folder, if provided via command-line argument
 /// @param job_id Job ID (for HPC)
 /// @param verbose Set log verbosity for simulation
 /// @return The configuration file information
-Configuration get_configuration(const std::filesystem::path &config_file, int job_id, bool verbose);
+Configuration get_configuration(const std::filesystem::path &config_file,
+                                const std::optional<std::string> &output_folder, int job_id,
+                                bool verbose);
 
 /// @brief Gets the collection of diseases that matches the selected input list
 /// @param data_api The back-end data store instance to be used.

--- a/src/HealthGPS.Input/configuration_parsing.cpp
+++ b/src/HealthGPS.Input/configuration_parsing.cpp
@@ -256,12 +256,25 @@ void load_running_info(const json &j, Configuration &config) {
     }
 }
 
-void load_output_info(const json &j, Configuration &config) {
+void load_output_info(const json &j, Configuration &config,
+                      const std::optional<std::string> &output_folder) {
     if (!get_to(j, "output", config.output)) {
         throw ConfigurationError{"Could not load output info"};
     }
 
-    config.output.folder = expand_environment_variables(config.output.folder);
+    if (output_folder.has_value() != config.output.folder.empty()) {
+        throw ConfigurationError(
+            "Must specify output folder via command line argument or config file, but not both");
+    }
+
+    if (output_folder.has_value()) {
+        config.output.folder = output_folder.value();
+    } else {
+        config.output.folder = expand_environment_variables(config.output.folder);
+        fmt::print(fmt::fg(fmt::color::dark_salmon),
+                   "Providing output folder via config file is deprecated. Please use -o "
+                   "command-line argument instead.");
+    }
 }
 
 } // namespace hgps::input

--- a/src/HealthGPS.Input/configuration_parsing.h
+++ b/src/HealthGPS.Input/configuration_parsing.h
@@ -5,6 +5,8 @@
 #pragma once
 #include "configuration.h"
 
+#include <optional>
+
 namespace hgps::input {
 /// @brief Check the schema version and throw if invalid
 /// @param j The root JSON object
@@ -32,6 +34,8 @@ void load_running_info(const nlohmann::json &j, Configuration &config);
 /// @brief Load output section of JSON object
 /// @param j The root JSON object
 /// @param config The config object to update
+/// @param output_folder Output folder, if provided via command-line argument
 /// @throw ConfigurationError: Could not load output info
-void load_output_info(const nlohmann::json &j, Configuration &config);
+void load_output_info(const nlohmann::json &j, Configuration &config,
+                      const std::optional<std::string> &output_folder);
 } // namespace hgps::input

--- a/src/HealthGPS.Input/jsonparser.cpp
+++ b/src/HealthGPS.Input/jsonparser.cpp
@@ -216,7 +216,9 @@ void to_json(json &j, const OutputInfo &p) {
 }
 
 void from_json(const json &j, OutputInfo &p) {
-    j.at("folder").get_to(p.folder);
+    if (j.contains("folder")) {
+        j.at("folder").get_to(p.folder);
+    }
     j.at("file_name").get_to(p.file_name);
     j.at("comorbidities").get_to(p.comorbidities);
 }

--- a/src/HealthGPS.Tests/Configuration.Test.cpp
+++ b/src/HealthGPS.Tests/Configuration.Test.cpp
@@ -644,7 +644,7 @@ TEST_F(ConfigParsingFixture, LoadOutputInfo) {
     // Valid info
     {
         auto config = create_config();
-        EXPECT_NO_THROW(load_output_info(valid_output_info, config));
+        EXPECT_NO_THROW(load_output_info(valid_output_info, config, std::nullopt));
         EXPECT_EQ(config.output, output_info);
     }
 
@@ -653,6 +653,6 @@ TEST_F(ConfigParsingFixture, LoadOutputInfo) {
         auto config = create_config();
         auto j = valid_output_info;
         j["output"][key] = nullptr; // None of the values should be null
-        EXPECT_THROW(load_output_info(j, config), ConfigurationError);
+        EXPECT_THROW(load_output_info(j, config, std::nullopt), ConfigurationError);
     }
 }


### PR DESCRIPTION
This PR adds the option to specify the output folder via a command-line argument instead of through an option in a config file. The latter is still supported, but a warning will be displayed, as longer term it would be good to move users away from this. Note that users still need to specify a file name in the config file for now, as this option is actually used to create two file names (for the JSON and CSV output files). (Plus, the name can also include a placeholder string representing a time stamp and it seemed weird to include this in the command-line argument.)

Closes #512.