### PR TITLE
weight quintile implementation

### DIFF
--- a/Technical Documentations/weight_quintile_plan.md
+++ b/Technical Documentations/weight_quintile_plan.md
@@ -1,0 +1,242 @@
+---
+name: Weight Quintile Quantiles
+overview: Add per-stratum weight quantile CSVs under WeightQuantiles (nested Quintile1..N), keep the legacy single-file shape, pick curves by income_adjustment_stratum when assigning weight, and print stratum/final-income summary tables on generate and update—same pattern as height.
+todos:
+  - id: schema-weight-quintiles
+    content: "Extend v1/v2 kevinhall.json WeightQuantiles Female/Male oneOf: legacy csv_file | Quintile1..N object"
+    status: completed
+  - id: parser-load-strata
+    content: Implement load_weight_quantiles_by_gender in model_parser.cpp with broadcast, count validation vs adjustment_income_stratum_count, sorted Quintile keys
+    status: in_progress
+  - id: runtime-stratum-select
+    content: Change KevinHallModel/Definition to vector<vector<double>> + resolve_weight_quantiles_for_person + update initialise_weight/get_weight_quantile
+    status: pending
+  - id: console-weight-tables
+    content: Add print_weight_stratum_assignment_table, print_weight_by_final_income_category_table, print_weight_summary_tables; call from generate and update paths (mirror height gating)
+    status: pending
+  - id: tests-weight-strata
+    content: Add parser/runtime tests for legacy, N files, broadcast, mismatch errors, and console table output where applicable
+    status: pending
+  - id: fixture-docs
+    content: Update FINCH dynamic_model.json when quintile CSVs exist; add weight_quantiles_quintile_plan.md
+    status: pending
+isProject: false
+---
+
+# Weight quantiles by income adjustment stratum
+
+## Goal
+
+- Keep **legacy** `WeightQuantiles.Female` / `Male` as a single `csv_file` (e.g. `weight_quantiles_NCDRisk_female.csv`).
+- Add **stratum files**: `Female.Quintile1` → `weight_quantiles_NCDRisk_female_quintile1.csv`, and the same for Male.
+- At **weight assignment**, use `person.income_adjustment_stratum` (from `adjustment_income_stratum_count` rank buckets) to choose which quantile curve to use—the same idea as height via `resolve_height_params_for_person` in [kevin_hall_model.cpp](src/HealthGPS/kevin_hall_model.cpp).
+- **Final reporting income** stays on `project_requirements.income.categories` (`"3"` or `"4"`) on `person.income`; that does not change.
+
+Example: 5 adjustment strata for factors-mean / weight curves, 4 categories in ProjectRequirements for output.
+
+## Pipeline order (static before dynamic)
+
+[RiskFactorModule](src/HealthGPS/riskfactor.cpp) always runs **static** then **Kevin Hall**. So when `initialise_weight` runs, the static model has already assigned `income_adjustment_stratum` and remapped `person.income` to 3 or 4 categories ([static_linear_model.cpp](src/HealthGPS/static_linear_model.cpp) ~786–905).
+
+## Lifecycle — initialize (`generate_risk_factors`)
+
+Applies on run start (first simulation year). Static completes stratum assignment and final income categories **before** Kevin Hall touches weight.
+
+```mermaid
+flowchart TD
+    subgraph staticGen [StaticLinearModel.generate]
+        s1[Init sector income RF PA]
+        s2[Factors-mean adjustment optional per stratum]
+        s3[assign_income_adjustment_strata_equal_split N]
+        s4[assign_income_categories_equal_split 3 or 4]
+    end
+
+    subgraph dynGen [KevinHallModel.generate]
+        d1[Init nutrient and energy intake]
+        d2[initialise_weight uses stratum quantile curve]
+        d3[Adjust weight mean to expected]
+        d4[Init height using stratum height params]
+        d5[Init Kevin Hall state and BMI]
+        d6[Print weight summary tables]
+    end
+
+    staticGen --> dynGen
+```
+
+**Weight-specific step:** `initialise_weight` resolves the quantile vector for `(gender, income_adjustment_stratum)` (or index 0 if no stratum flag), then applies the existing E/PA → weight quantile logic (~873–908).
+
+## Lifecycle — update (`update_risk_factors`)
+
+Runs each simulation year. Static runs first again (strata can refresh from updated continuous income); then Kevin Hall updates weight/height.
+
+```mermaid
+flowchart TD
+    subgraph staticUpd [StaticLinearModel.update each year]
+        u1[Init or update newborns vs others]
+        u2[Factors-mean adjustment optional per stratum]
+        u3[assign_income_adjustment_strata_equal_split N]
+        u4[assign_income_categories_equal_split 3 or 4]
+    end
+
+    subgraph dynUpd [KevinHallModel.update]
+        v0{Path}
+        v0 -->|Newborns age 0| n1[Init nutrient energy weight]
+        n1 --> n2[Newborn weight adjustment]
+        n2 --> n3[Init height and KH state]
+        n3 --> n4[Print weight summary tables phase update-newborns]
+
+        v0 -->|Non-newborns| c1[Update nutrient and energy]
+        c1 --> c2{Age less than 19}
+        c2 -->|Yes| c3[initialise_weight stratum quantiles]
+        c2 -->|No| c4[kevin_hall_run adult weight]
+        c3 --> c5[Scenario weight adjustments]
+        c4 --> c5
+        c5 --> c6[Update height if child]
+        c6 --> c7[Print weight summary tables phase update-children]
+    end
+
+    staticUpd --> dynUpd
+```
+
+**Note:** Adults (`age >= 19`) do not re-run `initialise_weight` each year; stratum-based quantiles matter most at init and for children. Console tables still run on update paths so we can confirm strata and weights wherever weight was set in that step.
+
+## Config and schema
+
+**Files:** [schemas/v2/config/models/kevinhall.json](schemas/v2/config/models/kevinhall.json), [schemas/v1/config/models/kevinhall.json](schemas/v1/config/models/kevinhall.json)
+
+For `WeightQuantiles.Female` and `.Male`, use **`oneOf`**:
+
+1. Legacy — `$ref` to `csv_file.json`
+2. Stratum — object with `Quintile1`, `Quintile2`, … each a `csv_file` block
+
+**New format example:**
+
+```json
+"WeightQuantiles": {
+  "Female": {
+    "Quintile1": { "name": "weight_quantiles_NCDRisk_female_quintile1.csv", "format": "csv", ... },
+    "Quintile2": { ... }
+  },
+  "Male": { ... }
+}
+```
+
+**Legacy (unchanged):**
+
+```json
+"Female": { "name": "weight_quantiles_NCDRisk_female.csv", "format": "csv", ... }
+```
+
+### Why list each quintile in JSON (vs something shorter)
+
+This is the approach to use unless requirements change later.
+
+| Approach | Config effort | Tradeoff |
+|----------|---------------|----------|
+| **Explicit `Quintile1`…`N` (chosen)** | Repeat `format` / `delimiter` / `columns` per file (or copy-paste blocks) | Same pattern as factors-mean strata in [examples/config_skeleton.json](examples/config_skeleton.json); schema can validate each file; wrong or missing file fails at load with a clear path |
+| **Name pattern** e.g. `…_quintile{n}.csv`, N from `adjustment_income_stratum_count` | One block per gender, fewer lines | Assumes rigid filenames; harder to mix non-standard names or skip a stratum |
+| **Ordered `files` array** | List filenames once, shared format on parent | Slightly shorter JSON, but still N filenames; new schema shape |
+| **Directory glob** | Almost nothing in JSON | Fragile ordering, accidental extra CSVs, weak validation |
+
+**Practical tip:** For FINCH, duplicate the existing `Female` / `Male` csv block five times, change `name` to `_quintile1` … `_quintile5`, and nest under `Quintile1` … `Quintile5`. No magic paths—the filenames in JSON are exactly what get loaded.
+
+Factors-mean quintiles stay in **config.json** (`baseline_adjustments.income_stratum_factors_mean.strata`); weight quantiles stay in **dynamic_model.json** because Kevin Hall already owns `WeightQuantiles` there today.
+
+Update [dynamic_model.json](input-data/data/KevinHall_FINCH/dynamic_model.json) when quintile CSVs are in the data folder.
+
+## Parser ([model_parser.cpp](src/HealthGPS.Input/model_parser.cpp))
+
+Replace the flat load at ~1864–1883 with a helper similar to Height (~1901–1937):
+
+| Config input | `adjustment_income_stratum_count` | Loaded shape per gender |
+|--------------|-----------------------------------|-------------------------|
+| Single `csv_file` | any | One vector; broadcast to N if stratum mode on and N > 1 |
+| `Quintile1`…`QuintileN` | N | N vectors; error if file count ≠ N |
+| Wrong count | — | Parse error with file count vs expected N |
+
+- Load each file: `load_datatable_from_csv`, first column `double`, sort once at load.
+- Order quintile keys numerically (`Quintile1`, `Quintile2`, …).
+- Read `config.modelling.baseline_adjustment.income_stratum_factors_mean` for `enabled` and `adjustment_income_stratum_count` (same as height ~1897–1899).
+- If multiple quintile files are configured but stratum adjustment is disabled, fail at parse time.
+
+## Runtime ([kevin_hall_model.h](src/HealthGPS/kevin_hall_model.h) / [kevin_hall_model.cpp](src/HealthGPS/kevin_hall_model.cpp))
+
+**Storage** (mirror `height_params_`):
+
+```cpp
+std::unordered_map<core::Gender, std::vector<std::vector<double>>> weight_quantiles_by_stratum_;
+```
+
+**Logic:**
+
+1. `resolve_weight_quantiles_for_person` — same rules as height (~69–85): stratum index when `has_income_adjustment_stratum`, else index 0.
+2. `get_weight_quantile(epa_quantile, const std::vector<double>& quantiles)` — no per-person allocation; quantiles already sorted at load.
+3. `initialise_weight` — resolve stratum vector, then existing EPA percentile → weight quantile math (~1027–1038).
+
+**Performance:** I/O and sorting only at load; per person stays O(log n) on `epa_quantiles_` plus O(1) index into the stratum vector.
+
+## Console output tables (required)
+
+Mirror the height helpers in [kevin_hall_model.cpp](src/HealthGPS/kevin_hall_model.cpp) (~87–225, ~1176–1194). Not optional—needed to verify stratum weight assignment in the log.
+
+**Gating** — reuse the same policy as `should_print_height_summary_tables` (~49–58):
+
+- Baseline scenario only
+- Start year and start year + 1 only (avoid flooding long runs)
+
+**Table 1 — `[WEIGHT STRATUM ASSIGNMENT]`** (by adjustment stratum)
+
+Modeled on `print_height_stratum_assignment_table`:
+
+| Column | Content |
+|--------|---------|
+| Bucket | `person.income_adjustment_stratum` (0..N-1) |
+| Stratum ID | `Quintile1` … `QuintileN` |
+| Count | Active people in bucket |
+| Quantile size | Number of values loaded for that stratum (sanity check) |
+| Weight Min / Max / Mean | From `person.risk_factors["Weight"]` after assignment in that step |
+
+Header note: uses `person.income_adjustment_stratum` from static model.
+
+**Table 2 — `[WEIGHT BY FINAL INCOME CATEGORY]`** (by output income)
+
+Modeled on `print_height_by_final_income_category_table`:
+
+| Column | Content |
+|--------|---------|
+| Category | Low / LowerMid / UpperMid / High (4) or Low / Middle / High (3) |
+| Count | People in `person.income` category |
+| Weight Min / Max / Mean | After assignment |
+
+Header note: `person.income` from ProjectRequirements categories after static remapping.
+
+**Call sites** — add `print_weight_summary_tables(context, phase)` alongside existing height printing:
+
+| Phase string | When |
+|--------------|------|
+| `generate` | End of `generate_risk_factors` (~291) |
+| `update-newborns` | End of `update_newborns` (~370) |
+| `update-children` | End of `update_non_newborns` child path (~441) |
+
+`bucket_count` for the stratum table: max loaded stratum count across genders (same as height ~1182–1186).
+
+## Tests
+
+In [KevinHallHeight.Test.cpp](src/HealthGPS.Tests/KevinHallHeight.Test.cpp) and/or [KevinHallWeightValidation.Test.cpp](src/HealthGPS.Tests/KevinHallWeightValidation.Test.cpp):
+
+- Legacy single-file config still parses and runs
+- Five quintile files with `adjustment_income_stratum_count = 5`
+- Single file broadcast when N = 5
+- File count mismatch throws a clear error
+- Two people, same EPA quantile, different strata → different weights
+- Console output contains `[WEIGHT STRATUM ASSIGNMENT]` and `Quintile1` when tables are enabled (capture stdout like height tests ~542)
+
+## Docs
+
+Short note in `Technical Documentations/weight_quantiles_quintile_plan.md` with config examples, both lifecycle diagrams, and table format—aligned with [height_csv_quintile_plan.md](Technical%20Documentations/height_csv_quintile_plan.md).
+
+## Out of scope
+
+- Changing static income rebucketing
+- Multi-row single CSV per gender (nested quintile files only)
+- Generating production quintile CSVs (tests use small fixtures)

