### PR TITLE
Add new schema for static linear model and enforce model schemas

### DIFF
--- a/schemas/v2/config/models/static.json
+++ b/schemas/v2/config/models/static.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v2/config/models/static.json",
+    "anyOf": [
+        {
+            "$ref": "../../../v1/config/models/dummy.json"
+        },
+        {
+            "$ref": "../../../v1/config/models/hlm.json"
+        },
+        {
+            "$ref": "staticlinear.json"
+        }
+    ]
+}

--- a/schemas/v2/config/models/staticlinear.json
+++ b/schemas/v2/config/models/staticlinear.json
@@ -1,0 +1,211 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v2/config/models/staticlinear.json",
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "ModelName": {
+            "const": "StaticLinear"
+        },
+        "InformationSpeed": {
+            "type": "number"
+        },
+        "PhysicalActivityStdDev": {
+            "type": "number"
+        },
+        "RuralPrevalence": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "Name": {
+                        "type": "string"
+                    },
+                    "Female": {
+                        "type": "number"
+                    },
+                    "Male": {
+                        "type": "number"
+                    }
+                },
+                "required": [
+                    "Name",
+                    "Female",
+                    "Male"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "IncomeModels": {
+            "type": "object",
+            "propertyNames": {
+                "enum": [
+                    "Low",
+                    "Middle",
+                    "High",
+                    "Unknown"
+                ]
+            },
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "Intercept": {
+                        "type": "number"
+                    },
+                    "Coefficients": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "number"
+                        }
+                    }
+                },
+                "required": [
+                    "Intercept",
+                    "Coefficients"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "RiskFactorModels": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "Lambda": {
+                        "type": "number"
+                    },
+                    "StdDev": {
+                        "type": "number"
+                    },
+                    "Intercept": {
+                        "type": "number"
+                    },
+                    "Range": {
+                        "type": "array",
+                        "items": {
+                            "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                    },
+                    "Coefficients": {
+                        "additionalProperties": {
+                            "type": "number"
+                        }
+                    },
+                    "Policy": {
+                        "type": "object",
+                        "properties": {
+                            "Intercept": {
+                                "type": "number"
+                            },
+                            "Range": {
+                                "type": "array",
+                                "items": {
+                                    "type": "number"
+                                },
+                                "minItems": 2,
+                                "maxItems": 2
+                            },
+                            "Coefficients": {
+                                "additionalProperties": {
+                                    "type": "number"
+                                }
+                            },
+                            "LogCoefficients": {
+                                "additionalProperties": {
+                                    "type": "number"
+                                }
+                            }
+                        },
+                        "required": [
+                            "Intercept",
+                            "Range",
+                            "Coefficients",
+                            "LogCoefficients"
+                        ],
+                        "additionalProperties": false
+                    },
+                    "Trend": {
+                        "type": "object",
+                        "properties": {
+                            "Intercept": {
+                                "type": "number"
+                            },
+                            "Coefficients": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "number"
+                                },
+                                "minItems": 1
+                            },
+                            "LogCoefficients": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "number"
+                                },
+                                "minItems": 1
+                            },
+                            "Range": {
+                                "type": "array",
+                                "items": {
+                                    "type": "number"
+                                },
+                                "minItems": 2,
+                                "maxItems": 2
+                            },
+                            "Lambda": {
+                                "type": "number"
+                            }
+                        },
+                        "required": [
+                            "Intercept",
+                            "Coefficients",
+                            "LogCoefficients",
+                            "Range",
+                            "Lambda"
+                        ],
+                        "additionalProperties": false
+                    },
+                    "ExpectedTrend": {
+                        "type": "number"
+                    },
+                    "ExpectedTrendBoxCox": {
+                        "type": "number"
+                    }
+                },
+                "required": [
+                    "Lambda",
+                    "StdDev",
+                    "Intercept",
+                    "Range",
+                    "Coefficients",
+                    "Policy",
+                    "Trend",
+                    "ExpectedTrend",
+                    "ExpectedTrendBoxCox"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "RiskFactorCorrelationFile": {
+            "$ref": "../../../v1/config/csv_file.json"
+        },
+        "PolicyCovarianceFile": {
+            "$ref": "../../../v1/config/csv_file.json"
+        }
+    },
+    "required": [
+        "ModelName",
+        "InformationSpeed",
+        "PhysicalActivityStdDev",
+        "RuralPrevalence",
+        "IncomeModels",
+        "RiskFactorModels",
+        "RiskFactorCorrelationFile",
+        "PolicyCovarianceFile"
+    ],
+    "additionalProperties": false
+}

