### PR TITLE
Fix bundling of DLLs on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,11 @@ jobs:
       - uses: ammaraskar/gcc-problem-matcher@master
       - name: Build HealthGPS (debug)
         if: '!cancelled()' # Run this step, even if the previous one fails
-        run: |
-          cmake --build --preset=debug-build-${{ matrix.platform }} --target=install
+        run: cmake --build --preset=debug-build-${{ matrix.platform }} --target=install
+
+      - name: Execute HealthGPS (debug)
+        if: '!cancelled()' # Run this step, even if the previous one fails
+        run: out/install/${{ matrix.platform }}-debug/bin/HealthGPS.Console --help
 
       - name: Build HealthGPS (release)
         if: '!cancelled()' # Run this step, even if the previous one fails
@@ -106,6 +109,10 @@ jobs:
           # Build documentation so we can show Doxygen warnings
           cmake --preset=${{ matrix.platform }}-release -DWARNINGS_AS_ERRORS=ON -DBUILD_DOC=ON
           cmake --build --preset=release-build-${{ matrix.platform }} --target=install
+
+      - name: Execute HealthGPS (release)
+        if: '!cancelled()' # Run this step, even if the previous one fails
+        run: out/install/${{ matrix.platform }}-release/bin/HealthGPS.Console --help
 
       - name: Upload artifacts
         if: matrix.is_main

--- a/src/HealthGPS.Console/CMakeLists.txt
+++ b/src/HealthGPS.Console/CMakeLists.txt
@@ -49,9 +49,28 @@ target_link_libraries(
             cxxopts::cxxopts
             TBB::tbb)
 
-install(TARGETS HealthGPS.Console DESTINATION "")
+install(
+    TARGETS HealthGPS.Console
+    RUNTIME
+    ARCHIVE
+    LIBRARY
+    RUNTIME
+    FRAMEWORK
+    BUNDLE
+    PUBLIC_HEADER
+    RESOURCE)
 if(WIN32)
-    install(IMPORTED_RUNTIME_ARTIFACTS fmt::fmt)
+    install(
+        TARGETS HealthGPS.Console
+        COMPONENT HealthGPS.Console
+        RUNTIME_DEPENDENCIES
+        PRE_EXCLUDE_REGEXES
+        "api-ms-"
+        "ext-ms-"
+        POST_EXCLUDE_REGEXES
+        ".*system32/.*\\.dll"
+        DIRECTORIES
+        $<TARGET_FILE_DIR:HealthGPS.Console>)
 endif()
 
 install(DIRECTORY ../../schemas DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")


### PR DESCRIPTION
Solved using advice from here: https://stackoverflow.com/questions/10671916/how-to-copy-dll-files-into-the-same-folder-as-the-executable-using-cmake/69736197#69736197

Both local builds and the CI generated binaries now work.

I've also added steps to the CI to check that `HealthGPS.Console` will run with the `--help` flag, which should catch these sorts of problem in future.

I'm now hitting another error when actually running the program 😞 , but I'll open a separate issue for this.

Fixes #533.