### PR TITLE
Fix schema validation for demographic_models property

### DIFF
--- a/schemas/v1/config/modelling.json
+++ b/schemas/v1/config/modelling.json
@@ -258,6 +258,7 @@
     },
     "required": [
         "ses_model",
+        "demographic_models",
         "risk_factors",
         "risk_factor_models",
         "baseline_adjustments"


### PR DESCRIPTION
Added demographic_models to the required properties in the modelling schema to fix validation errors when using this property.

The current required contains- 
"required": [
    "ses_model",
    "demographic_models",  // added this
    "risk_factors",
    "risk_factor_models",
    "baseline_adjustments"
],

This is coz despite adding a demographic_models to the v1/config/modelling.json, it is missing in the required section hence I'm getting this error of -
_Invalid configuration - /modelling/demographic_models: Additional property 'demographic_models' not allowed by schema._.

This should solve the above error. 