--- a/src/HealthGPS.Input/model_parser.cpp
+++ b/src/HealthGPS.Input/model_parser.cpp
@@ -2,16 +2,18 @@
 #include "configuration_parsing_helpers.h"
 #include "csvparser.h"
 #include "jsonparser.h"
+#include "schema.h"
 
 #include "HealthGPS.Core/exception.h"
 #include "HealthGPS.Core/scoped_timer.h"
 
 #include <Eigen/Cholesky>
 #include <Eigen/Dense>
-#include <algorithm>
-#include <filesystem>
 #include <fmt/color.h>
 #include <fmt/core.h>
+
+#include <algorithm>
+#include <filesystem>
 #include <fstream>
 #include <optional>
 
@@ -21,6 +23,56 @@
 #else
 #define MEASURE_FUNCTION()
 #endif
+
+namespace {
+// The latest schema version for each model
+constexpr int DummyModelSchemaVersion = 1;
+constexpr int EBHLMModelSchemaVersion = 1;
+constexpr int KevinHallModelSchemaVersion = 1;
+constexpr int HLMModelSchemaVersion = 1;
+constexpr int StaticLinearModelSchemaVersion = 2;
+
+//! Get the latest schema version for the given model
+int get_model_schema_version(const std::string &model_name) {
+    if (model_name == "dummy") {
+        return DummyModelSchemaVersion;
+    }
+    if (model_name == "ebhlm") {
+        return EBHLMModelSchemaVersion;
+    }
+    if (model_name == "kevinhall") {
+        return KevinHallModelSchemaVersion;
+    }
+    if (model_name == "hlm") {
+        return HLMModelSchemaVersion;
+    }
+    if (model_name == "staticlinear") {
+        return StaticLinearModelSchemaVersion;
+    }
+
+    throw std::invalid_argument(fmt::format("Unknown model: {}", model_name));
+}
+
+/// @brief Load the model's JSON config file and validate with the appropriate schema
+/// @param model_path The path to the model config file
+/// @return A pair including the name of the model and the JSON contents of the file
+std::pair<std::string, nlohmann::json>
+load_and_validate_model_json(const std::filesystem::path &model_path) {
+    std::ifstream ifs{model_path};
+    if (!ifs) {
+        throw std::runtime_error(fmt::format("Could not read file: {}", model_path.string()));
+    }
+
+    auto opt = nlohmann::json::parse(ifs);
+    auto model_name = hgps::core::to_lower(opt["ModelName"].get<std::string>());
+    const auto model_schema_name = fmt::format("config/models/{}.json", model_name);
+
+    ifs.seekg(0); // Rewind to start
+    hgps::input::validate_json(ifs, model_schema_name, get_model_schema_version(model_name));
+
+    return std::make_pair(std::move(model_name), std::move(opt));
+}
+} // anonymous namespace
 
 namespace hgps::input {
 
@@ -504,10 +556,9 @@ load_kevinhall_risk_model_definition(const nlohmann::json &opt, const Configurat
 }
 
 std::unique_ptr<hgps::RiskFactorModelDefinition>
-load_risk_model_definition(hgps::RiskFactorModelType model_type, const nlohmann::json &opt,
-                           const Configuration &config) {
-    // Get model name from JSON
-    const auto model_name = hgps::core::to_lower(opt["ModelName"].get<std::string>());
+load_risk_model_definition(hgps::RiskFactorModelType model_type,
+                           const std::filesystem::path &model_path, const Configuration &config) {
+    const auto &[model_name, opt] = load_and_validate_model_json(model_path);
 
     // Load appropriate model
     if (model_name == "dummy") {
@@ -542,24 +593,11 @@ load_risk_model_definition(hgps::RiskFactorModelType model_type, const nlohmann:
     }
 }
 
-nlohmann::json load_json(const std::filesystem::path &model_path) {
-    std::ifstream ifs(model_path, std::ifstream::in);
-    if (!ifs.good()) {
-        throw hgps::core::HgpsException{
-            fmt::format("Model file: {} not found", model_path.string())};
-    }
-
-    return nlohmann::json::parse(ifs);
-}
-
 void register_risk_factor_model_definitions(hgps::CachedRepository &repository,
                                             const Configuration &config) {
     MEASURE_FUNCTION();
 
     for (const auto &[model_type_str, model_path] : config.modelling.risk_factor_models) {
-        // Load file and parse JSON
-        const auto opt = load_json(model_path);
-
         RiskFactorModelType model_type;
         if (model_type_str == "static") {
             model_type = RiskFactorModelType::Static;
@@ -571,7 +609,7 @@ void register_risk_factor_model_definitions(hgps::CachedRepository &repository,
         }
 
         // Load appropriate dynamic/static model
-        auto model_definition = load_risk_model_definition(model_type, opt, config);
+        auto model_definition = load_risk_model_definition(model_type, model_path, config);
 
         // Register model in cache
         repository.register_risk_factor_model_definition(model_type, std::move(model_definition));

--- a/src/HealthGPS.Input/model_parser.cpp
+++ b/src/HealthGPS.Input/model_parser.cpp
@@ -61,7 +61,7 @@ load_risk_factor_expected(const Configuration &config) {
 }
 
 std::unique_ptr<hgps::DummyModelDefinition>
-load_dummy_model_definition(hgps::RiskFactorModelType type, const nlohmann::json &opt) {
+load_dummy_risk_model_definition(hgps::RiskFactorModelType type, const nlohmann::json &opt) {
     MEASURE_FUNCTION();
 
     // Get dummy model parameters
@@ -85,7 +85,7 @@ load_static_risk_model_definition(const std::string &model_name, const nlohmann:
                                   const Configuration &config) {
     // Load this static model with the appropriate loader.
     if (model_name == "dummy") {
-        return load_dummy_model_definition(hgps::RiskFactorModelType::Static, opt);
+        return load_dummy_risk_model_definition(hgps::RiskFactorModelType::Static, opt);
     }
     if (model_name == "hlm") {
         return load_hlm_risk_model_definition(opt);
@@ -360,7 +360,7 @@ load_dynamic_risk_model_definition(const std::string &model_name, const nlohmann
                                    const Configuration &config) {
     // Load this dynamic model with the appropriate loader.
     if (model_name == "dummy") {
-        return load_dummy_model_definition(hgps::RiskFactorModelType::Dynamic, opt);
+        return load_dummy_risk_model_definition(hgps::RiskFactorModelType::Dynamic, opt);
     }
     if (model_name == "ebhlm") {
         return load_ebhlm_risk_model_definition(opt, config);

--- a/src/HealthGPS.Input/model_parser.h
+++ b/src/HealthGPS.Input/model_parser.h
@@ -10,6 +10,7 @@
 #include "configuration.h"
 #include "jsonparser.h"
 
+#include <filesystem>
 #include <utility>
 
 namespace hgps::input {
@@ -56,12 +57,12 @@ load_kevinhall_risk_model_definition(const nlohmann::json &opt, const Configurat
 
 /// @brief Loads a risk model definition from a JSON file
 /// @param model_type The type of model to load
-/// @param opt The parsed model definition JSON file
+/// @param model_path The path to the model configuration file
 /// @param config The model configuration
 /// @return The model definition
 std::unique_ptr<hgps::RiskFactorModelDefinition>
-load_risk_model_definition(hgps::RiskFactorModelType model_type, const nlohmann::json &opt,
-                           const Configuration &config);
+load_risk_model_definition(hgps::RiskFactorModelType model_type,
+                           const std::filesystem::path &model_path, const Configuration &config);
 
 /// @brief Load and parse a JSON model file
 /// @param model_path The path to the model file

--- a/src/HealthGPS.Input/model_parser.h
+++ b/src/HealthGPS.Input/model_parser.h
@@ -25,7 +25,7 @@ std::unique_ptr<hgps::RiskFactorSexAgeTable> load_risk_factor_expected(const Con
 /// @return An instance of the hgps::DummyModelDefinition type
 /// @throw std::invalid_argument if error parsing model configuration file
 std::unique_ptr<hgps::DummyModelDefinition>
-load_dummy_model_definition(hgps::RiskFactorModelType type, const nlohmann::json &opt);
+load_dummy_risk_model_definition(hgps::RiskFactorModelType type, const nlohmann::json &opt);
 
 /// @brief Loads a static risk factor model from a JSON file
 /// @param model_name The name of the model to use

--- a/src/HealthGPS.Input/model_parser.h
+++ b/src/HealthGPS.Input/model_parser.h
@@ -27,16 +27,6 @@ std::unique_ptr<hgps::RiskFactorSexAgeTable> load_risk_factor_expected(const Con
 std::unique_ptr<hgps::DummyModelDefinition>
 load_dummy_risk_model_definition(hgps::RiskFactorModelType type, const nlohmann::json &opt);
 
-/// @brief Loads a static risk factor model from a JSON file
-/// @param model_name The name of the model to use
-/// @param opt The parsed model definition JSON file
-/// @param config The model configuration
-/// @return An instance of the hgps::RiskFactorModelDefinition type
-/// @throw std::invalid_argument if static model is unrecognised
-std::unique_ptr<hgps::RiskFactorModelDefinition>
-load_static_risk_model_definition(const std::string &model_name, const nlohmann::json &opt,
-                                  const Configuration &config);
-
 /// @brief Loads the full hierarchical linear regression model definition from a JSON file
 /// @param opt The parsed model definition JSON file
 /// @return An instance of the hgps::StaticHierarchicalLinearModelDefinition type
@@ -50,16 +40,6 @@ load_hlm_risk_model_definition(const nlohmann::json &opt);
 /// @return An instance of the hgps::StaticLinearModelDefinition type
 std::unique_ptr<hgps::StaticLinearModelDefinition>
 load_staticlinear_risk_model_definition(const nlohmann::json &opt, const Configuration &config);
-
-/// @brief Loads a dynamic risk factor model from a JSON file
-/// @param model_name The name of the model to use
-/// @param opt The parsed model definition JSON file
-/// @param config The model configuration
-/// @return An instance of the hgps::RiskFactorModelDefinition type
-/// @throw std::invalid_argument if dynamic model is unrecognised
-std::unique_ptr<hgps::RiskFactorModelDefinition>
-load_dynamic_risk_model_definition(const std::string &model_name, const nlohmann::json &opt,
-                                   const Configuration &config);
 
 /// @brief Loads the old energy balance model definition from a JSON file
 /// @param opt The parsed model definition JSON file
@@ -75,12 +55,12 @@ std::unique_ptr<hgps::KevinHallModelDefinition>
 load_kevinhall_risk_model_definition(const nlohmann::json &opt, const Configuration &config);
 
 /// @brief Loads a risk model definition from a JSON file
-/// @param model_type The type of model ("dynamic"/"static") to load
+/// @param model_type The type of model to load
 /// @param opt The parsed model definition JSON file
 /// @param config The model configuration
-/// @return A std::pair containing the model type and model definition
-std::pair<hgps::RiskFactorModelType, std::unique_ptr<hgps::RiskFactorModelDefinition>>
-load_risk_model_definition(const std::string &model_type, const nlohmann::json &opt,
+/// @return The model definition
+std::unique_ptr<hgps::RiskFactorModelDefinition>
+load_risk_model_definition(hgps::RiskFactorModelType model_type, const nlohmann::json &opt,
                            const Configuration &config);
 
 /// @brief Load and parse a JSON model file

--- a/src/HealthGPS.Input/schema.cpp
+++ b/src/HealthGPS.Input/schema.cpp
@@ -35,7 +35,7 @@ json resolve_uri(const uri &uri, const std::filesystem::path &program_directory)
 } // anonymous namespace
 
 namespace hgps::input {
-void validate_json(std::istream &is, const char *schema_file_name, int schema_version) {
+void validate_json(std::istream &is, const std::string &schema_file_name, int schema_version) {
     const auto data = json::parse(is);
 
     // Load schema
@@ -55,7 +55,7 @@ void validate_json(std::istream &is, const char *schema_file_name, int schema_ve
 }
 
 nlohmann::json load_and_validate_json(const std::filesystem::path &file_path,
-                                      const char *schema_file_name, int schema_version,
+                                      const std::string &schema_file_name, int schema_version,
                                       bool require_schema_property) {
     auto ifs = std::ifstream{file_path};
     if (!ifs) {

--- a/src/HealthGPS.Input/schema.cpp
+++ b/src/HealthGPS.Input/schema.cpp
@@ -32,15 +32,11 @@ json resolve_uri(const uri &uri, const std::filesystem::path &program_directory)
 
     return json::parse(ifs);
 }
+} // anonymous namespace
 
-/// @brief Validate a JSON file against the specified schema
-/// @param json_stream The input stream for the JSON file
-/// @param schema_file_name The name of the JSON schema file
-/// @param schema_version The version of the schema file
-void validate_json(std::istream &json_stream, const char *schema_file_name, int schema_version) {
-    // **YUCK**: We have to read in the data with jsoncons here rather than reusing the
-    // nlohmann-json representation :-(
-    const auto data = json::parse(json_stream);
+namespace hgps::input {
+void validate_json(std::istream &is, const char *schema_file_name, int schema_version) {
+    const auto data = json::parse(is);
 
     // Load schema
     const auto program_dir = hgps::get_program_directory();
@@ -57,9 +53,7 @@ void validate_json(std::istream &json_stream, const char *schema_file_name, int 
     // Perform validation
     schema.validate(data);
 }
-} // anonymous namespace
 
-namespace hgps::input {
 nlohmann::json load_and_validate_json(const std::filesystem::path &file_path,
                                       const char *schema_file_name, int schema_version,
                                       bool require_schema_property) {
@@ -93,7 +87,8 @@ nlohmann::json load_and_validate_json(const std::filesystem::path &file_path,
         }
     }
 
-    // Perform validation
+    // **YUCK**: We have to read in the data with jsoncons here rather than reusing the
+    // nlohmann-json representation :-(
     ifs.seekg(0); // Seek to start of file so we can reload
     validate_json(ifs, schema_file_name, schema_version);
 

--- a/src/HealthGPS.Input/schema.h
+++ b/src/HealthGPS.Input/schema.h
@@ -3,13 +3,14 @@
 #include <nlohmann/json.hpp>
 
 #include <filesystem>
+#include <string>
 
 namespace hgps::input {
 /// @brief Validate a JSON stream against the specified schema
 /// @param is The input stream for the JSON file
 /// @param schema_file_name The name of the JSON schema file
 /// @param schema_version The version of the schema file
-void validate_json(std::istream &is, const char *schema_file_name, int schema_version);
+void validate_json(std::istream &is, const std::string &schema_file_name, int schema_version);
 
 /// @brief Load a JSON file and validate against the specified schema
 /// @param file_path The path to the JSON file
@@ -18,6 +19,6 @@ void validate_json(std::istream &is, const char *schema_file_name, int schema_ve
 /// @param require_schema_property Whether to raise an exception if the $schema property
 ///                                is missing
 nlohmann::json load_and_validate_json(const std::filesystem::path &file_path,
-                                      const char *schema_file_name, int schema_version,
+                                      const std::string &schema_file_name, int schema_version,
                                       bool require_schema_property = true);
 } // namespace hgps::input

--- a/src/HealthGPS.Input/schema.h
+++ b/src/HealthGPS.Input/schema.h
@@ -5,6 +5,12 @@
 #include <filesystem>
 
 namespace hgps::input {
+/// @brief Validate a JSON stream against the specified schema
+/// @param is The input stream for the JSON file
+/// @param schema_file_name The name of the JSON schema file
+/// @param schema_version The version of the schema file
+void validate_json(std::istream &is, const char *schema_file_name, int schema_version);
+
 /// @brief Load a JSON file and validate against the specified schema
 /// @param file_path The path to the JSON file
 /// @param schema_file_name The name of the JSON schema file


### PR DESCRIPTION
This PR adds a new v2 schema for the static linear model, which adds the various trend-related fields. If you could check that the constraints I've chosen seem sensible (e.g. does anything need a max/min value property?) that would be great. Besides that, I don't *think* any of the other schemas need new versions yet (though see #531), but if I've missed any, please let me know!

I've added the code to enforce these schemas at model load time. I did a small amount of refactoring to facilitate this (mostly amalgamating the static and dynamic model loading functions).

Closes #529. Closes #530.