### PR TITLE
**HACK** Dump population at given intervals.

### DIFF
--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -158,7 +158,7 @@ void AnalysisModule::initialise_population(RuntimeContext &context) {
     while (std::getline(ss, item, ',')) {
         try {
             dump_times_.push_back(std::stoi(item));
-        } catch (const std::invalid_argument &e) {
+        } catch (const std::invalid_argument &) {
             std::cerr << "Invalid number in HGPS_DUMP_TIMES: " << item << '\n';
             std::exit(101);
         }

--- a/src/HealthGPS/analysis_module.cpp
+++ b/src/HealthGPS/analysis_module.cpp
@@ -145,7 +145,7 @@ void AnalysisModule::initialise_population(RuntimeContext &context) {
 
     const char *env_var = std::getenv("HGPS_DUMP_TIMES");
     if (env_var == nullptr) {
-        std::cerr << "HGPS_DUMP_TIMES environment variable is not set.\n" << std::endl;
+        std::cerr << "HGPS_DUMP_TIMES environment variable is not set.\n" << '\n';
         std::exit(100);
     }
 
@@ -159,7 +159,7 @@ void AnalysisModule::initialise_population(RuntimeContext &context) {
         try {
             dump_times_.push_back(std::stoi(item));
         } catch (const std::invalid_argument &e) {
-            std::cerr << "Invalid number in HGPS_DUMP_TIMES: " << item << std::endl;
+            std::cerr << "Invalid number in HGPS_DUMP_TIMES: " << item << '\n';
             std::exit(101);
         }
     }
@@ -168,14 +168,14 @@ void AnalysisModule::initialise_population(RuntimeContext &context) {
     for (const auto &time : dump_times_) {
         std::cout << time << " ";
     }
-    std::cout << std::endl;
+    std::cout << '\n';
 
     // CHECK TO DUMP POPULATION
     const auto &scenario = context.scenario().name();
     int elapsed_time = context.time_now() - context.start_time();
     if (std::find(dump_times_.cbegin(), dump_times_.cend(), elapsed_time) != dump_times_.cend()) {
         std::cout << "Dumping initial " << scenario << " population at time " << elapsed_time
-                  << std::endl;
+                  << '\n';
         dump(context);
     }
 }
@@ -192,7 +192,7 @@ void AnalysisModule::update_population(RuntimeContext &context) {
     int elapsed_time = context.time_now() - context.start_time();
     if (std::find(dump_times_.cbegin(), dump_times_.cend(), elapsed_time) != dump_times_.cend()) {
         std::cout << "Dumping updated " << scenario << " population at time " << elapsed_time
-                  << std::endl;
+                  << '\n';
         dump(context);
     }
 }

--- a/src/HealthGPS/analysis_module.h
+++ b/src/HealthGPS/analysis_module.h
@@ -42,6 +42,7 @@ class AnalysisModule final : public UpdatableModule {
     void update_population(RuntimeContext &context) override;
 
   private:
+    std::vector<int> dump_times_;
     AnalysisDefinition definition_;
     WeightModel weight_classifier_;
     DoubleAgeGenderTable residual_disability_weight_;


### PR DESCRIPTION
***DO NOT MERGE***

Hack to enable whole population dumping (baseline and intervention) of risk factors at selected times.

Control this by setting an environment variable before running healthgps:

```sh
export HGPS_DUMP_TIMES=0,10,25

# healthgps command here
```

Try it out locally if you can to check you see how it works, and if there's anything else you need dumped.


Resolves #535 

