### PR TITLE
Updated schema to have values as numbers instead of string as the code  is expecting numbers

### DIFF
--- a/schemas/v1/config/modelling.json
+++ b/schemas/v1/config/modelling.json
@@ -35,7 +35,7 @@
                                     "type": "object",
                                     "properties": {
                                         "age": {
-                                            "type": "string"
+                                            "type": "number"
                                         },
                                         "gender": {
                                             "type": "object",
@@ -58,7 +58,7 @@
                         "coefficients": {
                             "type": "object",
                             "additionalProperties": {
-                                "type": "string"
+                                "type": "number"
                             }
                         }
                     },
@@ -74,7 +74,7 @@
                                     "type": "object",
                                     "properties": {
                                         "age": {
-                                            "type": "string"
+                                            "type": "number"
                                         },
                                         "gender": {
                                             "type": "object",
@@ -91,7 +91,7 @@
                                         "region": {
                                             "type": "object",
                                             "additionalProperties": {
-                                                "type": "string"
+                                                "type": "number"
                                             }
                                         }
                                     },
@@ -103,7 +103,7 @@
                         "coefficients": {
                             "type": "object",
                             "additionalProperties": {
-                                "type": "string"
+                                "type": "number"
                             }
                         }
                     },
@@ -150,7 +150,7 @@
                             "type": "object",
                             "properties": {
                                 "age": {
-                                    "type": "string"
+                                    "type": "number"
                                 },
                                 "gender": {
                                     "type": "object",


### PR DESCRIPTION
All critical areas now align between schema and code:
| Area | Schema Type | Code Expectation | Compatible? |
|------|------------|------------------|------------|
| Region.age | number | double | ✓ Yes |
| Ethnicity.age | number | double | ✓ Yes |
| Region coefficients | number | double | ✓ Yes |
| Ethnicity.region values | number | double | ✓ Yes |
| Physical activity age | number | double | ✓ Yes |