### PR TITLE
configuration updates for windows and linux

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -54,9 +54,6 @@
             },
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
-                "CMAKE_C_COMPILER": "cl",
-                "CMAKE_CXX_COMPILER": "cl",
-                "CMAKE_LINKER": "link",
                 "VCPKG_TARGET_TRIPLET": "x64-windows",
                 "CMAKE_TOOLCHAIN_FILE": {
                     "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,13 +32,13 @@ target_include_directories(HealthGPS PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/external
 # Set the start-up project for the "play" button in MSVC
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT HealthGPS.Console)
 
-if (MSVC)
+if(MSVC)
     target_compile_options(HealthGPS.Core PRIVATE /EHsc)
     target_compile_options(HealthGPS.Input PRIVATE /EHsc)
     target_compile_options(HealthGPS PRIVATE /EHsc)
     target_compile_options(HealthGPS.Console PRIVATE /EHsc)
 
-    if (BUILD_TESTING)
+    if(BUILD_TESTING)
         target_compile_options(HealthGPS.Tests PRIVATE /EHsc)
     endif()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,3 +31,14 @@ target_include_directories(HealthGPS PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/external
 
 # Set the start-up project for the "play" button in MSVC
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT HealthGPS.Console)
+
+if (MSVC)
+    target_compile_options(HealthGPS.Core PRIVATE /EHsc)
+    target_compile_options(HealthGPS.Input PRIVATE /EHsc)
+    target_compile_options(HealthGPS PRIVATE /EHsc)
+    target_compile_options(HealthGPS.Console PRIVATE /EHsc)
+
+    if (BUILD_TESTING)
+        target_compile_options(HealthGPS.Tests PRIVATE /EHsc)
+    endif()
+endif()

--- a/src/HealthGPS.Console/CMakeLists.txt
+++ b/src/HealthGPS.Console/CMakeLists.txt
@@ -87,7 +87,7 @@ install(DIRECTORY ../../schemas DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
 
 set(ROOT_NAMESPACE hgps)
 
-if (MSVC)
+if(MSVC)
     target_compile_options(HealthGPS.Console PRIVATE /EHsc)
     target_compile_options(HealthGPS.LibConsole PRIVATE /EHsc)
 endif()

--- a/src/HealthGPS.Console/CMakeLists.txt
+++ b/src/HealthGPS.Console/CMakeLists.txt
@@ -86,3 +86,8 @@ endif()
 install(DIRECTORY ../../schemas DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
 
 set(ROOT_NAMESPACE hgps)
+
+if (MSVC)
+    target_compile_options(HealthGPS.Console PRIVATE /EHsc)
+    target_compile_options(HealthGPS.LibConsole PRIVATE /EHsc)
+endif()


### PR DESCRIPTION
After reboot:

cl.exe is not on PATH
Ninja does not auto-load MSVC
So CMake fails

-------> Visual Studio + Ninja already knows:

Which MSVC to use
Which host/target architecture to use
How to inject the environment correctly

"CMAKE_C_COMPILER": "cl",
"CMAKE_CXX_COMPILER": "cl",
"CMAKE_LINKER": "link",
By removing those 3 lines from CMakePresets.json, you let VS do its job every time, even after reboot.