--- a/schemas/v1/config/models/kevinhall.json
+++ b/schemas/v1/config/models/kevinhall.json
@@ -1,6 +1,25 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/config/models/kevinhall.json",
+    "$defs": {
+        "weightQuantileGenderEntry": {
+            "oneOf": [
+                {
+                    "$ref": "../csv_file.json"
+                },
+                {
+                    "type": "object",
+                    "propertyNames": {
+                        "pattern": "^Quintile[1-9][0-9]*$"
+                    },
+                    "additionalProperties": {
+                        "$ref": "../csv_file.json"
+                    },
+                    "minProperties": 1
+                }
+            ]
+        }
+    },
     "type": "object",
     "properties": {
         "$schema": {
@@ -64,6 +83,7 @@
             }
         },
         "WeightQuantiles": {
+            "type": "object",
             "propertyNames": {
                 "enum": [
                     "Male",
@@ -71,7 +91,7 @@
                 ]
             },
             "additionalProperties": {
-                "$ref": "../csv_file.json"
+                "$ref": "#/$defs/weightQuantileGenderEntry"
             }
         },
         "EnergyPhysicalActivityQuantiles": {

--- a/schemas/v2/config/models/kevinhall.json
+++ b/schemas/v2/config/models/kevinhall.json
@@ -1,6 +1,25 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v2/config/models/kevinhall.json",
+    "$defs": {
+        "weightQuantileGenderEntry": {
+            "oneOf": [
+                {
+                    "$ref": "../../../v1/config/csv_file.json"
+                },
+                {
+                    "type": "object",
+                    "propertyNames": {
+                        "pattern": "^Quintile[1-9][0-9]*$"
+                    },
+                    "additionalProperties": {
+                        "$ref": "../../../v1/config/csv_file.json"
+                    },
+                    "minProperties": 1
+                }
+            ]
+        }
+    },
     "type": "object",
     "properties": {
         "$schema": {
@@ -83,6 +102,7 @@
             }
         },
         "WeightQuantiles": {
+            "type": "object",
             "propertyNames": {
                 "enum": [
                     "Male",
@@ -90,7 +110,7 @@
                 ]
             },
             "additionalProperties": {
-                "$ref": "../../../v1/config/csv_file.json"
+                "$ref": "#/$defs/weightQuantileGenderEntry"
             }
         },
         "EnergyPhysicalActivityQuantiles": {

--- a/src/HealthGPS.Input/model_parser.cpp
+++ b/src/HealthGPS.Input/model_parser.cpp
@@ -128,6 +128,133 @@ std::vector<HeightRow> load_height_params_csv(const std::filesystem::path &path,
     return rows;
 }
 
+//
+bool is_weight_quantile_csv_file_block(const nlohmann::json &node) {
+    return node.is_object() && node.contains("name") && node.contains("format");
+}
+
+std::optional<std::size_t> parse_weight_quintile_key_index(const std::string &key) {
+    static constexpr std::string_view prefix = "Quintile";
+    if (!key.starts_with(prefix)) {
+        return std::nullopt;
+    }
+    const auto suffix = key.substr(prefix.size());
+    if (suffix.empty()) {
+        return std::nullopt;
+    }
+    for (const char ch : suffix) {
+        if (ch < '0' || ch > '9') {
+            return std::nullopt;
+        }
+    }
+    try {
+        const auto index = std::stoull(suffix);
+        if (index == 0) {
+            return std::nullopt;
+        }
+        return static_cast<std::size_t>(index - 1);
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+std::vector<double> load_sorted_weight_quantiles_from_table(const hgps::core::DataTable &table) {
+    std::vector<double> quantiles;
+    quantiles.reserve(table.num_rows());
+    for (std::size_t row = 0; row < table.num_rows(); ++row) {
+        quantiles.push_back(std::any_cast<double>(table.column(0).value(row)));
+    }
+    std::ranges::sort(quantiles);
+    return quantiles;
+}
+
+std::vector<double> load_sorted_weight_quantiles_from_csv(const hgps::input::FileInfo &file_info) {
+    const auto table = load_datatable_from_csv(file_info);
+    if (table.num_rows() == 0) {
+        throw hgps::core::HgpsException{
+            fmt::format("Weight quantile CSV '{}' does not contain any data rows",
+                        file_info.name.filename().string())};
+    }
+    return load_sorted_weight_quantiles_from_table(table);
+}
+
+std::vector<std::vector<double>>
+load_gender_weight_quantiles_by_stratum(const nlohmann::json &gender_node,
+                                        const std::filesystem::path &root_path,
+                                        std::string_view gender_label, bool stratum_enabled,
+                                        std::size_t stratum_count) {
+    if (is_weight_quantile_csv_file_block(gender_node)) {
+        const auto file_info = hgps::input::get_file_info(gender_node, root_path);
+        const auto quantiles = load_sorted_weight_quantiles_from_csv(file_info);
+        const std::size_t broadcast_count =
+            (stratum_enabled && stratum_count > 1u) ? stratum_count : 1u;
+        return std::vector<std::vector<double>>(broadcast_count, quantiles);
+    }
+
+    if (!gender_node.is_object()) {
+        throw hgps::core::HgpsException{
+            fmt::format("WeightQuantiles.{} must be a csv_file block or Quintile1..N object",
+                        gender_label)};
+    }
+
+    if (!stratum_enabled) {
+        throw hgps::core::HgpsException{fmt::format(
+            "WeightQuantiles.{} uses Quintile1..N files but "
+            "baseline_adjustments.income_stratum_factors_mean.enabled is false",
+            gender_label)};
+    }
+
+    if (stratum_count < 2u) {
+        throw hgps::core::HgpsException{fmt::format(
+            "WeightQuantiles.{} uses Quintile1..N files but adjustment_income_stratum_count "
+            "must be >= 2",
+            gender_label)};
+    }
+
+    std::vector<std::pair<std::size_t, std::string>> quintile_keys;
+    for (const auto &[key, value] : gender_node.items()) {
+        const auto index = parse_weight_quintile_key_index(key);
+        if (!index.has_value()) {
+            throw hgps::core::HgpsException{fmt::format(
+                "WeightQuantiles.{} contains unsupported key '{}'. Use Quintile1, Quintile2, ...",
+                gender_label, key)};
+        }
+        if (!is_weight_quantile_csv_file_block(value)) {
+            throw hgps::core::HgpsException{fmt::format(
+                "WeightQuantiles.{}.{} must be a csv_file block", gender_label, key)};
+        }
+        quintile_keys.emplace_back(index.value(), key);
+    }
+
+    if (quintile_keys.size() != stratum_count) {
+        throw hgps::core::HgpsException{fmt::format(
+            "WeightQuantiles.{} defines {} quintile file(s) but adjustment_income_stratum_count "
+            "is {}. Provide exactly {} Quintile keys or use a single legacy csv_file.",
+            gender_label, quintile_keys.size(), stratum_count, stratum_count)};
+    }
+
+    std::ranges::sort(quintile_keys, [](const auto &lhs, const auto &rhs) {
+        return lhs.first < rhs.first;
+    });
+
+    for (std::size_t i = 0; i < quintile_keys.size(); ++i) {
+        if (quintile_keys[i].first != i) {
+            throw hgps::core::HgpsException{fmt::format(
+                "WeightQuantiles.{} quintile keys must be contiguous Quintile1..Quintile{}",
+                gender_label, stratum_count)};
+        }
+    }
+
+    std::vector<std::vector<double>> by_stratum;
+    by_stratum.reserve(stratum_count);
+    for (const auto &[index, key] : quintile_keys) {
+        (void)index;
+        const auto file_info = hgps::input::get_file_info(gender_node.at(key), root_path);
+        by_stratum.push_back(load_sorted_weight_quantiles_from_csv(file_info));
+    }
+    return by_stratum;
+}
+
 char parse_delimiter_char(const std::string &delimiter) {
     if (delimiter == "\\t") {
         return '\t';
@@ -1861,26 +1988,19 @@ load_kevinhall_risk_model_definition(const nlohmann::json &opt, const Configurat
         }
     }
 
-    // Weight quantiles.
-    const auto weight_quantiles_table_F = load_datatable_from_csv(
-        hgps::input::get_file_info(opt["WeightQuantiles"]["Female"], config.root_path));
-    const auto weight_quantiles_table_M = load_datatable_from_csv(
-        hgps::input::get_file_info(opt["WeightQuantiles"]["Male"], config.root_path));
-    std::unordered_map<hgps::core::Gender, std::vector<double>> weight_quantiles = {
-        {hgps::core::Gender::female, {}}, {hgps::core::Gender::male, {}}};
-    weight_quantiles[hgps::core::Gender::female].reserve(weight_quantiles_table_F.num_rows());
-    weight_quantiles[hgps::core::Gender::male].reserve(weight_quantiles_table_M.num_rows());
-    for (size_t j = 0; j < weight_quantiles_table_F.num_rows(); j++) {
-        weight_quantiles[hgps::core::Gender::female].push_back(
-            std::any_cast<double>(weight_quantiles_table_F.column(0).value(j)));
-    }
-    for (size_t j = 0; j < weight_quantiles_table_M.num_rows(); j++) {
-        weight_quantiles[hgps::core::Gender::male].push_back(
-            std::any_cast<double>(weight_quantiles_table_M.column(0).value(j)));
-    }
-    for (auto &[unused, quantiles] : weight_quantiles) {
-        std::sort(quantiles.begin(), quantiles.end());
-    }
+    const auto &stratum_cfg = config.modelling.baseline_adjustment.income_stratum_factors_mean;
+    const bool stratum_enabled = stratum_cfg.enabled;
+    const std::size_t stratum_count = stratum_cfg.adjustment_income_stratum_count;
+
+    // Weight quantiles (legacy single csv_file per gender, or Quintile1..N per gender).
+    std::unordered_map<hgps::core::Gender, std::vector<std::vector<double>>>
+        weight_quantiles_by_stratum;
+    weight_quantiles_by_stratum[hgps::core::Gender::female] =
+        load_gender_weight_quantiles_by_stratum(opt["WeightQuantiles"]["Female"], config.root_path,
+                                              "Female", stratum_enabled, stratum_count);
+    weight_quantiles_by_stratum[hgps::core::Gender::male] =
+        load_gender_weight_quantiles_by_stratum(opt["WeightQuantiles"]["Male"], config.root_path,
+                                              "Male", stratum_enabled, stratum_count);
 
     // Energy Physical Activity quantiles.
     const auto epa_quantiles_table = load_datatable_from_csv(
@@ -1894,9 +2014,6 @@ load_kevinhall_risk_model_definition(const nlohmann::json &opt, const Configurat
 
     // Load height model parameters.
     std::unordered_map<hgps::core::Gender, std::vector<hgps::HeightModelParams>> height_params;
-    const auto &stratum_cfg = config.modelling.baseline_adjustment.income_stratum_factors_mean;
-    const bool stratum_enabled = stratum_cfg.enabled;
-    const std::size_t stratum_count = stratum_cfg.adjustment_income_stratum_count;
 
     if (opt.contains("Height")) {
         const auto &height_csv_block = opt["Height"];
@@ -1947,7 +2064,7 @@ load_kevinhall_risk_model_definition(const nlohmann::json &opt, const Configurat
     return std::make_unique<hgps::KevinHallModelDefinition>(
         std::move(expected), std::move(expected_trend), std::move(trend_steps),
         std::move(energy_equation), std::move(nutrient_ranges), std::move(nutrient_equations),
-        std::move(food_prices), std::move(weight_quantiles), std::move(epa_quantiles),
+        std::move(food_prices), std::move(weight_quantiles_by_stratum), std::move(epa_quantiles),
         std::move(height_params));
 }
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/src/HealthGPS.Input/model_parser.cpp
+++ b/src/HealthGPS.Input/model_parser.cpp
@@ -178,11 +178,9 @@ std::vector<double> load_sorted_weight_quantiles_from_csv(const hgps::input::Fil
     return load_sorted_weight_quantiles_from_table(table);
 }
 
-std::vector<std::vector<double>>
-load_gender_weight_quantiles_by_stratum(const nlohmann::json &gender_node,
-                                        const std::filesystem::path &root_path,
-                                        std::string_view gender_label, bool stratum_enabled,
-                                        std::size_t stratum_count) {
+std::vector<std::vector<double>> load_gender_weight_quantiles_by_stratum(
+    const nlohmann::json &gender_node, const std::filesystem::path &root_path,
+    std::string_view gender_label, bool stratum_enabled, std::size_t stratum_count) {
     if (is_weight_quantile_csv_file_block(gender_node)) {
         const auto file_info = hgps::input::get_file_info(gender_node, root_path);
         const auto quantiles = load_sorted_weight_quantiles_from_csv(file_info);
@@ -192,16 +190,15 @@ load_gender_weight_quantiles_by_stratum(const nlohmann::json &gender_node,
     }
 
     if (!gender_node.is_object()) {
-        throw hgps::core::HgpsException{
-            fmt::format("WeightQuantiles.{} must be a csv_file block or Quintile1..N object",
-                        gender_label)};
+        throw hgps::core::HgpsException{fmt::format(
+            "WeightQuantiles.{} must be a csv_file block or Quintile1..N object", gender_label)};
     }
 
     if (!stratum_enabled) {
-        throw hgps::core::HgpsException{fmt::format(
-            "WeightQuantiles.{} uses Quintile1..N files but "
-            "baseline_adjustments.income_stratum_factors_mean.enabled is false",
-            gender_label)};
+        throw hgps::core::HgpsException{
+            fmt::format("WeightQuantiles.{} uses Quintile1..N files but "
+                        "baseline_adjustments.income_stratum_factors_mean.enabled is false",
+                        gender_label)};
     }
 
     if (stratum_count < 2u) {
@@ -220,8 +217,8 @@ load_gender_weight_quantiles_by_stratum(const nlohmann::json &gender_node,
                 gender_label, key)};
         }
         if (!is_weight_quantile_csv_file_block(value)) {
-            throw hgps::core::HgpsException{fmt::format(
-                "WeightQuantiles.{}.{} must be a csv_file block", gender_label, key)};
+            throw hgps::core::HgpsException{
+                fmt::format("WeightQuantiles.{}.{} must be a csv_file block", gender_label, key)};
         }
         quintile_keys.emplace_back(index.value(), key);
     }
@@ -233,9 +230,8 @@ load_gender_weight_quantiles_by_stratum(const nlohmann::json &gender_node,
             gender_label, quintile_keys.size(), stratum_count, stratum_count)};
     }
 
-    std::ranges::sort(quintile_keys, [](const auto &lhs, const auto &rhs) {
-        return lhs.first < rhs.first;
-    });
+    std::ranges::sort(quintile_keys,
+                      [](const auto &lhs, const auto &rhs) { return lhs.first < rhs.first; });
 
     for (std::size_t i = 0; i < quintile_keys.size(); ++i) {
         if (quintile_keys[i].first != i) {
@@ -1997,10 +1993,9 @@ load_kevinhall_risk_model_definition(const nlohmann::json &opt, const Configurat
         weight_quantiles_by_stratum;
     weight_quantiles_by_stratum[hgps::core::Gender::female] =
         load_gender_weight_quantiles_by_stratum(opt["WeightQuantiles"]["Female"], config.root_path,
-                                              "Female", stratum_enabled, stratum_count);
-    weight_quantiles_by_stratum[hgps::core::Gender::male] =
-        load_gender_weight_quantiles_by_stratum(opt["WeightQuantiles"]["Male"], config.root_path,
-                                              "Male", stratum_enabled, stratum_count);
+                                                "Female", stratum_enabled, stratum_count);
+    weight_quantiles_by_stratum[hgps::core::Gender::male] = load_gender_weight_quantiles_by_stratum(
+        opt["WeightQuantiles"]["Male"], config.root_path, "Male", stratum_enabled, stratum_count);
 
     // Energy Physical Activity quantiles.
     const auto epa_quantiles_table = load_datatable_from_csv(

--- a/src/HealthGPS.Tests/CMakeLists.txt
+++ b/src/HealthGPS.Tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_sources(
             "ModelParserFinch.Test.cpp"
             "KevinHallWeightValidation.Test.cpp"
             "KevinHallHeight.Test.cpp"
+            "KevinHallWeightQuantiles.Test.cpp"
             "EventMonitor.Test.cpp"
             "RelativeRiskLookup.Test.cpp"
             "RuntimeMetric.Test.cpp"

--- a/src/HealthGPS.Tests/KevinHallWeightQuantiles.Test.cpp
+++ b/src/HealthGPS.Tests/KevinHallWeightQuantiles.Test.cpp
@@ -1,0 +1,316 @@
+#include "pch.h"
+
+#include "HealthGPS.Core/identifier.h"
+#include "HealthGPS.Input/api.h"
+#include "HealthGPS.Input/model_parser.h"
+#include "HealthGPS/baseline_scenario.h"
+#include "HealthGPS/event_bus.h"
+#include "HealthGPS/interfaces.h"
+#include "HealthGPS/kevin_hall_model.h"
+#include "HealthGPS/modelinput.h"
+#include "HealthGPS/runtime_context.h"
+#include "TestConsoleCapture.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <fstream>
+
+namespace {
+
+std::filesystem::path healthgps_repo_root() {
+    return std::filesystem::path(__FILE__).parent_path().parent_path().parent_path();
+}
+
+std::filesystem::path finch_data_root() {
+    return healthgps_repo_root() / "input-data/data/KevinHall_FINCH";
+}
+
+hgps::input::Configuration make_finch_configuration() {
+    const auto finch = finch_data_root();
+    hgps::input::Configuration config;
+    config.root_path = finch;
+    config.settings.age_range = hgps::core::IntegerInterval(0, 110);
+    config.modelling.baseline_adjustment.format = "CSV";
+    config.modelling.baseline_adjustment.delimiter = ",";
+    config.modelling.baseline_adjustment.file_names["factorsmean_male"] =
+        finch / "Finch.FactorsMean.Male.csv";
+    config.modelling.baseline_adjustment.file_names["factorsmean_female"] =
+        finch / "Finch.FactorsMean.Female.csv";
+    config.project_requirements.income.type = "continuous";
+    config.project_requirements.income.categories = "4";
+    return config;
+}
+
+hgps::input::Configuration make_quintile_stratum_configuration() {
+    auto config = make_finch_configuration();
+    config.modelling.baseline_adjustment.income_stratum_factors_mean.enabled = true;
+    config.modelling.baseline_adjustment.income_stratum_factors_mean
+        .adjustment_income_stratum_count = 5u;
+    return config;
+}
+
+std::filesystem::path create_temp_weight_quantile_csv(const std::string &filename,
+                                                      const std::string &content) {
+    const auto dir = std::filesystem::temp_directory_path() / "hgps_weight_quantile_tests";
+    std::filesystem::create_directories(dir);
+    const auto path = dir / filename;
+    std::ofstream out(path);
+    out << content;
+    out.close();
+    return path;
+}
+
+nlohmann::json make_csv_file_json(const std::filesystem::path &path) {
+    return nlohmann::json{{"name", path.string()},
+                          {"format", "csv"},
+                          {"delimiter", ","},
+                          {"encoding", "ASCII"},
+                          {"columns", {{"quantile", "double"}}}};
+}
+
+void seed_finch_kevin_hall_food_factors(hgps::Person &person) {
+    using namespace hgps;
+    static constexpr std::array<const char *, 3> k_food_keys = {"FoodCarbohydrate", "FoodProtein",
+                                                                "FoodFat"};
+    for (const auto *key : k_food_keys) {
+        person.risk_factors[core::Identifier(key)] = 50.0;
+    }
+    person.risk_factors["PhysicalActivity"_id] = 1.4;
+    person.risk_factors["EnergyIntake"_id] = 8000.0;
+}
+
+struct KevinHallWeightRuntime {
+    std::unique_ptr<hgps::RiskFactorModelDefinition> definition_storage;
+    std::unique_ptr<hgps::RiskFactorModel> model_storage;
+    hgps::KevinHallModel *model{nullptr};
+    hgps::RuntimeContext context;
+};
+
+KevinHallWeightRuntime make_kevin_hall_weight_runtime(const nlohmann::json &dynamic_json,
+                                                      const hgps::input::Configuration &config,
+                                                      std::size_t population_size,
+                                                      int start_year = 2020) {
+    using namespace hgps;
+    using namespace hgps::core;
+
+    auto definition_storage =
+        hgps::input::load_kevinhall_risk_model_definition(dynamic_json, config);
+    if (!definition_storage) {
+        throw HgpsException("Failed to load Kevin Hall model definition");
+    }
+    auto model_storage = definition_storage->create_model();
+    auto *kevin_hall = dynamic_cast<KevinHallModel *>(model_storage.get());
+    if (!kevin_hall) {
+        throw HgpsException("Expected KevinHallModel instance");
+    }
+
+    DataTable data;
+    IntegerDataTableColumnBuilder age_builder("Age");
+    age_builder.append(30);
+    data.add(age_builder.build());
+
+    const auto country = Country{.code = 826, .name = "United Kingdom", .alpha2 = "GB", .alpha3 = "GBR"};
+    const auto settings = Settings{country, 0.1f, IntegerInterval(0, 110)};
+    const auto run = RunInfo{.start_time = static_cast<unsigned int>(start_year),
+                             .stop_time = static_cast<unsigned int>(start_year + 5),
+                             .sync_timeout_ms = 1000,
+                             .seed = 42u};
+    const auto ses = SESDefinition{.fuction_name = "normal", .parameters = {0.0, 1.0}};
+    const auto mapping = HierarchicalMapping(
+        {MappingEntry{"Weight", 0, DoubleInterval{5.0, 200.0}}, MappingEntry{"Age", 0}});
+    auto project_requirements = hgps::input::ProjectRequirements{};
+    project_requirements.income.type = "continuous";
+    project_requirements.income.categories = "4";
+    auto inputs = std::make_shared<ModelInput>(data, settings, run, ses, mapping,
+                                               std::vector<DiseaseInfo>{}, project_requirements,
+                                               hgps::input::PIFInfo{});
+
+    auto bus = std::make_shared<hgps::DefaultEventBus>();
+    hgps::SyncChannel channel;
+    auto scenario = std::make_unique<hgps::BaselineScenario>(channel);
+    hgps::RuntimeContext context(bus, inputs, std::move(scenario));
+    context.reset_population(population_size);
+    context.set_current_time(start_year);
+    context.set_current_run(1);
+
+    return KevinHallWeightRuntime{.definition_storage = std::move(definition_storage),
+                                  .model_storage = std::move(model_storage),
+                                  .model = kevin_hall,
+                                  .context = std::move(context)};
+}
+
+nlohmann::json set_quintile_weight_quantiles(nlohmann::json json,
+                                             const std::filesystem::path &female_base,
+                                             const std::filesystem::path &male_base,
+                                             double female_scale, double male_scale) {
+    auto make_quintile_block = [&](const std::filesystem::path &base, double scale) {
+        nlohmann::json block;
+        for (std::size_t q = 1; q <= 5; ++q) {
+            const auto path = create_temp_weight_quantile_csv(
+                base.filename().string() + "_q" + std::to_string(q) + ".csv",
+                ",quantile\n1," + std::to_string(scale * static_cast<double>(q)) + "\n2," +
+                    std::to_string(scale * static_cast<double>(q) + 0.1) + "\n3," +
+                    std::to_string(scale * static_cast<double>(q) + 0.2) + "\n");
+            block["Quintile" + std::to_string(q)] = make_csv_file_json(path);
+        }
+        return block;
+    };
+
+    json["WeightQuantiles"]["Female"] = make_quintile_block(female_base, female_scale);
+    json["WeightQuantiles"]["Male"] = make_quintile_block(male_base, male_scale);
+    return json;
+}
+
+} // namespace
+
+TEST(KevinHallWeightQuantiles, LegacySingleFileConfigStillLoads) {
+    const auto finch = finch_data_root();
+    if (!std::filesystem::exists(finch / "dynamic_model.json")) {
+        GTEST_SKIP() << "FINCH input data not available at " << finch.string();
+    }
+
+    auto json = hgps::input::load_json(finch / "dynamic_model.json");
+    auto config = make_finch_configuration();
+    auto definition = hgps::input::load_kevinhall_risk_model_definition(json, config);
+    ASSERT_NE(definition, nullptr);
+    EXPECT_NE(definition->create_model(), nullptr);
+}
+
+TEST(KevinHallWeightQuantiles, SingleFileWeightBroadcastLoadsWithFiveStrata) {
+    const auto finch = finch_data_root();
+    if (!std::filesystem::exists(finch / "dynamic_model.json")) {
+        GTEST_SKIP() << "FINCH input data not available at " << finch.string();
+    }
+
+    auto json = hgps::input::load_json(finch / "dynamic_model.json");
+    auto config = make_quintile_stratum_configuration();
+    auto definition = hgps::input::load_kevinhall_risk_model_definition(json, config);
+    ASSERT_NE(definition, nullptr);
+    EXPECT_NE(definition->create_model(), nullptr);
+}
+
+TEST(KevinHallWeightQuantiles, QuintileWeightFilesLoadWhenMatchingStrataCount) {
+    const auto finch = finch_data_root();
+    if (!std::filesystem::exists(finch / "dynamic_model.json")) {
+        GTEST_SKIP() << "FINCH input data not available at " << finch.string();
+    }
+
+    auto json = hgps::input::load_json(finch / "dynamic_model.json");
+    json = set_quintile_weight_quantiles(json, finch / "weight_female", finch / "weight_male", 1.0,
+                                         1.0);
+    auto config = make_quintile_stratum_configuration();
+    auto definition = hgps::input::load_kevinhall_risk_model_definition(json, config);
+    ASSERT_NE(definition, nullptr);
+    EXPECT_NE(definition->create_model(), nullptr);
+}
+
+TEST(KevinHallWeightQuantiles, QuintileWeightFileCountMismatchThrows) {
+    const auto finch = finch_data_root();
+    if (!std::filesystem::exists(finch / "dynamic_model.json")) {
+        GTEST_SKIP() << "FINCH input data not available at " << finch.string();
+    }
+
+    auto json = hgps::input::load_json(finch / "dynamic_model.json");
+    json = set_quintile_weight_quantiles(json, finch / "weight_female", finch / "weight_male", 1.0,
+                                         1.0);
+    json["WeightQuantiles"]["Female"].erase("Quintile5");
+    auto config = make_quintile_stratum_configuration();
+
+    EXPECT_THROW(
+        {
+            auto definition = hgps::input::load_kevinhall_risk_model_definition(json, config);
+            (void)definition;
+        },
+        hgps::core::HgpsException);
+}
+
+TEST(KevinHallWeightQuantiles, QuintileWeightFilesRequireStratumAdjustmentEnabled) {
+    const auto finch = finch_data_root();
+    if (!std::filesystem::exists(finch / "dynamic_model.json")) {
+        GTEST_SKIP() << "FINCH input data not available at " << finch.string();
+    }
+
+    auto json = hgps::input::load_json(finch / "dynamic_model.json");
+    json = set_quintile_weight_quantiles(json, finch / "weight_female", finch / "weight_male", 1.0,
+                                         1.0);
+    auto config = make_finch_configuration();
+
+    EXPECT_THROW(
+        {
+            auto definition = hgps::input::load_kevinhall_risk_model_definition(json, config);
+            (void)definition;
+        },
+        hgps::core::HgpsException);
+}
+
+TEST(KevinHallWeightQuantiles, GeneratePrintsWeightStratumAndIncomeCategoryTables) {
+    using hgps::test::capture_stdout;
+
+    const auto finch = finch_data_root();
+    if (!std::filesystem::exists(finch / "dynamic_model.json")) {
+        GTEST_SKIP() << "FINCH input data not available at " << finch.string();
+    }
+
+    constexpr int start_year = 2020;
+    auto json = hgps::input::load_json(finch / "dynamic_model.json");
+    json = set_quintile_weight_quantiles(json, finch / "weight_female", finch / "weight_male", 1.0,
+                                         1.0);
+    auto config = make_quintile_stratum_configuration();
+    auto runtime = make_kevin_hall_weight_runtime(json, config, 6, start_year);
+
+    for (std::size_t i = 0; i < runtime.context.population().size(); ++i) {
+        auto &person = runtime.context.population()[i];
+        person.gender = hgps::core::Gender::female;
+        person.age = 12;
+        person.income = hgps::core::Income::lowermiddle;
+        person.has_income_adjustment_stratum = true;
+        person.income_adjustment_stratum = i % 5;
+        seed_finch_kevin_hall_food_factors(person);
+    }
+
+    const auto output =
+        capture_stdout([&] { runtime.model->generate_risk_factors(runtime.context); });
+
+    EXPECT_NE(output.find("[WEIGHT STRATUM ASSIGNMENT]"), std::string::npos);
+    EXPECT_NE(output.find("[WEIGHT BY FINAL INCOME CATEGORY]"), std::string::npos);
+    EXPECT_NE(output.find("Quintile1"), std::string::npos);
+    EXPECT_NE(output.find("Quantile Size"), std::string::npos);
+}
+
+TEST(KevinHallWeightQuantiles, DifferentStrataCanProduceDifferentWeights) {
+    using namespace hgps;
+
+    const auto finch = finch_data_root();
+    if (!std::filesystem::exists(finch / "dynamic_model.json")) {
+        GTEST_SKIP() << "FINCH input data not available at " << finch.string();
+    }
+
+    auto json = hgps::input::load_json(finch / "dynamic_model.json");
+    json = set_quintile_weight_quantiles(json, finch / "weight_female", finch / "weight_male", 1.0,
+                                         1.0);
+    auto config = make_quintile_stratum_configuration();
+    auto runtime = make_kevin_hall_weight_runtime(json, config, 2, 2020);
+
+    auto &person0 = runtime.context.population()[0];
+    person0.gender = hgps::core::Gender::female;
+    person0.age = 15;
+    person0.has_income_adjustment_stratum = true;
+    person0.income_adjustment_stratum = 0;
+    seed_finch_kevin_hall_food_factors(person0);
+
+    auto &person1 = runtime.context.population()[1];
+    person1.gender = hgps::core::Gender::female;
+    person1.age = 15;
+    person1.has_income_adjustment_stratum = true;
+    person1.income_adjustment_stratum = 4;
+    seed_finch_kevin_hall_food_factors(person1);
+
+    runtime.model->generate_risk_factors(runtime.context);
+
+    const double weight0 = person0.risk_factors.at("Weight"_id);
+    const double weight1 = person1.risk_factors.at("Weight"_id);
+    EXPECT_GT(weight0, 0.0);
+    EXPECT_GT(weight1, 0.0);
+    EXPECT_NE(weight0, weight1);
+}

--- a/src/HealthGPS.Tests/KevinHallWeightQuantiles.Test.cpp
+++ b/src/HealthGPS.Tests/KevinHallWeightQuantiles.Test.cpp
@@ -110,7 +110,8 @@ KevinHallWeightRuntime make_kevin_hall_weight_runtime(const nlohmann::json &dyna
     age_builder.append(30);
     data.add(age_builder.build());
 
-    const auto country = Country{.code = 826, .name = "United Kingdom", .alpha2 = "GB", .alpha3 = "GBR"};
+    const auto country =
+        Country{.code = 826, .name = "United Kingdom", .alpha2 = "GB", .alpha3 = "GBR"};
     const auto settings = Settings{country, 0.1f, IntegerInterval(0, 110)};
     const auto run = RunInfo{.start_time = static_cast<unsigned int>(start_year),
                              .stop_time = static_cast<unsigned int>(start_year + 5),
@@ -122,9 +123,9 @@ KevinHallWeightRuntime make_kevin_hall_weight_runtime(const nlohmann::json &dyna
     auto project_requirements = hgps::input::ProjectRequirements{};
     project_requirements.income.type = "continuous";
     project_requirements.income.categories = "4";
-    auto inputs = std::make_shared<ModelInput>(data, settings, run, ses, mapping,
-                                               std::vector<DiseaseInfo>{}, project_requirements,
-                                               hgps::input::PIFInfo{});
+    auto inputs =
+        std::make_shared<ModelInput>(data, settings, run, ses, mapping, std::vector<DiseaseInfo>{},
+                                     project_requirements, hgps::input::PIFInfo{});
 
     auto bus = std::make_shared<hgps::DefaultEventBus>();
     hgps::SyncChannel channel;

--- a/src/HealthGPS.Tests/KevinHallWeightQuantiles.Test.cpp
+++ b/src/HealthGPS.Tests/KevinHallWeightQuantiles.Test.cpp
@@ -151,8 +151,8 @@ nlohmann::json set_quintile_weight_quantiles(nlohmann::json json,
             const auto path = create_temp_weight_quantile_csv(
                 base.filename().string() + "_q" + std::to_string(q) + ".csv",
                 ",quantile\n1," + std::to_string(scale * static_cast<double>(q)) + "\n2," +
-                    std::to_string(scale * static_cast<double>(q) + 0.1) + "\n3," +
-                    std::to_string(scale * static_cast<double>(q) + 0.2) + "\n");
+                    std::to_string((scale * static_cast<double>(q)) + 0.1) + "\n3," +
+                    std::to_string((scale * static_cast<double>(q)) + 0.2) + "\n");
             block["Quintile" + std::to_string(q)] = make_csv_file_json(path);
         }
         return block;

--- a/src/HealthGPS/kevin_hall_model.cpp
+++ b/src/HealthGPS/kevin_hall_model.cpp
@@ -46,7 +46,7 @@ std::string gender_label(const hgps::Person &person) {
     return "unknown";
 }
 
-bool should_print_height_summary_tables(const hgps::RuntimeContext &context) {
+bool should_print_kevin_hall_summary_tables(const hgps::RuntimeContext &context) {
     // MAHIMA: Keep console reporting limited to baseline start and first update year so
     // diagnostics remain useful without flooding long simulation logs.
     if (context.scenario().type() != hgps::ScenarioType::baseline) {
@@ -65,6 +65,22 @@ struct HeightBucketSummary {
     double height_max{std::numeric_limits<double>::lowest()};
     double height_sum{0.0};
 };
+
+const std::vector<double> &resolve_weight_quantiles_for_person(
+    const hgps::Person &person,
+    const std::unordered_map<hgps::core::Gender, std::vector<std::vector<double>>>
+        &weight_quantiles_by_stratum) {
+    const auto by_gender = weight_quantiles_by_stratum.find(person.gender);
+    if (by_gender == weight_quantiles_by_stratum.end() || by_gender->second.empty()) {
+        throw hgps::core::HgpsException("Weight quantiles missing for person gender");
+    }
+    const auto &params = by_gender->second;
+    if (!person.has_income_adjustment_stratum) {
+        return params.front();
+    }
+    const std::size_t index = std::min(person.income_adjustment_stratum, params.size() - 1);
+    return params[index];
+}
 
 const hgps::HeightModelParams &resolve_height_params_for_person(
     const hgps::Person &person,
@@ -148,6 +164,152 @@ void print_height_stratum_assignment_table(
     }
     out << "+--------+----------------------+-------+-------------+-------------+-------------+"
            "-------------+-------------+\n";
+    std::osyncstream(std::cout) << out.str();
+}
+
+struct WeightBucketSummary {
+    std::size_t count{0};
+    std::size_t quantile_size{0};
+    double weight_min{std::numeric_limits<double>::max()};
+    double weight_max{std::numeric_limits<double>::lowest()};
+    double weight_sum{0.0};
+};
+
+void print_weight_stratum_assignment_table(
+    const hgps::Population &population,
+    const std::unordered_map<hgps::core::Gender, std::vector<std::vector<double>>>
+        &weight_quantiles_by_stratum,
+    std::size_t bucket_count, int year, std::string_view phase) {
+    if (bucket_count == 0) {
+        return;
+    }
+
+    const hgps::core::Identifier weight_id("Weight");
+    std::vector<WeightBucketSummary> summaries(bucket_count);
+    for (const auto &person : population) {
+        if (!person.is_active() || !person.has_income_adjustment_stratum ||
+            person.income_adjustment_stratum >= bucket_count) {
+            continue;
+        }
+        auto weight_it = person.risk_factors.find(weight_id);
+        if (weight_it == person.risk_factors.end()) {
+            continue;
+        }
+
+        const auto &quantiles =
+            resolve_weight_quantiles_for_person(person, weight_quantiles_by_stratum);
+        auto &summary = summaries[person.income_adjustment_stratum];
+        summary.count++;
+        summary.quantile_size = quantiles.size();
+        const double weight = weight_it->second;
+        summary.weight_sum += weight;
+        summary.weight_min = std::min(summary.weight_min, weight);
+        summary.weight_max = std::max(summary.weight_max, weight);
+    }
+
+    std::ostringstream out;
+    out << "\n[WEIGHT STRATUM ASSIGNMENT] Year " << year << " phase=" << phase
+        << " (uses person.income_adjustment_stratum from static model)\n";
+    out << "+--------+----------------------+-------+---------------+-------------+-------------+"
+           "-------------+\n";
+    out << "| Bucket | Stratum ID           | Count | Quantile Size | Weight Min  | Weight Max  | "
+           "Weight Mean |\n";
+    out << "+--------+----------------------+-------+---------------+-------------+-------------+"
+           "-------------+\n";
+    for (std::size_t k = 0; k < bucket_count; ++k) {
+        const auto &summary = summaries[k];
+        const std::string stratum_id = "Quintile" + std::to_string(k + 1);
+        out << "| " << std::setw(6) << k << " | " << std::setw(20) << std::left << stratum_id
+            << std::right << " | " << std::setw(5) << summary.count << " | ";
+        if (summary.count == 0) {
+            out << std::setw(13) << "n/a"
+                << " | " << std::setw(11) << "n/a"
+                << " | " << std::setw(11) << "n/a"
+                << " | " << std::setw(11) << "n/a";
+        } else {
+            const auto n = static_cast<double>(summary.count);
+            out << std::setw(13) << summary.quantile_size << " | " << std::setw(11)
+                << fmt::format("{:.3f}", summary.weight_min) << " | " << std::setw(11)
+                << fmt::format("{:.3f}", summary.weight_max) << " | " << std::setw(11)
+                << fmt::format("{:.3f}", summary.weight_sum / n);
+        }
+        out << " |\n";
+    }
+    out << "+--------+----------------------+-------+---------------+-------------+-------------+"
+           "-------------+\n";
+    std::osyncstream(std::cout) << out.str();
+}
+
+void print_weight_by_final_income_category_table(const hgps::Population &population,
+                                                 std::string_view categories, int year,
+                                                 std::string_view phase) {
+    const auto cat_count = categories == "4" ? 4u : 3u;
+    const hgps::core::Identifier weight_id("Weight");
+    std::vector<WeightBucketSummary> summaries(cat_count);
+
+    for (const auto &person : population) {
+        if (!person.is_active()) {
+            continue;
+        }
+        auto weight_it = person.risk_factors.find(weight_id);
+        if (weight_it == person.risk_factors.end()) {
+            continue;
+        }
+
+        std::size_t idx = 0;
+        switch (person.income) {
+        case hgps::core::Income::low:
+            idx = 0;
+            break;
+        case hgps::core::Income::lowermiddle:
+        case hgps::core::Income::middle:
+            idx = 1;
+            break;
+        case hgps::core::Income::uppermiddle:
+            idx = 2;
+            break;
+        case hgps::core::Income::high:
+            idx = categories == "4" ? 3u : 2u;
+            break;
+        default:
+            continue;
+        }
+
+        auto &summary = summaries[idx];
+        summary.count++;
+        const double weight = weight_it->second;
+        summary.weight_sum += weight;
+        summary.weight_min = std::min(summary.weight_min, weight);
+        summary.weight_max = std::max(summary.weight_max, weight);
+    }
+
+    std::ostringstream out;
+    out << "\n[WEIGHT BY FINAL INCOME CATEGORY] Year " << year << " phase=" << phase
+        << " project_requirements.categories=" << categories
+        << " (person.income set by static model after quintile adjustment)\n";
+    out << "+----------+--------+-------------+-------------+-------------+\n";
+    out << "| Category | Count  | Weight Min  | Weight Max  | Weight Mean |\n";
+    out << "+----------+--------+-------------+-------------+-------------+\n";
+    const std::vector<std::string> labels =
+        categories == "4" ? std::vector<std::string>{"Low", "LowerMid", "UpperMid", "High"}
+                          : std::vector<std::string>{"Low", "Middle", "High"};
+    for (std::size_t i = 0; i < summaries.size(); ++i) {
+        const auto &summary = summaries[i];
+        out << "| " << std::setw(8) << std::left << labels[i] << std::right << " | " << std::setw(6)
+            << summary.count << " | ";
+        if (summary.count == 0) {
+            out << std::setw(11) << "n/a"
+                << " | " << std::setw(11) << "n/a"
+                << " | " << std::setw(11) << "n/a";
+        } else {
+            out << std::setw(11) << fmt::format("{:.3f}", summary.weight_min) << " | "
+                << std::setw(11) << fmt::format("{:.3f}", summary.weight_max) << " | "
+                << std::setw(11)
+                << fmt::format("{:.3f}", summary.weight_sum / static_cast<double>(summary.count));
+        }
+        out << " |\n";
+    }
+    out << "+----------+--------+-------------+-------------+-------------+\n";
     std::osyncstream(std::cout) << out.str();
 }
 
@@ -242,15 +404,16 @@ KevinHallModel::KevinHallModel(
     const std::unordered_map<core::Identifier, std::map<core::Identifier, double>>
         &nutrient_equations,
     const std::unordered_map<core::Identifier, std::optional<double>> &food_prices,
-    const std::unordered_map<core::Gender, std::vector<double>> &weight_quantiles,
+    const std::unordered_map<core::Gender, std::vector<std::vector<double>>>
+        &weight_quantiles_by_stratum,
     const std::vector<double> &epa_quantiles,
     std::unordered_map<core::Gender, std::vector<HeightModelParams>> height_params)
     : RiskFactorAdjustableModel{std::move(expected), std::move(expected_trend),
                                 std::move(trend_steps)},
       energy_equation_{energy_equation}, nutrient_ranges_{nutrient_ranges},
       nutrient_equations_{nutrient_equations}, food_prices_{food_prices},
-      weight_quantiles_{weight_quantiles}, epa_quantiles_{epa_quantiles},
-      height_params_{std::move(height_params)} {}
+      weight_quantiles_by_stratum_{weight_quantiles_by_stratum},
+      epa_quantiles_{epa_quantiles}, height_params_{std::move(height_params)} {}
 
 RiskFactorModelType KevinHallModel::type() const noexcept { return RiskFactorModelType::Dynamic; }
 
@@ -289,6 +452,7 @@ void KevinHallModel::generate_risk_factors(RuntimeContext &context) {
     }
 
     print_height_summary_tables(context, "generate");
+    print_weight_summary_tables(context, "generate");
 }
 
 void KevinHallModel::update_risk_factors(RuntimeContext &context) {
@@ -368,6 +532,7 @@ void KevinHallModel::update_newborns(RuntimeContext &context) const {
     }
 
     print_height_summary_tables(context, "update-newborns");
+    print_weight_summary_tables(context, "update-newborns");
 }
 
 void KevinHallModel::update_non_newborns(RuntimeContext &context) const {
@@ -439,6 +604,7 @@ void KevinHallModel::update_non_newborns(RuntimeContext &context) const {
     }
 
     print_height_summary_tables(context, "update-children");
+    print_weight_summary_tables(context, "update-children");
 }
 
 KevinHallAdjustmentTable KevinHallModel::receive_weight_adjustments(RuntimeContext &context) const {
@@ -903,7 +1069,9 @@ void KevinHallModel::initialise_weight(RuntimeContext &context, Person &person) 
     // Compute new weight.
     double w_expected =
         get_expected(context, person.gender, person.age, "Weight"_id, std::nullopt, true);
-    double w_quantile = get_weight_quantile(epa_quantile, person.gender);
+    const auto &weight_quantiles =
+        resolve_weight_quantiles_for_person(person, weight_quantiles_by_stratum_);
+    double w_quantile = get_weight_quantile(epa_quantile, weight_quantiles);
     person.risk_factors["Weight"_id] = w_expected * w_quantile;
     validate_weight_in_config_range(context, person, "initialise_weight");
 }
@@ -1024,7 +1192,11 @@ void KevinHallModel::validate_weight_in_config_range(const RuntimeContext &conte
     throw core::HgpsException(message.str());
 }
 
-double KevinHallModel::get_weight_quantile(double epa_quantile, core::Gender sex) const {
+double KevinHallModel::get_weight_quantile(double epa_quantile,
+                                           const std::vector<double> &quantiles) const {
+    if (quantiles.empty()) {
+        throw core::HgpsException("Weight quantile curve is empty");
+    }
 
     // Compute Energy Physical Activity percentile (taking midpoint of duplicates).
     auto epa_range = std::equal_range(epa_quantiles_.begin(), epa_quantiles_.end(), epa_quantile);
@@ -1033,9 +1205,9 @@ double KevinHallModel::get_weight_quantile(double epa_quantile, core::Gender sex
     auto epa_percentile = epa_index / epa_quantiles_.size();
 
     // Find weight quantile.
-    size_t weight_index_last = weight_quantiles_.at(sex).size() - 1;
-    auto weight_index = static_cast<size_t>(epa_percentile * weight_index_last);
-    return weight_quantiles_.at(sex)[weight_index];
+    const size_t weight_index_last = quantiles.size() - 1;
+    const auto weight_index = static_cast<size_t>(epa_percentile * weight_index_last);
+    return quantiles[weight_index];
 }
 
 KevinHallAdjustmentTable
@@ -1173,9 +1345,30 @@ void KevinHallModel::update_height(RuntimeContext &context, Person &person,
     person.risk_factors["Height"_id] = H;
 }
 
+void KevinHallModel::print_weight_summary_tables(RuntimeContext &context,
+                                               std::string_view phase) const {
+    if (!should_print_kevin_hall_summary_tables(context)) {
+        return;
+    }
+
+    std::size_t bucket_count = 0;
+    for (const auto &[gender, by_stratum] : weight_quantiles_by_stratum_) {
+        (void)gender;
+        bucket_count = std::max(bucket_count, by_stratum.size());
+    }
+    bucket_count = std::max<std::size_t>(bucket_count, 1);
+
+    print_weight_stratum_assignment_table(context.population(), weight_quantiles_by_stratum_,
+                                          bucket_count, context.time_now(), phase);
+
+    const auto &categories = context.inputs().project_requirements().income.categories;
+    print_weight_by_final_income_category_table(context.population(), categories,
+                                                context.time_now(), phase);
+}
+
 void KevinHallModel::print_height_summary_tables(RuntimeContext &context,
                                                  std::string_view phase) const {
-    if (!should_print_height_summary_tables(context)) {
+    if (!should_print_kevin_hall_summary_tables(context)) {
         return;
     }
 
@@ -1201,15 +1394,16 @@ KevinHallModelDefinition::KevinHallModelDefinition(
     std::unordered_map<core::Identifier, core::DoubleInterval> nutrient_ranges,
     std::unordered_map<core::Identifier, std::map<core::Identifier, double>> nutrient_equations,
     std::unordered_map<core::Identifier, std::optional<double>> food_prices,
-    std::unordered_map<core::Gender, std::vector<double>> weight_quantiles,
+    std::unordered_map<core::Gender, std::vector<std::vector<double>>>
+        weight_quantiles_by_stratum,
     std::vector<double> epa_quantiles,
     std::unordered_map<core::Gender, std::vector<HeightModelParams>> height_params)
     : RiskFactorAdjustableModelDefinition{std::move(expected), std::move(expected_trend),
                                           std::move(trend_steps)},
       energy_equation_{std::move(energy_equation)}, nutrient_ranges_{std::move(nutrient_ranges)},
       nutrient_equations_{std::move(nutrient_equations)}, food_prices_{std::move(food_prices)},
-      weight_quantiles_{std::move(weight_quantiles)}, epa_quantiles_{std::move(epa_quantiles)},
-      height_params_{std::move(height_params)} {
+      weight_quantiles_by_stratum_{std::move(weight_quantiles_by_stratum)},
+      epa_quantiles_{std::move(epa_quantiles)}, height_params_{std::move(height_params)} {
 
     if (energy_equation_.empty()) {
         throw core::HgpsException("Energy equation mapping is empty");
@@ -1223,8 +1417,21 @@ KevinHallModelDefinition::KevinHallModelDefinition(
     if (food_prices_.empty()) {
         throw core::HgpsException("Food prices mapping is empty");
     }
-    if (weight_quantiles_.empty()) {
+    if (weight_quantiles_by_stratum_.empty()) {
         throw core::HgpsException("Weight quantiles mapping is empty");
+    }
+    for (const auto &[gender, by_stratum] : weight_quantiles_by_stratum_) {
+        if (by_stratum.empty()) {
+            throw core::HgpsException(
+                fmt::format("Weight quantiles mapping contains empty stratum list for gender {}",
+                            gender == core::Gender::male ? "male" : "female"));
+        }
+        for (const auto &quantiles : by_stratum) {
+            if (quantiles.empty()) {
+                throw core::HgpsException(
+                    "Weight quantiles mapping contains an empty quantile curve");
+            }
+        }
     }
     if (epa_quantiles_.empty()) {
         throw core::HgpsException("Energy Physical Activity quantiles mapping is empty");
@@ -1242,7 +1449,8 @@ KevinHallModelDefinition::KevinHallModelDefinition(
 std::unique_ptr<RiskFactorModel> KevinHallModelDefinition::create_model() const {
     return std::make_unique<KevinHallModel>(
         expected_, expected_trend_, trend_steps_, energy_equation_, nutrient_ranges_,
-        nutrient_equations_, food_prices_, weight_quantiles_, epa_quantiles_, height_params_);
+        nutrient_equations_, food_prices_, weight_quantiles_by_stratum_, epa_quantiles_,
+        height_params_);
 }
 
 } // namespace hgps

--- a/src/HealthGPS/kevin_hall_model.cpp
+++ b/src/HealthGPS/kevin_hall_model.cpp
@@ -412,8 +412,8 @@ KevinHallModel::KevinHallModel(
                                 std::move(trend_steps)},
       energy_equation_{energy_equation}, nutrient_ranges_{nutrient_ranges},
       nutrient_equations_{nutrient_equations}, food_prices_{food_prices},
-      weight_quantiles_by_stratum_{weight_quantiles_by_stratum},
-      epa_quantiles_{epa_quantiles}, height_params_{std::move(height_params)} {}
+      weight_quantiles_by_stratum_{weight_quantiles_by_stratum}, epa_quantiles_{epa_quantiles},
+      height_params_{std::move(height_params)} {}
 
 RiskFactorModelType KevinHallModel::type() const noexcept { return RiskFactorModelType::Dynamic; }
 
@@ -1346,7 +1346,7 @@ void KevinHallModel::update_height(RuntimeContext &context, Person &person,
 }
 
 void KevinHallModel::print_weight_summary_tables(RuntimeContext &context,
-                                               std::string_view phase) const {
+                                                 std::string_view phase) const {
     if (!should_print_kevin_hall_summary_tables(context)) {
         return;
     }
@@ -1394,8 +1394,7 @@ KevinHallModelDefinition::KevinHallModelDefinition(
     std::unordered_map<core::Identifier, core::DoubleInterval> nutrient_ranges,
     std::unordered_map<core::Identifier, std::map<core::Identifier, double>> nutrient_equations,
     std::unordered_map<core::Identifier, std::optional<double>> food_prices,
-    std::unordered_map<core::Gender, std::vector<std::vector<double>>>
-        weight_quantiles_by_stratum,
+    std::unordered_map<core::Gender, std::vector<std::vector<double>>> weight_quantiles_by_stratum,
     std::vector<double> epa_quantiles,
     std::unordered_map<core::Gender, std::vector<HeightModelParams>> height_params)
     : RiskFactorAdjustableModelDefinition{std::move(expected), std::move(expected_trend),
@@ -1447,10 +1446,10 @@ KevinHallModelDefinition::KevinHallModelDefinition(
 }
 
 std::unique_ptr<RiskFactorModel> KevinHallModelDefinition::create_model() const {
-    return std::make_unique<KevinHallModel>(
-        expected_, expected_trend_, trend_steps_, energy_equation_, nutrient_ranges_,
-        nutrient_equations_, food_prices_, weight_quantiles_by_stratum_, epa_quantiles_,
-        height_params_);
+    return std::make_unique<KevinHallModel>(expected_, expected_trend_, trend_steps_,
+                                            energy_equation_, nutrient_ranges_, nutrient_equations_,
+                                            food_prices_, weight_quantiles_by_stratum_,
+                                            epa_quantiles_, height_params_);
 }
 
 } // namespace hgps

--- a/src/HealthGPS/kevin_hall_model.h
+++ b/src/HealthGPS/kevin_hall_model.h
@@ -195,8 +195,7 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     /// @brief Returns the weight quantile for the given E/PA quantile and stratum quantile curve.
     /// @param epa_quantile The Energy / Physical Activity quantile.
     /// @param quantiles Sorted weight quantiles for the person's adjustment stratum.
-    double get_weight_quantile(double epa_quantile,
-                               const std::vector<double> &quantiles) const;
+    double get_weight_quantile(double epa_quantile, const std::vector<double> &quantiles) const;
 
     /// @brief Compute the mean of weight (optionally raised to a power) for each sex and age
     /// @param population The population to compute the mean for

--- a/src/HealthGPS/kevin_hall_model.h
+++ b/src/HealthGPS/kevin_hall_model.h
@@ -34,7 +34,8 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     /// @param nutrient_ranges The interval boundaries for nutrient values
     /// @param nutrient_equations The nutrient coefficients for each food group
     /// @param food_prices The unit price for each food group
-    /// @param weight_quantiles The weight quantiles (must be sorted)
+    /// @param weight_quantiles_by_stratum Weight quantiles by gender and income adjustment stratum
+    /// (each inner vector must be sorted).
     /// @param epa_quantiles The Energy / Physical Activity quantiles (must be sorted)
     /// @param height_params Height model parameters by gender and income adjustment stratum.
     ///        Index 0 is the fallback/default stratum used for legacy scalar config.
@@ -47,7 +48,8 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
         const std::unordered_map<core::Identifier, std::map<core::Identifier, double>>
             &nutrient_equations,
         const std::unordered_map<core::Identifier, std::optional<double>> &food_prices,
-        const std::unordered_map<core::Gender, std::vector<double>> &weight_quantiles,
+        const std::unordered_map<core::Gender, std::vector<std::vector<double>>>
+            &weight_quantiles_by_stratum,
         const std::vector<double> &epa_quantiles,
         std::unordered_map<core::Gender, std::vector<HeightModelParams>> height_params);
 
@@ -190,10 +192,11 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
                         const core::Identifier &factor, OptionalRange range,
                         bool apply_trend) const override;
 
-    /// @brief Returns the weight quantile for the given E overPA quantile and sex.
+    /// @brief Returns the weight quantile for the given E/PA quantile and stratum quantile curve.
     /// @param epa_quantile The Energy / Physical Activity quantile.
-    /// @param sex The sex of the person.
-    double get_weight_quantile(double epa_quantile, core::Gender sex) const;
+    /// @param quantiles Sorted weight quantiles for the person's adjustment stratum.
+    double get_weight_quantile(double epa_quantile,
+                               const std::vector<double> &quantiles) const;
 
     /// @brief Compute the mean of weight (optionally raised to a power) for each sex and age
     /// @param population The population to compute the mean for
@@ -225,12 +228,16 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     /// @brief Print height stratum and final-income-category summary tables (baseline only).
     void print_height_summary_tables(RuntimeContext &context, std::string_view phase) const;
 
+    /// @brief Print weight stratum and final-income-category summary tables (baseline only).
+    void print_weight_summary_tables(RuntimeContext &context, std::string_view phase) const;
+
     const std::unordered_map<core::Identifier, double> &energy_equation_;
     const std::unordered_map<core::Identifier, core::DoubleInterval> &nutrient_ranges_;
     const std::unordered_map<core::Identifier, std::map<core::Identifier, double>>
         &nutrient_equations_;
     const std::unordered_map<core::Identifier, std::optional<double>> &food_prices_;
-    const std::unordered_map<core::Gender, std::vector<double>> &weight_quantiles_;
+    const std::unordered_map<core::Gender, std::vector<std::vector<double>>>
+        &weight_quantiles_by_stratum_;
     const std::vector<double> &epa_quantiles_;
     std::unordered_map<core::Gender, std::vector<HeightModelParams>> height_params_;
 
@@ -260,7 +267,8 @@ class KevinHallModelDefinition final : public RiskFactorAdjustableModelDefinitio
     /// @param nutrient_ranges The interval boundaries for nutrient values
     /// @param nutrient_equations The nutrient coefficients for each food group
     /// @param food_prices The unit price for each food group
-    /// @param weight_quantiles The weight quantiles (must be sorted)
+    /// @param weight_quantiles_by_stratum Weight quantiles by gender and income adjustment stratum
+    /// (each inner vector must be sorted).
     /// @param epa_quantiles The Energy / Physical Activity quantiles (must be sorted)
     /// @param height_params Height model parameters by gender and income adjustment stratum.
     /// @throws std::invalid_argument for empty arguments
@@ -272,7 +280,8 @@ class KevinHallModelDefinition final : public RiskFactorAdjustableModelDefinitio
         std::unordered_map<core::Identifier, core::DoubleInterval> nutrient_ranges,
         std::unordered_map<core::Identifier, std::map<core::Identifier, double>> nutrient_equations,
         std::unordered_map<core::Identifier, std::optional<double>> food_prices,
-        std::unordered_map<core::Gender, std::vector<double>> weight_quantiles,
+        std::unordered_map<core::Gender, std::vector<std::vector<double>>>
+            weight_quantiles_by_stratum,
         std::vector<double> epa_quantiles,
         std::unordered_map<core::Gender, std::vector<HeightModelParams>> height_params);
 
@@ -285,7 +294,7 @@ class KevinHallModelDefinition final : public RiskFactorAdjustableModelDefinitio
     std::unordered_map<core::Identifier, core::DoubleInterval> nutrient_ranges_;
     std::unordered_map<core::Identifier, std::map<core::Identifier, double>> nutrient_equations_;
     std::unordered_map<core::Identifier, std::optional<double>> food_prices_;
-    std::unordered_map<core::Gender, std::vector<double>> weight_quantiles_;
+    std::unordered_map<core::Gender, std::vector<std::vector<double>>> weight_quantiles_by_stratum_;
     std::vector<double> epa_quantiles_;
     std::unordered_map<core::Gender, std::vector<HeightModelParams>> height_params_;
 };

--- a/src/HealthGPS/kevin_hall_model.h
+++ b/src/HealthGPS/kevin_hall_model.h
@@ -230,6 +230,7 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     /// @brief Print weight stratum and final-income-category summary tables (baseline only).
     void print_weight_summary_tables(RuntimeContext &context, std::string_view phase) const;
 
+    // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members) references to model definition data
     const std::unordered_map<core::Identifier, double> &energy_equation_;
     const std::unordered_map<core::Identifier, core::DoubleInterval> &nutrient_ranges_;
     const std::unordered_map<core::Identifier, std::map<core::Identifier, double>>
@@ -238,6 +239,7 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     const std::unordered_map<core::Gender, std::vector<std::vector<double>>>
         &weight_quantiles_by_stratum_;
     const std::vector<double> &epa_quantiles_;
+    // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
     std::unordered_map<core::Gender, std::vector<HeightModelParams>> height_params_;
 
     // Model parameters.

--- a/src/HealthGPS/kevin_hall_model.h
+++ b/src/HealthGPS/kevin_hall_model.h
@@ -230,7 +230,8 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
     /// @brief Print weight stratum and final-income-category summary tables (baseline only).
     void print_weight_summary_tables(RuntimeContext &context, std::string_view phase) const;
 
-    // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members) references to model definition data
+    // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members) references to model definition
+    // data
     const std::unordered_map<core::Identifier, double> &energy_equation_;
     const std::unordered_map<core::Identifier, core::DoubleInterval> &nutrient_ranges_;
     const std::unordered_map<core::Identifier, std::map<core::Identifier, double>>


### PR DESCRIPTION
Implemented weight quantiles by income adjustment stratum per the plan. Summary:

Schema
[schemas/v2/config/models/kevinhall.json](vscode-file://vscode-app/c:/Program%20Files/cursor/resources/app/out/vs/code/electron-sandbox/workbench/schemas/v2/config/models/kevinhall.json) and [schemas/v1/config/models/kevinhall.json](vscode-file://vscode-app/c:/Program%20Files/cursor/resources/app/out/vs/code/electron-sandbox/workbench/schemas/v1/config/models/kevinhall.json): WeightQuantiles.Female / Male are oneOf legacy csv_file or Quintile1…QuintileN objects.

Parser ([model_parser.cpp](vscode-file://vscode-app/c:/Program%20Files/cursor/resources/app/out/vs/code/electron-sandbox/workbench/src/HealthGPS.Input/model_parser.cpp))
load_gender_weight_quantiles_by_stratum: legacy single file (broadcast to N when stratum adjustment is on), or explicit quintile files validated against adjustment_income_stratum_count.
Quintile keys must be contiguous Quintile1…QuintileN; quintile layout requires stratum adjustment enabled.

Runtime ([kevin_hall_model.h](vscode-file://vscode-app/c:/Program%20Files/cursor/resources/app/out/vs/code/electron-sandbox/workbench/src/HealthGPS/kevin_hall_model.h) / [kevin_hall_model.cpp](vscode-file://vscode-app/c:/Program%20Files/cursor/resources/app/out/vs/code/electron-sandbox/workbench/src/HealthGPS/kevin_hall_model.cpp))

Storage: weight_quantiles_by_stratum_ (vector<vector<double>> per gender).
resolve_weight_quantiles_for_person + get_weight_quantile(epa, quantiles) used in initialise_weight.
Console tables (baseline, start year and start year + 1):

[WEIGHT STRATUM ASSIGNMENT] — bucket, Quintile ID, count, quantile size, weight min/max/mean.
[WEIGHT BY FINAL INCOME CATEGORY] — same pattern as height.
Printed from generate, update-newborns, and update-children.

Tests & docs
[KevinHallWeightQuantiles.Test.cpp](vscode-file://vscode-app/c:/Program%20Files/cursor/resources/app/out/vs/code/electron-sandbox/workbench/src/HealthGPS.Tests/KevinHallWeightQuantiles.Test.cpp) — legacy load, broadcast, quintile load, mismatch/disabled errors, console output, different-stratum weights.

[Technical Documentations/weight_quantiles_quintile_plan.md](vscode-file://vscode-app/c:/Program%20Files/cursor/resources/app/out/vs/code/electron-sandbox/workbench/Technical%20Documentations/weight_quantiles_quintile_plan.md)

FINCH dynamic_model.json
Left on legacy single-file WeightQuantiles (no quintile CSVs in the repo yet). When quintile files exist, nest them under Female.Quintile1…Quintile5 as in the plan.