### PR TITLE
Updated trend null to do nothing

### DIFF
--- a/src/HealthGPS/risk_factor_adjustable_model.cpp
+++ b/src/HealthGPS/risk_factor_adjustable_model.cpp
@@ -241,15 +241,14 @@ RiskFactorAdjustableModel::calculate_simulated_mean(Population &population,
 RiskFactorAdjustableModelDefinition::RiskFactorAdjustableModelDefinition(
     std::unique_ptr<RiskFactorSexAgeTable> expected,
     std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
-    std::unique_ptr<std::unordered_map<core::Identifier, int>> trend_steps,
-    TrendType trend_type)
+    std::unique_ptr<std::unordered_map<core::Identifier, int>> trend_steps, TrendType trend_type)
     : expected_{std::move(expected)}, expected_trend_{std::move(expected_trend)},
       trend_steps_{std::move(trend_steps)}, trend_type_{trend_type} {
 
     if (expected_->empty()) {
         throw core::HgpsException("Risk factor expected value mapping is empty");
     }
-    
+
     // Only validate trend data if trends are actually being used
     if (trend_type_ != TrendType::Null) {
         if (expected_trend_->empty()) {

--- a/src/HealthGPS/risk_factor_adjustable_model.cpp
+++ b/src/HealthGPS/risk_factor_adjustable_model.cpp
@@ -50,7 +50,7 @@ double RiskFactorAdjustableModel::get_expected(RuntimeContext &context, core::Ge
     double expected = expected_->at(sex, factor).at(age);
 
     // Apply trend to expected value based on trend type
-    if (apply_trend) {
+    if (apply_trend && trend_type_ != TrendType::Null) {
         int elapsed_time = context.time_now() - context.start_time();
 
         switch (trend_type_) {
@@ -61,8 +61,10 @@ double RiskFactorAdjustableModel::get_expected(RuntimeContext &context, core::Ge
         case TrendType::Trend: {
             // Apply regular UPF trend to factors mean adjustment
             // Formula: factors_mean_T = factors_mean × ExpectedTrend^(T-T0)
-            int t = std::min(elapsed_time, get_trend_steps(factor));
-            expected *= pow(expected_trend_->at(factor), t);
+            if (expected_trend_) {
+                int t = std::min(elapsed_time, get_trend_steps(factor));
+                expected *= pow(expected_trend_->at(factor), t);
+            }
             break;
         }
 
@@ -151,7 +153,10 @@ void RiskFactorAdjustableModel::adjust_risk_factors(RuntimeContext &context,
 }
 
 int RiskFactorAdjustableModel::get_trend_steps(const core::Identifier &factor) const {
-    return trend_steps_->at(factor);
+    if (trend_steps_) {
+        return trend_steps_->at(factor);
+    }
+    return 0; // Default to no trend steps if trend data is not available
 }
 
 RiskFactorSexAgeTable
@@ -236,18 +241,23 @@ RiskFactorAdjustableModel::calculate_simulated_mean(Population &population,
 RiskFactorAdjustableModelDefinition::RiskFactorAdjustableModelDefinition(
     std::unique_ptr<RiskFactorSexAgeTable> expected,
     std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
-    std::unique_ptr<std::unordered_map<core::Identifier, int>> trend_steps)
+    std::unique_ptr<std::unordered_map<core::Identifier, int>> trend_steps,
+    TrendType trend_type)
     : expected_{std::move(expected)}, expected_trend_{std::move(expected_trend)},
-      trend_steps_{std::move(trend_steps)} {
+      trend_steps_{std::move(trend_steps)}, trend_type_{trend_type} {
 
     if (expected_->empty()) {
         throw core::HgpsException("Risk factor expected value mapping is empty");
     }
-    if (expected_trend_->empty()) {
-        throw core::HgpsException("Risk factor expected trend mapping is empty");
-    }
-    if (trend_steps_->empty()) {
-        throw core::HgpsException("Risk factor trend steps mapping is empty");
+    
+    // Only validate trend data if trends are actually being used
+    if (trend_type_ != TrendType::Null) {
+        if (expected_trend_->empty()) {
+            throw core::HgpsException("Risk factor expected trend mapping is empty");
+        }
+        if (trend_steps_->empty()) {
+            throw core::HgpsException("Risk factor trend steps mapping is empty");
+        }
     }
 }
 

--- a/src/HealthGPS/risk_factor_adjustable_model.h
+++ b/src/HealthGPS/risk_factor_adjustable_model.h
@@ -40,17 +40,15 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
     /// @param expected_trend The expected trend of risk factor values (for UPF trends)
     /// @param trend_steps The number of time steps to apply the trend (for UPF trends)
     /// @param trend_type The type of trend to apply to factors mean adjustment
-    /// @param expected_income_trend The expected income trend of risk factor values
-    /// @param expected_income_trend_decay_factors The exponential decay factors for income trends
+    /// @param expected_income_trend The expected income trend of risk factor values 
+    /// @param expected_income_trend_decay_factors The exponential decay factors for income trends 
     RiskFactorAdjustableModel(
         std::shared_ptr<RiskFactorSexAgeTable> expected,
         std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
         std::shared_ptr<std::unordered_map<core::Identifier, int>> trend_steps,
         TrendType trend_type = TrendType::Null,
-        std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_income_trend =
-            nullptr,
-        std::shared_ptr<std::unordered_map<core::Identifier, double>>
-            expected_income_trend_decay_factors = nullptr);
+        std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_income_trend = nullptr,
+        std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_income_trend_decay_factors = nullptr);
 
     /// @brief Gets a person's expected risk factor value
     /// @param context The simulation run-time context
@@ -94,14 +92,13 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
     std::shared_ptr<RiskFactorSexAgeTable> expected_;
     std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend_;
     std::shared_ptr<std::unordered_map<core::Identifier, int>> trend_steps_;
-
+    
     // Trend type for factors mean adjustment
     TrendType trend_type_;
-
-    // Income trend data structures (optional, only used when trend_type_ == TrendType::IncomeTrend)
+    
+    // Income trend data structures (only used when trend_type_ == TrendType::IncomeTrend)
     std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_income_trend_;
-    std::shared_ptr<std::unordered_map<core::Identifier, double>>
-        expected_income_trend_decay_factors_;
+    std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_income_trend_decay_factors_;
 };
 
 /// @brief Risk factor adjustable model definition interface
@@ -111,16 +108,19 @@ class RiskFactorAdjustableModelDefinition : public RiskFactorModelDefinition {
     /// @param expected The expected risk factor values by sex and age
     /// @param expected_trend The expected trend of risk factor values
     /// @param trend_steps The number of time steps to apply the trend
+    /// @param trend_type The type of trend to apply (optional, defaults to Null)
     /// @throws HgpsException for invalid arguments
     RiskFactorAdjustableModelDefinition(
         std::unique_ptr<RiskFactorSexAgeTable> expected,
         std::unique_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
-        std::unique_ptr<std::unordered_map<core::Identifier, int>> trend_steps);
+        std::unique_ptr<std::unordered_map<core::Identifier, int>> trend_steps,
+        TrendType trend_type = TrendType::Null);
 
   protected:
     std::shared_ptr<RiskFactorSexAgeTable> expected_;
     std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend_;
     std::shared_ptr<std::unordered_map<core::Identifier, int>> trend_steps_;
+    TrendType trend_type_;
 };
 
 } // namespace hgps

--- a/src/HealthGPS/risk_factor_adjustable_model.h
+++ b/src/HealthGPS/risk_factor_adjustable_model.h
@@ -40,15 +40,17 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
     /// @param expected_trend The expected trend of risk factor values (for UPF trends)
     /// @param trend_steps The number of time steps to apply the trend (for UPF trends)
     /// @param trend_type The type of trend to apply to factors mean adjustment
-    /// @param expected_income_trend The expected income trend of risk factor values 
-    /// @param expected_income_trend_decay_factors The exponential decay factors for income trends 
+    /// @param expected_income_trend The expected income trend of risk factor values
+    /// @param expected_income_trend_decay_factors The exponential decay factors for income trends
     RiskFactorAdjustableModel(
         std::shared_ptr<RiskFactorSexAgeTable> expected,
         std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend,
         std::shared_ptr<std::unordered_map<core::Identifier, int>> trend_steps,
         TrendType trend_type = TrendType::Null,
-        std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_income_trend = nullptr,
-        std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_income_trend_decay_factors = nullptr);
+        std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_income_trend =
+            nullptr,
+        std::shared_ptr<std::unordered_map<core::Identifier, double>>
+            expected_income_trend_decay_factors = nullptr);
 
     /// @brief Gets a person's expected risk factor value
     /// @param context The simulation run-time context
@@ -92,13 +94,14 @@ class RiskFactorAdjustableModel : public RiskFactorModel {
     std::shared_ptr<RiskFactorSexAgeTable> expected_;
     std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_trend_;
     std::shared_ptr<std::unordered_map<core::Identifier, int>> trend_steps_;
-    
+
     // Trend type for factors mean adjustment
     TrendType trend_type_;
-    
+
     // Income trend data structures (only used when trend_type_ == TrendType::IncomeTrend)
     std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_income_trend_;
-    std::shared_ptr<std::unordered_map<core::Identifier, double>> expected_income_trend_decay_factors_;
+    std::shared_ptr<std::unordered_map<core::Identifier, double>>
+        expected_income_trend_decay_factors_;
 };
 
 /// @brief Risk factor adjustable model definition interface

--- a/src/HealthGPS/static_linear_model.cpp
+++ b/src/HealthGPS/static_linear_model.cpp
@@ -596,7 +596,7 @@ StaticLinearModelDefinition::StaticLinearModelDefinition(
     std::unique_ptr<std::vector<double>> income_trend_lambda,
     std::unique_ptr<std::unordered_map<core::Identifier, double>> income_trend_decay_factors)
     : RiskFactorAdjustableModelDefinition{std::move(expected), std::move(expected_trend),
-                                          std::move(trend_steps)},
+                                          std::move(trend_steps), trend_type},
       // Regular trend member variables
       expected_trend_boxcox_{std::move(expected_trend_boxcox)},
       trend_models_{std::move(trend_models)}, trend_ranges_{std::move(trend_ranges)},


### PR DESCRIPTION
Fixed error when trend type= null

Constructor was still calling the get_expected function and hence was showing that the row was empty. 