### PR TITLE
Trend max steps

### DIFF
--- a/src/HealthGPS.Input/model_parser.cpp
+++ b/src/HealthGPS.Input/model_parser.cpp
@@ -188,6 +188,7 @@ load_staticlinear_risk_model_definition(const nlohmann::json &opt, const Configu
     auto trend_models = std::make_unique<std::vector<LinearModelParams>>();
     auto trend_ranges = std::make_unique<std::vector<core::DoubleInterval>>();
     auto trend_lambda = std::make_unique<std::vector<double>>();
+    auto trend_steps = std::make_unique<std::vector<int>>();
     auto expected_trend = std::make_unique<std::unordered_map<core::Identifier, double>>();
     auto expected_trend_boxcox = std::make_unique<std::unordered_map<core::Identifier, double>>();
 
@@ -257,6 +258,7 @@ load_staticlinear_risk_model_definition(const nlohmann::json &opt, const Configu
         trend_models->emplace_back(std::move(trend_model));
         trend_ranges->emplace_back(trend_json_params["Range"].get<core::DoubleInterval>());
         trend_lambda->emplace_back(trend_json_params["Lambda"].get<double>());
+        trend_steps->emplace_back(trend_json_params["Steps"].get<int>());
 
         // Load expected value trends.
         (*expected_trend)[key] = json_params["ExpectedTrend"].get<double>();
@@ -464,6 +466,9 @@ load_kevinhall_risk_model_definition(const nlohmann::json &opt, const Configurat
     auto expected = load_risk_factor_expected(config);
     auto expected_trend = std::make_unique<std::unordered_map<core::Identifier, double>>();
 
+    // Number of steps to apply nutrient time trends.
+    auto trend_steps = std::make_unique<std::unordered_map<core::Identifier, int>>();
+
     // Nutrient groups.
     std::unordered_map<hgps::core::Identifier, double> energy_equation;
     std::unordered_map<hgps::core::Identifier, hgps::core::DoubleInterval> nutrient_ranges;
@@ -480,6 +485,7 @@ load_kevinhall_risk_model_definition(const nlohmann::json &opt, const Configurat
     for (const auto &food : opt["Foods"]) {
         auto food_key = food["Name"].get<hgps::core::Identifier>();
         (*expected_trend)[food_key] = food["ExpectedTrend"].get<double>();
+        (*trend_steps)[food_key] = food["TrendSteps"].get<int>();
         food_prices[food_key] = food["Price"].get<std::optional<double>>();
         auto food_nutrients = food["Nutrients"].get<std::map<hgps::core::Identifier, double>>();
 

--- a/src/HealthGPS.Input/model_parser.cpp
+++ b/src/HealthGPS.Input/model_parser.cpp
@@ -349,12 +349,12 @@ load_staticlinear_risk_model_definition(const nlohmann::json &opt, const Configu
     const double physical_activity_stddev = opt["PhysicalActivityStdDev"].get<double>();
 
     return std::make_unique<StaticLinearModelDefinition>(
-        std::move(expected), std::move(expected_trend), std::move(expected_trend_boxcox),
-        std::move(names), std::move(models), std::move(ranges), std::move(lambda),
-        std::move(stddev), std::move(cholesky), std::move(policy_models), std::move(policy_ranges),
-        std::move(policy_cholesky), std::move(trend_models), std::move(trend_ranges),
-        std::move(trend_lambda), info_speed, std::move(rural_prevalence), std::move(income_models),
-        physical_activity_stddev);
+        std::move(expected), std::move(expected_trend), std::move(trend_steps),
+        std::move(expected_trend_boxcox), std::move(names), std::move(models), std::move(ranges),
+        std::move(lambda), std::move(stddev), std::move(cholesky), std::move(policy_models),
+        std::move(policy_ranges), std::move(policy_cholesky), std::move(trend_models),
+        std::move(trend_ranges), std::move(trend_lambda), info_speed, std::move(rural_prevalence),
+        std::move(income_models), physical_activity_stddev);
 }
 
 std::unique_ptr<hgps::RiskFactorModelDefinition>
@@ -451,10 +451,11 @@ load_ebhlm_risk_model_definition(const nlohmann::json &opt, const Configuration 
     // Risk factor expected values by sex and age.
     auto expected = load_risk_factor_expected(config);
     auto expected_trend = std::make_unique<std::unordered_map<core::Identifier, double>>();
+    auto trend_steps = std::make_unique<std::unordered_map<core::Identifier, int>>();
 
     return std::make_unique<hgps::DynamicHierarchicalLinearModelDefinition>(
-        std::move(expected), std::move(expected_trend), std::move(equations), std::move(variables),
-        percentage);
+        std::move(expected), std::move(expected_trend), std::move(trend_steps),
+        std::move(equations), std::move(variables), percentage);
 }
 // NOLINTEND(readability-function-cognitive-complexity)
 
@@ -539,10 +540,10 @@ load_kevinhall_risk_model_definition(const nlohmann::json &opt, const Configurat
         {hgps::core::Gender::male, opt["HeightSlope"]["Male"].get<double>()}};
 
     return std::make_unique<hgps::KevinHallModelDefinition>(
-        std::move(expected), std::move(expected_trend), std::move(energy_equation),
-        std::move(nutrient_ranges), std::move(nutrient_equations), std::move(food_prices),
-        std::move(weight_quantiles), std::move(epa_quantiles), std::move(height_stddev),
-        std::move(height_slope));
+        std::move(expected), std::move(expected_trend), std::move(trend_steps),
+        std::move(energy_equation), std::move(nutrient_ranges), std::move(nutrient_equations),
+        std::move(food_prices), std::move(weight_quantiles), std::move(epa_quantiles),
+        std::move(height_stddev), std::move(height_slope));
 }
 
 std::pair<hgps::RiskFactorModelType, std::unique_ptr<hgps::RiskFactorModelDefinition>>

--- a/src/HealthGPS.Input/model_parser.cpp
+++ b/src/HealthGPS.Input/model_parser.cpp
@@ -262,7 +262,7 @@ load_staticlinear_risk_model_definition(const nlohmann::json &opt, const Configu
         // Load expected value trends.
         (*expected_trend)[key] = json_params["ExpectedTrend"].get<double>();
         (*expected_trend_boxcox)[key] = json_params["ExpectedTrendBoxCox"].get<double>();
-        (*trend_steps)[key] = trend_json_params["Steps"].get<int>();
+        (*trend_steps)[key] = json_params["TrendSteps"].get<int>();
 
         // Increment table column index.
         i++;

--- a/src/HealthGPS.Input/model_parser.cpp
+++ b/src/HealthGPS.Input/model_parser.cpp
@@ -188,9 +188,9 @@ load_staticlinear_risk_model_definition(const nlohmann::json &opt, const Configu
     auto trend_models = std::make_unique<std::vector<LinearModelParams>>();
     auto trend_ranges = std::make_unique<std::vector<core::DoubleInterval>>();
     auto trend_lambda = std::make_unique<std::vector<double>>();
-    auto trend_steps = std::make_unique<std::vector<int>>();
     auto expected_trend = std::make_unique<std::unordered_map<core::Identifier, double>>();
     auto expected_trend_boxcox = std::make_unique<std::unordered_map<core::Identifier, double>>();
+    auto trend_steps = std::make_unique<std::unordered_map<core::Identifier, int>>();
 
     size_t i = 0;
     for (const auto &[key, json_params] : opt["RiskFactorModels"].items()) {
@@ -258,11 +258,11 @@ load_staticlinear_risk_model_definition(const nlohmann::json &opt, const Configu
         trend_models->emplace_back(std::move(trend_model));
         trend_ranges->emplace_back(trend_json_params["Range"].get<core::DoubleInterval>());
         trend_lambda->emplace_back(trend_json_params["Lambda"].get<double>());
-        trend_steps->emplace_back(trend_json_params["Steps"].get<int>());
 
         // Load expected value trends.
         (*expected_trend)[key] = json_params["ExpectedTrend"].get<double>();
         (*expected_trend_boxcox)[key] = json_params["ExpectedTrendBoxCox"].get<double>();
+        (*trend_steps)[key] = trend_json_params["Steps"].get<int>();
 
         // Increment table column index.
         i++;

--- a/src/HealthGPS/dynamic_hierarchical_linear_model.cpp
+++ b/src/HealthGPS/dynamic_hierarchical_linear_model.cpp
@@ -141,9 +141,11 @@ double DynamicHierarchicalLinearModel::sample_normal_with_boundary(Random &rando
 DynamicHierarchicalLinearModelDefinition::DynamicHierarchicalLinearModelDefinition(
     std::unique_ptr<RiskFactorSexAgeTable> expected,
     std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
+    std::unique_ptr<std::unordered_map<core::Identifier, int>> trend_steps,
     std::map<core::IntegerInterval, AgeGroupGenderEquation> equations,
     std::map<core::Identifier, core::Identifier> variables, const double boundary_percentage)
-    : RiskFactorAdjustableModelDefinition{std::move(expected), std::move(expected_trend)},
+    : RiskFactorAdjustableModelDefinition{std::move(expected), std::move(expected_trend),
+                                          std::move(trend_steps)},
       equations_{std::move(equations)}, variables_{std::move(variables)},
       boundary_percentage_{boundary_percentage} {
 

--- a/src/HealthGPS/dynamic_hierarchical_linear_model.cpp
+++ b/src/HealthGPS/dynamic_hierarchical_linear_model.cpp
@@ -11,9 +11,11 @@ namespace hgps {
 DynamicHierarchicalLinearModel::DynamicHierarchicalLinearModel(
     std::shared_ptr<RiskFactorSexAgeTable> expected,
     std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
+    std::shared_ptr<std::unordered_map<core::Identifier, int>> trend_steps,
     const std::map<core::IntegerInterval, AgeGroupGenderEquation> &equations,
     const std::map<core::Identifier, core::Identifier> &variables, double boundary_percentage)
-    : RiskFactorAdjustableModel{std::move(expected), std::move(expected_trend)},
+    : RiskFactorAdjustableModel{std::move(expected), std::move(expected_trend),
+                                std::move(trend_steps)},
       equations_{equations}, variables_{variables}, boundary_percentage_{boundary_percentage} {}
 
 RiskFactorModelType DynamicHierarchicalLinearModel::type() const noexcept {
@@ -158,8 +160,8 @@ DynamicHierarchicalLinearModelDefinition::DynamicHierarchicalLinearModelDefiniti
 }
 
 std::unique_ptr<RiskFactorModel> DynamicHierarchicalLinearModelDefinition::create_model() const {
-    return std::make_unique<DynamicHierarchicalLinearModel>(expected_, expected_trend_, equations_,
-                                                            variables_, boundary_percentage_);
+    return std::make_unique<DynamicHierarchicalLinearModel>(
+        expected_, expected_trend_, trend_steps_, equations_, variables_, boundary_percentage_);
 }
 
 } // namespace hgps

--- a/src/HealthGPS/dynamic_hierarchical_linear_model.h
+++ b/src/HealthGPS/dynamic_hierarchical_linear_model.h
@@ -40,12 +40,14 @@ class DynamicHierarchicalLinearModel final : public RiskFactorAdjustableModel {
     /// @brief Initialises a new instance of the DynamicHierarchicalLinearModel class
     /// @param expected The expected values
     /// @param expected_trend The expected trend of risk factor values
+    /// @param trend_steps The number of time steps to apply the trend
     /// @param equations The linear regression equations
     /// @param variables The factors delta variables mapping
     /// @param boundary_percentage The boundary percentage to sample
     DynamicHierarchicalLinearModel(
         std::shared_ptr<RiskFactorSexAgeTable> expected,
         std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
+        std::shared_ptr<std::unordered_map<core::Identifier, int>> trend_steps,
         const std::map<core::IntegerInterval, AgeGroupGenderEquation> &equations,
         const std::map<core::Identifier, core::Identifier> &variables,
         const double boundary_percentage);

--- a/src/HealthGPS/dynamic_hierarchical_linear_model.h
+++ b/src/HealthGPS/dynamic_hierarchical_linear_model.h
@@ -83,6 +83,7 @@ class DynamicHierarchicalLinearModelDefinition : public RiskFactorAdjustableMode
     /// @brief Initialises a new instance of the DynamicHierarchicalLinearModelDefinition class
     /// @param expected The expected values
     /// @param expected_trend The expected trend of risk factor values
+    /// @param trend_steps The number of time steps to apply the trend
     /// @param equations The linear regression equations
     /// @param variables The factors delta variables mapping
     /// @param boundary_percentage The boundary percentage to sample
@@ -90,6 +91,7 @@ class DynamicHierarchicalLinearModelDefinition : public RiskFactorAdjustableMode
     DynamicHierarchicalLinearModelDefinition(
         std::unique_ptr<RiskFactorSexAgeTable> expected,
         std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
+        std::unique_ptr<std::unordered_map<core::Identifier, int>> trend_steps,
         std::map<core::IntegerInterval, AgeGroupGenderEquation> equations,
         std::map<core::Identifier, core::Identifier> variables,
         const double boundary_percentage = 0.05);

--- a/src/HealthGPS/kevin_hall_model.cpp
+++ b/src/HealthGPS/kevin_hall_model.cpp
@@ -755,6 +755,7 @@ void KevinHallModel::update_height(RuntimeContext &context, Person &person,
 KevinHallModelDefinition::KevinHallModelDefinition(
     std::unique_ptr<RiskFactorSexAgeTable> expected,
     std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
+    std::unique_ptr<std::unordered_map<core::Identifier, int>> trend_steps,
     std::unordered_map<core::Identifier, double> energy_equation,
     std::unordered_map<core::Identifier, core::DoubleInterval> nutrient_ranges,
     std::unordered_map<core::Identifier, std::map<core::Identifier, double>> nutrient_equations,
@@ -762,7 +763,8 @@ KevinHallModelDefinition::KevinHallModelDefinition(
     std::unordered_map<core::Gender, std::vector<double>> weight_quantiles,
     std::vector<double> epa_quantiles, std::unordered_map<core::Gender, double> height_stddev,
     std::unordered_map<core::Gender, double> height_slope)
-    : RiskFactorAdjustableModelDefinition{std::move(expected), std::move(expected_trend)},
+    : RiskFactorAdjustableModelDefinition{std::move(expected), std::move(expected_trend),
+                                          std::move(trend_steps)},
       energy_equation_{std::move(energy_equation)}, nutrient_ranges_{std::move(nutrient_ranges)},
       nutrient_equations_{std::move(nutrient_equations)}, food_prices_{std::move(food_prices)},
       weight_quantiles_{std::move(weight_quantiles)}, epa_quantiles_{std::move(epa_quantiles)},

--- a/src/HealthGPS/kevin_hall_model.cpp
+++ b/src/HealthGPS/kevin_hall_model.cpp
@@ -25,6 +25,7 @@ namespace hgps {
 KevinHallModel::KevinHallModel(
     std::shared_ptr<RiskFactorSexAgeTable> expected,
     std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
+    std::shared_ptr<std::unordered_map<core::Identifier, int>> trend_steps,
     const std::unordered_map<core::Identifier, double> &energy_equation,
     const std::unordered_map<core::Identifier, core::DoubleInterval> &nutrient_ranges,
     const std::unordered_map<core::Identifier, std::map<core::Identifier, double>>
@@ -34,7 +35,8 @@ KevinHallModel::KevinHallModel(
     const std::vector<double> &epa_quantiles,
     const std::unordered_map<core::Gender, double> &height_stddev,
     const std::unordered_map<core::Gender, double> &height_slope)
-    : RiskFactorAdjustableModel{std::move(expected), std::move(expected_trend)},
+    : RiskFactorAdjustableModel{std::move(expected), std::move(expected_trend),
+                                std::move(trend_steps)},
       energy_equation_{energy_equation}, nutrient_ranges_{nutrient_ranges},
       nutrient_equations_{nutrient_equations}, food_prices_{food_prices},
       weight_quantiles_{weight_quantiles}, epa_quantiles_{epa_quantiles},
@@ -797,9 +799,10 @@ KevinHallModelDefinition::KevinHallModelDefinition(
 }
 
 std::unique_ptr<RiskFactorModel> KevinHallModelDefinition::create_model() const {
-    return std::make_unique<KevinHallModel>(
-        expected_, expected_trend_, energy_equation_, nutrient_ranges_, nutrient_equations_,
-        food_prices_, weight_quantiles_, epa_quantiles_, height_stddev_, height_slope_);
+    return std::make_unique<KevinHallModel>(expected_, expected_trend_, trend_steps_,
+                                            energy_equation_, nutrient_ranges_, nutrient_equations_,
+                                            food_prices_, weight_quantiles_, epa_quantiles_,
+                                            height_stddev_, height_slope_);
 }
 
 } // namespace hgps

--- a/src/HealthGPS/kevin_hall_model.h
+++ b/src/HealthGPS/kevin_hall_model.h
@@ -236,6 +236,7 @@ class KevinHallModelDefinition final : public RiskFactorAdjustableModelDefinitio
     /// @brief Initialises a new instance of the KevinHallModelDefinition class
     /// @param expected The risk factor expected values by sex and age
     /// @param expected_trend The expected trend of risk factor values
+    /// @param trend_steps The number of time steps to apply the trend
     /// @param energy_equation The energy coefficients for each nutrient
     /// @param nutrient_ranges The interval boundaries for nutrient values
     /// @param nutrient_equations The nutrient coefficients for each food group
@@ -248,6 +249,7 @@ class KevinHallModelDefinition final : public RiskFactorAdjustableModelDefinitio
     KevinHallModelDefinition(
         std::unique_ptr<RiskFactorSexAgeTable> expected,
         std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
+        std::unique_ptr<std::unordered_map<core::Identifier, int>> trend_steps,
         std::unordered_map<core::Identifier, double> energy_equation,
         std::unordered_map<core::Identifier, core::DoubleInterval> nutrient_ranges,
         std::unordered_map<core::Identifier, std::map<core::Identifier, double>> nutrient_equations,

--- a/src/HealthGPS/kevin_hall_model.h
+++ b/src/HealthGPS/kevin_hall_model.h
@@ -23,6 +23,7 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     /// @brief Initialises a new instance of the KevinHallModel class
     /// @param expected The risk factor expected values by sex and age
     /// @param expected_trend The expected trend of risk factor values
+    /// @param trend_steps The number of time steps to apply the trend
     /// @param energy_equation The energy coefficients for each nutrient
     /// @param nutrient_ranges The interval boundaries for nutrient values
     /// @param nutrient_equations The nutrient coefficients for each food group
@@ -34,6 +35,7 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     KevinHallModel(
         std::shared_ptr<RiskFactorSexAgeTable> expected,
         std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
+        std::shared_ptr<std::unordered_map<core::Identifier, int>> trend_steps,
         const std::unordered_map<core::Identifier, double> &energy_equation,
         const std::unordered_map<core::Identifier, core::DoubleInterval> &nutrient_ranges,
         const std::unordered_map<core::Identifier, std::map<core::Identifier, double>>

--- a/src/HealthGPS/risk_factor_adjustable_model.cpp
+++ b/src/HealthGPS/risk_factor_adjustable_model.cpp
@@ -114,6 +114,10 @@ void RiskFactorAdjustableModel::adjust_risk_factors(RuntimeContext &context,
     }
 }
 
+int RiskFactorAdjustableModel::get_trend_steps(const core::Identifier &factor) const noexcept {
+    return trend_steps_->at(factor);
+}
+
 RiskFactorSexAgeTable
 RiskFactorAdjustableModel::calculate_adjustments(RuntimeContext &context,
                                                  const std::vector<core::Identifier> &factors,

--- a/src/HealthGPS/risk_factor_adjustable_model.cpp
+++ b/src/HealthGPS/risk_factor_adjustable_model.cpp
@@ -33,8 +33,10 @@ namespace hgps {
 
 RiskFactorAdjustableModel::RiskFactorAdjustableModel(
     std::shared_ptr<RiskFactorSexAgeTable> expected,
-    std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend)
-    : expected_{std::move(expected)}, expected_trend_{std::move(expected_trend)} {}
+    std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
+    std::shared_ptr<std::unordered_map<core::Identifier, int>> trend_steps)
+    : expected_{std::move(expected)}, expected_trend_{std::move(expected_trend)},
+      trend_steps_{trend_steps} {}
 
 double RiskFactorAdjustableModel::get_expected(RuntimeContext &context, core::Gender sex, int age,
                                                const core::Identifier &factor, OptionalRange range,

--- a/src/HealthGPS/risk_factor_adjustable_model.cpp
+++ b/src/HealthGPS/risk_factor_adjustable_model.cpp
@@ -193,14 +193,19 @@ RiskFactorAdjustableModel::calculate_simulated_mean(Population &population,
 
 RiskFactorAdjustableModelDefinition::RiskFactorAdjustableModelDefinition(
     std::unique_ptr<RiskFactorSexAgeTable> expected,
-    std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend)
-    : expected_{std::move(expected)}, expected_trend_{std::move(expected_trend)} {
+    std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
+    std::unique_ptr<std::unordered_map<core::Identifier, int>> trend_steps)
+    : expected_{std::move(expected)}, expected_trend_{std::move(expected_trend)},
+      trend_steps_{std::move(trend_steps)} {
 
     if (expected_->empty()) {
         throw core::HgpsException("Risk factor expected value mapping is empty");
     }
     if (expected_trend_->empty()) {
         throw core::HgpsException("Risk factor expected trend mapping is empty");
+    }
+    if (trend_steps_->empty()) {
+        throw core::HgpsException("Risk factor trend steps mapping is empty");
     }
 }
 

--- a/src/HealthGPS/risk_factor_adjustable_model.cpp
+++ b/src/HealthGPS/risk_factor_adjustable_model.cpp
@@ -46,7 +46,8 @@ double RiskFactorAdjustableModel::get_expected(RuntimeContext &context, core::Ge
     // Apply optional trend to expected value.
     if (apply_trend) {
         int elapsed_time = context.time_now() - context.start_time();
-        expected *= pow(expected_trend_->at(factor), elapsed_time);
+        int t = std::min(elapsed_time, get_trend_steps(factor));
+        expected *= pow(expected_trend_->at(factor), t);
     }
 
     // Clamp expected value to an optionally specified range.

--- a/src/HealthGPS/risk_factor_adjustable_model.cpp
+++ b/src/HealthGPS/risk_factor_adjustable_model.cpp
@@ -36,7 +36,7 @@ RiskFactorAdjustableModel::RiskFactorAdjustableModel(
     std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
     std::shared_ptr<std::unordered_map<core::Identifier, int>> trend_steps)
     : expected_{std::move(expected)}, expected_trend_{std::move(expected_trend)},
-      trend_steps_{trend_steps} {}
+      trend_steps_{std::move(trend_steps)} {}
 
 double RiskFactorAdjustableModel::get_expected(RuntimeContext &context, core::Gender sex, int age,
                                                const core::Identifier &factor, OptionalRange range,

--- a/src/HealthGPS/risk_factor_adjustable_model.cpp
+++ b/src/HealthGPS/risk_factor_adjustable_model.cpp
@@ -115,7 +115,7 @@ void RiskFactorAdjustableModel::adjust_risk_factors(RuntimeContext &context,
     }
 }
 
-int RiskFactorAdjustableModel::get_trend_steps(const core::Identifier &factor) const noexcept {
+int RiskFactorAdjustableModel::get_trend_steps(const core::Identifier &factor) const {
     return trend_steps_->at(factor);
 }
 

--- a/src/HealthGPS/risk_factor_adjustable_model.h
+++ b/src/HealthGPS/risk_factor_adjustable_model.h
@@ -60,7 +60,7 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
     /// @brief Gets the number of time steps to apply the trend
     /// @param factor The risk factor to get the trend steps
     /// @returns The number of time steps to apply the trend
-    int get_trend_steps(const core::Identifier &factor) const noexcept;
+    int get_trend_steps(const core::Identifier &factor) const;
 
   private:
     /// @brief Adjust risk factors such that mean sim value matches expected value

--- a/src/HealthGPS/risk_factor_adjustable_model.h
+++ b/src/HealthGPS/risk_factor_adjustable_model.h
@@ -79,14 +79,17 @@ class RiskFactorAdjustableModelDefinition : public RiskFactorModelDefinition {
     /// @brief Constructs a new RiskFactorAdjustableModelDefinition instance
     /// @param expected The expected risk factor values by sex and age
     /// @param expected_trend The expected trend of risk factor values
+    /// @param trend_steps The number of time steps to apply the trend
     /// @throws HgpsException for invalid arguments
     RiskFactorAdjustableModelDefinition(
         std::unique_ptr<RiskFactorSexAgeTable> expected,
-        std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend);
+        std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
+        std::unique_ptr<std::unordered_map<core::Identifier, int>> trend_steps);
 
   protected:
     std::shared_ptr<RiskFactorSexAgeTable> expected_;
     std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend_;
+    std::shared_ptr<std::unordered_map<core::Identifier, int>> trend_steps_;
 };
 
 } // namespace hgps

--- a/src/HealthGPS/risk_factor_adjustable_model.h
+++ b/src/HealthGPS/risk_factor_adjustable_model.h
@@ -57,6 +57,11 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
     void adjust_risk_factors(RuntimeContext &context, const std::vector<core::Identifier> &factors,
                              OptionalRanges ranges, bool apply_trend) const;
 
+    /// @brief Gets the number of time steps to apply the trend
+    /// @param factor The risk factor to get the trend steps
+    /// @returns The number of time steps to apply the trend
+    int get_trend_steps(const core::Identifier &factor) const noexcept;
+
   private:
     /// @brief Adjust risk factors such that mean sim value matches expected value
     /// @param context The simulation run-time context

--- a/src/HealthGPS/risk_factor_adjustable_model.h
+++ b/src/HealthGPS/risk_factor_adjustable_model.h
@@ -31,9 +31,11 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
     /// @brief Constructs a new RiskFactorAdjustableModel instance
     /// @param expected The risk factor expected values by sex and age
     /// @param expected_trend The expected trend of risk factor values
+    /// @param trend_steps The number of time steps to apply the trend
     RiskFactorAdjustableModel(
         std::shared_ptr<RiskFactorSexAgeTable> expected,
-        std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend);
+        std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
+        std::shared_ptr<std::unordered_map<core::Identifier, int>> trend_steps);
 
     /// @brief Gets a person's expected risk factor value
     /// @param context The simulation run-time context
@@ -71,6 +73,7 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
 
     std::shared_ptr<RiskFactorSexAgeTable> expected_;
     std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend_;
+    std::shared_ptr<std::unordered_map<core::Identifier, int>> trend_steps_;
 };
 
 /// @brief Risk factor adjustable model definition interface

--- a/src/HealthGPS/static_linear_model.cpp
+++ b/src/HealthGPS/static_linear_model.cpp
@@ -432,6 +432,7 @@ void StaticLinearModel::initialise_physical_activity(RuntimeContext &context, Pe
 StaticLinearModelDefinition::StaticLinearModelDefinition(
     std::unique_ptr<RiskFactorSexAgeTable> expected,
     std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
+    std::unique_ptr<std::unordered_map<core::Identifier, int>> trend_steps,
     std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend_boxcox,
     std::vector<core::Identifier> names, std::vector<LinearModelParams> models,
     std::vector<core::DoubleInterval> ranges, std::vector<double> lambda,
@@ -443,7 +444,8 @@ StaticLinearModelDefinition::StaticLinearModelDefinition(
     std::unordered_map<core::Identifier, std::unordered_map<core::Gender, double>> rural_prevalence,
     std::unordered_map<core::Income, LinearModelParams> income_models,
     double physical_activity_stddev)
-    : RiskFactorAdjustableModelDefinition{std::move(expected), std::move(expected_trend)},
+    : RiskFactorAdjustableModelDefinition{std::move(expected), std::move(expected_trend),
+                                          std::move(trend_steps)},
       expected_trend_boxcox_{std::move(expected_trend_boxcox)}, names_{std::move(names)},
       models_{std::move(models)}, ranges_{std::move(ranges)}, lambda_{std::move(lambda)},
       stddev_{std::move(stddev)}, cholesky_{std::move(cholesky)},

--- a/src/HealthGPS/static_linear_model.cpp
+++ b/src/HealthGPS/static_linear_model.cpp
@@ -10,6 +10,7 @@ namespace hgps {
 StaticLinearModel::StaticLinearModel(
     std::shared_ptr<RiskFactorSexAgeTable> expected,
     std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
+    std::shared_ptr<std::unordered_map<core::Identifier, int>> trend_steps,
     std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend_boxcox,
     const std::vector<core::Identifier> &names, const std::vector<LinearModelParams> &models,
     const std::vector<core::DoubleInterval> &ranges, const std::vector<double> &lambda,
@@ -23,7 +24,8 @@ StaticLinearModel::StaticLinearModel(
         &rural_prevalence,
     const std::unordered_map<core::Income, LinearModelParams> &income_models,
     double physical_activity_stddev)
-    : RiskFactorAdjustableModel{std::move(expected), std::move(expected_trend)},
+    : RiskFactorAdjustableModel{std::move(expected), std::move(expected_trend),
+                                std::move(trend_steps)},
       expected_trend_boxcox_{std::move(expected_trend_boxcox)}, names_{names}, models_{models},
       ranges_{ranges}, lambda_{lambda}, stddev_{stddev}, cholesky_{cholesky},
       policy_models_{policy_models}, policy_ranges_{policy_ranges},
@@ -510,9 +512,9 @@ StaticLinearModelDefinition::StaticLinearModelDefinition(
 
 std::unique_ptr<RiskFactorModel> StaticLinearModelDefinition::create_model() const {
     return std::make_unique<StaticLinearModel>(
-        expected_, expected_trend_, expected_trend_boxcox_, names_, models_, ranges_, lambda_,
-        stddev_, cholesky_, policy_models_, policy_ranges_, policy_cholesky_, trend_models_,
-        trend_ranges_, trend_lambda_, info_speed_, rural_prevalence_, income_models_,
+        expected_, expected_trend_, trend_steps_, expected_trend_boxcox_, names_, models_, ranges_,
+        lambda_, stddev_, cholesky_, policy_models_, policy_ranges_, policy_cholesky_,
+        trend_models_, trend_ranges_, trend_lambda_, info_speed_, rural_prevalence_, income_models_,
         physical_activity_stddev_);
 }
 

--- a/src/HealthGPS/static_linear_model.cpp
+++ b/src/HealthGPS/static_linear_model.cpp
@@ -220,7 +220,8 @@ void StaticLinearModel::update_trends(RuntimeContext &context, Person &person) c
 
         // Apply trend to risk factor.
         double factor = person.risk_factors.at(names_[i]);
-        factor *= pow(trend, elapsed_time);
+        int t = std::min(elapsed_time, get_trend_steps(names_[i]));
+        factor *= pow(trend, t);
         factor = ranges_[i].clamp(factor);
 
         // Save risk factor.

--- a/src/HealthGPS/static_linear_model.h
+++ b/src/HealthGPS/static_linear_model.h
@@ -142,6 +142,7 @@ class StaticLinearModelDefinition : public RiskFactorAdjustableModelDefinition {
     /// @brief Initialises a new instance of the StaticLinearModelDefinition class
     /// @param expected The expected risk factor values by sex and age
     /// @param expected_trend The expected trend of risk factor values
+    /// @param trend_steps The number of time steps to apply the trend
     /// @param expected_trend_boxcox The expected boxcox factor
     /// @param names The risk factor names
     /// @param models The linear models used to compute a person's risk factors
@@ -163,6 +164,7 @@ class StaticLinearModelDefinition : public RiskFactorAdjustableModelDefinition {
     StaticLinearModelDefinition(
         std::unique_ptr<RiskFactorSexAgeTable> expected,
         std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
+        std::unique_ptr<std::unordered_map<core::Identifier, int>> trend_steps,
         std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend_boxcox,
         std::vector<core::Identifier> names, std::vector<LinearModelParams> models,
         std::vector<core::DoubleInterval> ranges, std::vector<double> lambda,

--- a/src/HealthGPS/static_linear_model.h
+++ b/src/HealthGPS/static_linear_model.h
@@ -24,6 +24,7 @@ class StaticLinearModel final : public RiskFactorAdjustableModel {
     /// @brief Initialises a new instance of the StaticLinearModel class
     /// @param expected The expected risk factor values by sex and age
     /// @param expected_trend The expected trend of risk factor values
+    /// @param trend_steps The number of time steps to apply the trend
     /// @param expected_trend_boxcox The expected boxcox factor
     /// @param names The risk factor names
     /// @param models The linear models used to compute a person's risk factor values
@@ -45,6 +46,7 @@ class StaticLinearModel final : public RiskFactorAdjustableModel {
     StaticLinearModel(
         std::shared_ptr<RiskFactorSexAgeTable> expected,
         std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
+        std::shared_ptr<std::unordered_map<core::Identifier, int>> trend_steps,
         std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend_boxcox,
         const std::vector<core::Identifier> &names, const std::vector<LinearModelParams> &models,
         const std::vector<core::DoubleInterval> &ranges, const std::vector<double> &lambda,


### PR DESCRIPTION
*REVIEW AFTER #527*

This change adds a new configurable `TrendSteps` value (must be defined for both the static (i.e. `StaticLinear.json`) and the dynamic (i.e. `KevinHall.json`) models).

This is used to ensure that the exponential trends in `RiskFactorAdjustableModel` and `StaticLinearModel`are capped after a defined number of elapsed time steps.

Resolves #517 
