### PR TITLE
Set max threads with command-line argument

### DIFF
--- a/src/HealthGPS.Console/command_options.cpp
+++ b/src/HealthGPS.Console/command_options.cpp
@@ -11,10 +11,13 @@ cxxopts::Options create_options() {
     cxxopts::Options options("HealthGPS.Console", "Health-GPS microsimulation for policy options.");
     options.add_options()("f,file", "Configuration file full name.", cxxopts::value<std::string>())(
         "s,storage", "Path to root folder of the data storage.", cxxopts::value<std::string>())(
-        "j,jobid", "The batch execution job identifier.",
-        cxxopts::value<int>())("verbose", "Print more information about progress",
-                               cxxopts::value<bool>()->default_value("false"))(
-        "help", "Help about this application.")("version", "Print the application version number.");
+        "j,jobid", "The batch execution job identifier.", cxxopts::value<int>())(
+        "T,threads", "The maximum number of threads to create (0: no limit, default).",
+        cxxopts::value<size_t>())
+
+        ("verbose", "Print more information about progress",
+         cxxopts::value<bool>()->default_value("false"))("help", "Help about this application.")(
+            "version", "Print the application version number.");
 
     return options;
 }
@@ -69,6 +72,10 @@ std::optional<CommandOptions> parse_arguments(cxxopts::Options &options, int arg
             throw std::runtime_error(
                 fmt::format("Job identifier value outside range: (0 < x) given: {}.", cmd.job_id));
         }
+    }
+
+    if (result.count("threads")) {
+        cmd.num_threads = result["threads"].as<size_t>();
     }
 
     return cmd;

--- a/src/HealthGPS.Console/command_options.h
+++ b/src/HealthGPS.Console/command_options.h
@@ -25,6 +25,9 @@ struct CommandOptions {
 
     /// @brief The batch job identifier value, optional.
     int job_id{};
+
+    /// @brief The maximum number of threads to use (0: no limit).
+    size_t num_threads{};
 };
 
 /// @brief Creates the command-line interface (CLI) options


### PR DESCRIPTION
The current method for setting the maximum number of threads is to set the environment variable OMP_THREAD_LIMIT. While HealthGPS doesn't (presently) use OpenMP, this was introduced for the sake of backwards compatibility; the older version of HealthGPS *did* use OpenMP.

The problem is that OMP_THEAD_LIMIT isn't the only environment variable used to control the number of threads with OpenMP: the usual one to set is OMP_NUM_THREADS. Unfortunately, Imperial's HPC cluster doesn't automatically set OMP_THREAD_LIMIT, just OMP_NUM_THREADS, meaning that the current hack won't actually work: users have to explicitly set OMP_THREAD_LIMIT to control parallelism.

I think it would be cleaner to abandon the hack altogether and let users (optionally) set the parallelism via a command-line argument, which is what I've implemented here.

As this is technically a breaking change, I've opened the PR in draft.