### PR TITLE
Add schemas for model configs

### DIFF
--- a/schemas/v1/config/csv_file.json
+++ b/schemas/v1/config/csv_file.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/config/csv_file.json",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "format": {
+            "const": "csv"
+        },
+        "delimiter": {
+            "const": ","
+        },
+        "encoding": {
+            "const": "ASCII"
+        },
+        "columns": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    {
+                        "const": "integer"
+                    },
+                    {
+                        "const": "double"
+                    }
+                ]
+            }
+        }
+    },
+    "required": [
+        "name",
+        "format",
+        "delimiter",
+        "encoding",
+        "columns"
+    ],
+    "additionalProperties": false
+}

--- a/schemas/v1/config/inputs.json
+++ b/schemas/v1/config/inputs.json
@@ -4,42 +4,7 @@
     "type": "object",
     "properties": {
         "dataset": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "format": {
-                    "const": "csv"
-                },
-                "delimiter": {
-                    "type": "string"
-                },
-                "encoding": {
-                    "type": "string"
-                },
-                "columns": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "anyOf": [
-                            {
-                                "const": "integer"
-                            },
-                            {
-                                "const": "double"
-                            }
-                        ]
-                    }
-                }
-            },
-            "required": [
-                "name",
-                "format",
-                "delimiter",
-                "encoding",
-                "columns"
-            ],
-            "additionalProperties": false
+            "$ref": "csv_file.json"
         },
         "settings": {
             "type": "object",

--- a/schemas/v1/config/models/dummy.json
+++ b/schemas/v1/config/models/dummy.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/config/models/dummy.json",
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "ModelName": {
+            "const": "Dummy"
+        },
+        "ModelParameters": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "Value": {
+                        "type": "number"
+                    },
+                    "Policy": {
+                        "type": "number"
+                    },
+                    "PolicyStart": {
+                        "type": "integer",
+                        "minimum": 0
+                    }
+                }
+            },
+            "minItems": 1
+        }
+    },
+    "required": [
+        "ModelName",
+        "ModelParameters"
+    ],
+    "additionalProperties": false
+}

--- a/schemas/v1/config/models/dynamic.json
+++ b/schemas/v1/config/models/dynamic.json
@@ -4,6 +4,9 @@
     "anyOf": [
         {
             "$ref": "dummy.json"
+        },
+        {
+            "$ref": "ebhlm.json"
         }
     ]
 }

--- a/schemas/v1/config/models/dynamic.json
+++ b/schemas/v1/config/models/dynamic.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/config/models/dynamic.json",
+    "anyOf": [
+        {
+            "$ref": "dummy.json"
+        }
+    ]
+}

--- a/schemas/v1/config/models/dynamic.json
+++ b/schemas/v1/config/models/dynamic.json
@@ -7,6 +7,9 @@
         },
         {
             "$ref": "ebhlm.json"
+        },
+        {
+            "$ref": "kevinhall.json"
         }
     ]
 }

--- a/schemas/v1/config/models/ebhlm.json
+++ b/schemas/v1/config/models/ebhlm.json
@@ -1,0 +1,119 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/config/models/ebhlm.json",
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "ModelName": {
+            "const": "EBHLM"
+        },
+        "Country": {
+            "type": "object",
+            "properties": {
+                "Code": {
+                    "type": "integer"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "Alpha2": {
+                    "type": "string"
+                },
+                "Alpha3": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Code",
+                "Name",
+                "Alpha2",
+                "Alpha3"
+            ],
+            "additionalProperties": false
+        },
+        "BoundaryPercentage": {
+            "type": "number",
+            "exclusiveMinimum": 0.0,
+            "exclusiveMaximum": 1.0
+        },
+        "Variables": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "Name": {
+                        "type": "string"
+                    },
+                    "Factor": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "Name",
+                    "Factor"
+                ],
+                "additionalProperties": false
+            },
+            "minItems": 1
+        },
+        "Equations": {
+            "type": "object",
+            "propertyNames": {
+                "pattern": "^[0-9]+\\-[0-9]+$"
+            },
+            "additionalProperties": {
+                "type": "object",
+                "propertyNames": {
+                    "enum": [
+                        "Male",
+                        "Female"
+                    ]
+                },
+                "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "Name": {
+                                "type": "string"
+                            },
+                            "Coefficients": {
+                                "type": "object",
+                                "properties": {
+                                    "Intercept": {
+                                        "type": "number"
+                                    }
+                                },
+                                "additionalProperties": {
+                                    "type": "number"
+                                },
+                                "required": [
+                                    "Intercept"
+                                ]
+                            },
+                            "ResidualsStandardDeviation": {
+                                "type": "number"
+                            }
+                        },
+                        "required": [
+                            "Name",
+                            "Coefficients",
+                            "ResidualsStandardDeviation"
+                        ],
+                        "additionalProperties": false
+                    }
+                }
+            }
+        }
+    },
+    "required": [
+        "ModelName",
+        "Country",
+        "BoundaryPercentage",
+        "Variables",
+        "Equations"
+    ],
+    "additionalProperties": false
+}

