### PR TITLE
Add `--dry-run` flag to validate input files without running simulation

### DIFF
--- a/src/HealthGPS.Console/command_options.cpp
+++ b/src/HealthGPS.Console/command_options.cpp
@@ -17,6 +17,8 @@ cxxopts::Options create_options() {
         ("c,config", "Path to configuration file, folder or URL.", cxxopts::value<std::string>())
         ("s,storage", "Path to root folder of the data storage.", cxxopts::value<std::string>())
         ("j,jobid", "The batch execution job identifier.", cxxopts::value<int>())
+        ("dry-run",  "Check the input files without running a simulation",
+            cxxopts::value<bool>()->default_value("false"))
         ("o,output", "Path to output folder", cxxopts::value<std::string>())
         ("T,threads", "The maximum number of threads to create (0: no limit, default).",
             cxxopts::value<size_t>())
@@ -70,6 +72,11 @@ std::optional<CommandOptions> parse_arguments(cxxopts::Options &options, int arg
         fmt::print("Data source: {}\n", source);
 
         cmd.data_source = hgps::input::DataSource(std::move(source));
+    }
+
+    if (result.count("dry-run")) {
+        cmd.dry_run = true;
+        fmt::print(fmt::fg(fmt::color::yellow), "Performing dry run.\n");
     }
 
     if (result.count("output")) {

--- a/src/HealthGPS.Console/command_options.cpp
+++ b/src/HealthGPS.Console/command_options.cpp
@@ -9,18 +9,22 @@ namespace hgps {
 
 cxxopts::Options create_options() {
     cxxopts::Options options("HealthGPS.Console", "Health-GPS microsimulation for policy options.");
-    options.add_options()("f,file", "Path to configuration file, folder or URL (deprecated).",
-                          cxxopts::value<std::string>())(
-        "c,config", "Path to configuration file, folder or URL.", cxxopts::value<std::string>())(
-        "s,storage", "Path to root folder of the data storage.", cxxopts::value<std::string>())(
-        "j,jobid", "The batch execution job identifier.",
-        cxxopts::value<int>())("o,output", "Path to output folder", cxxopts::value<std::string>())(
-        "T,threads", "The maximum number of threads to create (0: no limit, default).",
-        cxxopts::value<size_t>())
 
+    // clang-format off
+    options.add_options()
+        ("f,file", "Path to configuration file, folder or URL (deprecated).",
+            cxxopts::value<std::string>())
+        ("c,config", "Path to configuration file, folder or URL.", cxxopts::value<std::string>())
+        ("s,storage", "Path to root folder of the data storage.", cxxopts::value<std::string>())
+        ("j,jobid", "The batch execution job identifier.", cxxopts::value<int>())
+        ("o,output", "Path to output folder", cxxopts::value<std::string>())
+        ("T,threads", "The maximum number of threads to create (0: no limit, default).",
+            cxxopts::value<size_t>())
         ("verbose", "Print more information about progress",
-         cxxopts::value<bool>()->default_value("false"))("help", "Help about this application.")(
-            "version", "Print the application version number.");
+            cxxopts::value<bool>()->default_value("false"))
+        ("help", "Help for this application.")
+        ("version", "Print the application version number.");
+    // clang-format on
 
     return options;
 }

--- a/src/HealthGPS.Console/command_options.h
+++ b/src/HealthGPS.Console/command_options.h
@@ -31,6 +31,9 @@ struct CommandOptions {
 
     /// @brief The maximum number of threads to use (0: no limit).
     size_t num_threads{};
+
+    /// @brief Whether to check input files without actually running simulation
+    bool dry_run{};
 };
 
 /// @brief Creates the command-line interface (CLI) options

--- a/src/HealthGPS.Console/program.cpp
+++ b/src/HealthGPS.Console/program.cpp
@@ -107,17 +107,6 @@ int main(int argc, char *argv[]) { // NOLINT(bugprone-exception-escape)
         return exit_application(EXIT_FAILURE);
     }
 
-    // Create output folder
-    if (!std::filesystem::exists(config.output.folder)) {
-        fmt::print(fg(fmt::color::dark_salmon), "\nCreating output folder: {} ...\n",
-                   config.output.folder);
-        if (!std::filesystem::create_directories(config.output.folder)) {
-            fmt::print(fg(fmt::color::red), "Failed to create output folder: {}\n",
-                       config.output.folder);
-            return exit_application(EXIT_FAILURE);
-        }
-    }
-
     // Load input data file into a datatable asynchronous
     auto table_future = core::run_async(load_datatable_from_csv, config.file);
 
@@ -170,6 +159,17 @@ int main(int argc, char *argv[]) { // NOLINT(bugprone-exception-escape)
         // Create complete model input from configuration
         auto model_input = std::make_shared<ModelInput>(
             create_model_input(input_table, std::move(country), config, std::move(diseases)));
+
+        // Create output folder
+        if (!std::filesystem::exists(config.output.folder)) {
+            fmt::print(fg(fmt::color::dark_salmon), "\nCreating output folder: {} ...\n",
+                       config.output.folder);
+            if (!std::filesystem::create_directories(config.output.folder)) {
+                fmt::print(fg(fmt::color::red), "Failed to create output folder: {}\n",
+                           config.output.folder);
+                return exit_application(EXIT_FAILURE);
+            }
+        }
 
         // Create event bus and event monitor with a results file writer
         auto event_bus = std::make_shared<DefaultEventBus>();

--- a/src/HealthGPS.Console/program.cpp
+++ b/src/HealthGPS.Console/program.cpp
@@ -160,6 +160,12 @@ int main(int argc, char *argv[]) { // NOLINT(bugprone-exception-escape)
         auto model_input = std::make_shared<ModelInput>(
             create_model_input(input_table, std::move(country), config, std::move(diseases)));
 
+        // If the user is just validating input files, abort here
+        if (cmd_args.dry_run) {
+            fmt::print(fg(fmt::color::yellow), "Dry run completed successfully.\n");
+            return exit_application(EXIT_SUCCESS);
+        }
+
         // Create output folder
         if (!std::filesystem::exists(config.output.folder)) {
             fmt::print(fg(fmt::color::dark_salmon), "\nCreating output folder: {} ...\n",


### PR DESCRIPTION
This PR adds a new `--dry-run` flag which can be passed to HGPS in order to validate input files without actually running a simulation. The idea is that it will enable @jzhu20 to check that the input data files are valid before submitting HPC jobs.

Closes #549.