### PR TITLE
Various Windows fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,11 @@ jobs:
       - uses: ammaraskar/gcc-problem-matcher@master
       - name: Build HealthGPS (debug)
         if: '!cancelled()' # Run this step, even if the previous one fails
-        run: |
-          cmake --build --preset=debug-build-${{ matrix.platform }} --target=install
+        run: cmake --build --preset=debug-build-${{ matrix.platform }} --target=install
+
+      - name: Execute HealthGPS (debug)
+        if: '!cancelled()' # Run this step, even if the previous one fails
+        run: out/install/${{ matrix.platform }}-debug/bin/HealthGPS.Console --help
 
       - name: Build HealthGPS (release)
         if: '!cancelled()' # Run this step, even if the previous one fails
@@ -106,6 +109,10 @@ jobs:
           # Build documentation so we can show Doxygen warnings
           cmake --preset=${{ matrix.platform }}-release -DWARNINGS_AS_ERRORS=ON -DBUILD_DOC=ON
           cmake --build --preset=release-build-${{ matrix.platform }} --target=install
+
+      - name: Execute HealthGPS (release)
+        if: '!cancelled()' # Run this step, even if the previous one fails
+        run: out/install/${{ matrix.platform }}-release/bin/HealthGPS.Console --help
 
       - name: Upload artifacts
         if: matrix.is_main

--- a/src/HealthGPS.Console/CMakeLists.txt
+++ b/src/HealthGPS.Console/CMakeLists.txt
@@ -49,9 +49,28 @@ target_link_libraries(
             cxxopts::cxxopts
             TBB::tbb)
 
-install(TARGETS HealthGPS.Console DESTINATION "")
+install(
+    TARGETS HealthGPS.Console
+    RUNTIME
+    ARCHIVE
+    LIBRARY
+    RUNTIME
+    FRAMEWORK
+    BUNDLE
+    PUBLIC_HEADER
+    RESOURCE)
 if(WIN32)
-    install(IMPORTED_RUNTIME_ARTIFACTS fmt::fmt)
+    install(
+        TARGETS HealthGPS.Console
+        COMPONENT HealthGPS.Console
+        RUNTIME_DEPENDENCIES
+        PRE_EXCLUDE_REGEXES
+        "api-ms-"
+        "ext-ms-"
+        POST_EXCLUDE_REGEXES
+        ".*system32/.*\\.dll"
+        DIRECTORIES
+        $<TARGET_FILE_DIR:HealthGPS.Console>)
 endif()
 
 install(DIRECTORY ../../schemas DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")

--- a/src/HealthGPS.Input/download_file.cpp
+++ b/src/HealthGPS.Input/download_file.cpp
@@ -33,7 +33,7 @@ std::filesystem::path get_temporary_file_path(const std::string &file_prefix,
 
 namespace hgps::input {
 void download_file(const std::string &url, const std::filesystem::path &download_path) {
-    std::ofstream ofs{download_path};
+    std::ofstream ofs{download_path, std::ios::binary};
     if (!ofs) {
         throw std::runtime_error(fmt::format("Failed to create file {}", download_path.string()));
     }

--- a/src/HealthGPS.Input/zip_file.cpp
+++ b/src/HealthGPS.Input/zip_file.cpp
@@ -67,6 +67,7 @@ void extract_zip_file(const std::filesystem::path &file_path,
                     fmt::format("Failed to create directory: {}", out_path.string())};
             }
         } else {
+            // NB: We assume all files are text files
             std::ofstream ofs{out_path};
             if (!ofs) {
                 throw std::runtime_error{

--- a/src/HealthGPS.Input/zip_file.cpp
+++ b/src/HealthGPS.Input/zip_file.cpp
@@ -62,6 +62,8 @@ void extract_zip_file(const std::filesystem::path &file_path,
     for (const auto &entry : zf.getEntries()) {
         out_path = temp_output_directory / entry.getName();
         if (entry.isDirectory()) {
+            // Names seem to have a trailing slash which confuses Windows, hence:
+            out_path /= ".";
             if (!std::filesystem::create_directories(out_path)) {
                 throw std::runtime_error{
                     fmt::format("Failed to create directory: {}", out_path.string())};

--- a/src/HealthGPS.Input/zip_file.cpp
+++ b/src/HealthGPS.Input/zip_file.cpp
@@ -64,10 +64,8 @@ void extract_zip_file(const std::filesystem::path &file_path,
         if (entry.isDirectory()) {
             // Names seem to have a trailing slash which confuses Windows, hence:
             out_path /= ".";
-            if (!std::filesystem::create_directories(out_path)) {
-                throw std::runtime_error{
-                    fmt::format("Failed to create directory: {}", out_path.string())};
-            }
+
+            std::filesystem::create_directories(out_path);
         } else {
             // NB: We assume all files are text files
             std::ofstream ofs{out_path};

--- a/src/HealthGPS/sha256.cpp
+++ b/src/HealthGPS/sha256.cpp
@@ -11,7 +11,7 @@
 
 namespace hgps {
 std::string compute_sha256_for_file(const std::filesystem::path &file_path, size_t buffer_size) {
-    std::ifstream ifs{file_path};
+    std::ifstream ifs{file_path, std::ios::binary};
     if (!ifs) {
         throw std::runtime_error(fmt::format("Could not read file: {}", file_path.string()));
     }


### PR DESCRIPTION
This PR fixes the Windows (MSVC) build of HGPS.

There were a few issues I had in trying to get HGPS to run on Windows:

1. A bunch of dependent DLLs were missing from the install directory, meaning both local and CI builds wouldn't run. Fixed by scanning the exe for depending DLLs and including them.
2. There were a few places where `fstream`s were being opened in text mode rather than binary mode, which won't work with binary files on Windows
3. A trailing slash on the end of directory names was breaking things

Fixes #533. Fixes #536.