--- a/schemas/v1/config/models/hlm.json
+++ b/schemas/v1/config/models/hlm.json
@@ -1,0 +1,157 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/config/models/hlm.json",
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "ModelName": {
+            "const": "HLM"
+        },
+        "models": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "formula": {
+                        "type": "string"
+                    },
+                    "coefficients": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "value": {
+                                    "type": "number"
+                                },
+                                "stdError": {
+                                    "type": "number"
+                                },
+                                "tValue": {
+                                    "type": "number"
+                                },
+                                "pValue": {
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "value",
+                                "stdError",
+                                "tValue",
+                                "pValue"
+                            ],
+                            "additionalProperties": false
+                        }
+                    },
+                    "residuals": {
+                        "type": "array",
+                        "items": {
+                            "type": "number"
+                        }
+                    },
+                    "fittedValues": {
+                        "type": "array",
+                        "items": {
+                            "type": "number"
+                        }
+                    },
+                    "residualsStandardDeviation": {
+                        "type": "number"
+                    },
+                    "rSquared": {
+                        "type": "number"
+                    }
+                },
+                "required": [
+                    "formula",
+                    "coefficients",
+                    "residuals",
+                    "fittedValues",
+                    "residualsStandardDeviation",
+                    "rSquared"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "levels": {
+            "type": "object",
+            "propertyNames": {
+                "pattern": "^[0-9]+$"
+            },
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "variables": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 1
+                    },
+                    "m": {
+                        "$ref": "#/$defs/variable"
+                    },
+                    "w": {
+                        "$ref": "#/$defs/variable"
+                    },
+                    "s": {
+                        "$ref": "#/$defs/variable"
+                    },
+                    "correlation": {
+                        "$ref": "#/$defs/variable"
+                    },
+                    "variances": {
+                        "type": "array",
+                        "items": {
+                            "type": "number"
+                        }
+                    }
+                },
+                "required": [
+                    "variables",
+                    "m",
+                    "w",
+                    "s",
+                    "correlation",
+                    "variances"
+                ],
+                "additionalProperties": false
+            }
+        }
+    },
+    "required": [
+        "ModelName",
+        "models",
+        "levels"
+    ],
+    "additionalProperties": false,
+    "$defs": {
+        "variable": {
+            "type": "object",
+            "properties": {
+                "rows": {
+                    "type": "number",
+                    "minimum": 1
+                },
+                "cols": {
+                    "type": "number",
+                    "minimum": 1
+                },
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    },
+                    "minItems": 1
+                }
+            },
+            "required": [
+                "rows",
+                "cols",
+                "data"
+            ],
+            "additionalProperties": false
+        }
+    }
+}

--- a/schemas/v1/config/models/kevinhall.json
+++ b/schemas/v1/config/models/kevinhall.json
@@ -1,0 +1,133 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/config/models/kevinhall.json",
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "ModelName": {
+            "const": "KevinHall"
+        },
+        "Nutrients": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "Name": {
+                        "type": "string"
+                    },
+                    "Range": {
+                        "type": "array",
+                        "items": {
+                            "type": "number",
+                            "minimum": 0.0
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                    },
+                    "Energy": {
+                        "type": "number",
+                        "minimum": 0.0
+                    }
+                },
+                "required": [
+                    "Name",
+                    "Range",
+                    "Energy"
+                ],
+                "additionalProperties": false
+            },
+            "minItems": 1
+        },
+        "Foods": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "Name": {
+                        "type": "string"
+                    },
+                    "Nutrients": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "number"
+                        }
+                    },
+                    "Price": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "required": [
+                    "Name",
+                    "Nutrients",
+                    "Price"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "WeightQuantiles": {
+            "propertyNames": {
+                "enum": [
+                    "Male",
+                    "Female"
+                ]
+            },
+            "additionalProperties": {
+                "$ref": "../csv_file.json"
+            }
+        },
+        "EnergyPhysicalActivityQuantiles": {
+            "$ref": "../csv_file.json"
+        },
+        "HeightStdDev": {
+            "type": "object",
+            "properties": {
+                "Male": {
+                    "type": "number"
+                },
+                "Female": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "Male",
+                "Female"
+            ],
+            "additionalProperties": false
+        },
+        "HeightSlope": {
+            "type": "object",
+            "properties": {
+                "Male": {
+                    "type": "number"
+                },
+                "Female": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "Male",
+                "Female"
+            ],
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "ModelName",
+        "Nutrients",
+        "Foods",
+        "WeightQuantiles",
+        "EnergyPhysicalActivityQuantiles",
+        "HeightStdDev",
+        "HeightSlope"
+    ],
+    "additionalProperties": false
+}

