### PR TITLE
Child weight in KevinHall::get_expected.

### DIFF
--- a/src/HealthGPS/kevin_hall_model.h
+++ b/src/HealthGPS/kevin_hall_model.h
@@ -216,7 +216,7 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     const std::unordered_map<core::Gender, double> &height_slope_;
 
     // Model parameters.
-    static constexpr int kevin_hall_age_min = 19; // Minimum age for the model.
+    static constexpr int kevin_hall_age_min = 19; // Start age for the main Kevin Hall model.
     static constexpr double rho_F = 39.5e3;       // Energy content of fat (kJ/kg).
     static constexpr double rho_L = 7.6e3;        // Energy content of lean (kJ/kg).
     static constexpr double rho_G = 17.6e3;       // Energy content of glycogen (kJ/kg).


### PR DESCRIPTION
This change modifies `KevinHallModel::get_expected` to handle children differently. This is because we are using separate KevinHall models for both children and adults, and the expected value calculation needs to account for this.

Resolves #522 