--- a/schemas/v1/config/models/static.json
+++ b/schemas/v1/config/models/static.json
@@ -4,6 +4,9 @@
     "anyOf": [
         {
             "$ref": "dummy.json"
+        },
+        {
+            "$ref": "hlm.json"
         }
     ]
 }

--- a/schemas/v1/config/models/static.json
+++ b/schemas/v1/config/models/static.json
@@ -7,6 +7,9 @@
         },
         {
             "$ref": "hlm.json"
+        },
+        {
+            "$ref": "staticlinear.json"
         }
     ]
 }

--- a/schemas/v1/config/models/static.json
+++ b/schemas/v1/config/models/static.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/config/models/static.json",
+    "anyOf": [
+        {
+            "$ref": "dummy.json"
+        }
+    ]
+}

--- a/schemas/v1/config/models/staticlinear.json
+++ b/schemas/v1/config/models/staticlinear.json
@@ -1,0 +1,161 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/config/models/staticlinear.json",
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "ModelName": {
+            "const": "StaticLinear"
+        },
+        "InformationSpeed": {
+            "type": "number"
+        },
+        "PhysicalActivityStdDev": {
+            "type": "number"
+        },
+        "RuralPrevalence": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "Name": {
+                        "type": "string"
+                    },
+                    "Female": {
+                        "type": "number"
+                    },
+                    "Male": {
+                        "type": "number"
+                    }
+                },
+                "required": [
+                    "Name",
+                    "Female",
+                    "Male"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "IncomeModels": {
+            "type": "object",
+            "propertyNames": {
+                "enum": [
+                    "Low",
+                    "Middle",
+                    "High",
+                    "Unknown"
+                ]
+            },
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "Intercept": {
+                        "type": "number"
+                    },
+                    "Coefficients": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "number"
+                        }
+                    }
+                },
+                "required": [
+                    "Intercept",
+                    "Coefficients"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "RiskFactorModels": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "Lambda": {
+                        "type": "number"
+                    },
+                    "StdDev": {
+                        "type": "number"
+                    },
+                    "Intercept": {
+                        "type": "number"
+                    },
+                    "Range": {
+                        "type": "array",
+                        "items": {
+                            "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                    },
+                    "Coefficients": {
+                        "additionalProperties": {
+                            "type": "number"
+                        }
+                    },
+                    "Policy": {
+                        "type": "object",
+                        "properties": {
+                            "Intercept": {
+                                "type": "number"
+                            },
+                            "Range": {
+                                "type": "array",
+                                "items": {
+                                    "type": "number"
+                                },
+                                "minItems": 2,
+                                "maxItems": 2
+                            },
+                            "Coefficients": {
+                                "additionalProperties": {
+                                    "type": "number"
+                                }
+                            },
+                            "LogCoefficients": {
+                                "additionalProperties": {
+                                    "type": "number"
+                                }
+                            }
+                        },
+                        "required": [
+                            "Intercept",
+                            "Range",
+                            "Coefficients",
+                            "LogCoefficients"
+                        ],
+                        "additionalProperties": false
+                    }
+                },
+                "required": [
+                    "Lambda",
+                    "StdDev",
+                    "Intercept",
+                    "Range",
+                    "Coefficients",
+                    "Policy"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "RiskFactorCorrelationFile": {
+            "$ref": "../csv_file.json"
+        },
+        "PolicyCovarianceFile": {
+            "$ref": "../csv_file.json"
+        }
+    },
+    "required": [
+        "ModelName",
+        "InformationSpeed",
+        "PhysicalActivityStdDev",
+        "RuralPrevalence",
+        "IncomeModels",
+        "RiskFactorModels",
+        "RiskFactorCorrelationFile",
+        "PolicyCovarianceFile"
+    ],
+    "additionalProperties": false
+}

--- a/schemas/v1/config/running.json
+++ b/schemas/v1/config/running.json
@@ -5,7 +5,7 @@
     "properties": {
         "seed": {
             "type": "array",
-            "minItems": 1,
+            "minItems": 0,
             "maxItems": 1,
             "items": {
                 "type": "integer"


### PR DESCRIPTION
This PR adds JSON schemas for both static and dynamic model configuration files. I've used the files in `healthgps-examples` as a reference, which means that the schemas are currently slightly out of step with the model parsing code in HealthGPS (see #521). I don't intend to enforce these schemas for now though -- I just want them as a reference for when we make a release for `healthgps-examples`. Once we've done that, I'll start on some v2 schemas that we can actually enforce (though I'll probably still need some example config files to work from).

All the config files in `healthgps-examples` validate successfully with these schemas :partying_face:.

There is one small unrelated fix: I noticed that the schema for the `index.json` file doesn't allow the user to omit the random seed (which they can do by providing an empty array: #487) so I've changed that.

Closes #450. Closes #451.