### PR TITLE
unique ID

### DIFF
--- a/Technical Documentations/same_person_id_across_baseline_and_intervention-plan.md
+++ b/Technical Documentations/same_person_id_across_baseline_and_intervention-plan.md
@@ -1,7 +1,21 @@
 ---
 name: Same person ID across baseline and intervention
 overview: Assign Person IDs from population index (id = index + 1) so the same logical person has the same ID in both baseline and intervention runs. Changes are limited to Person and Population with MAHIMA comments; no change to scenario logic or event bus.
-todos: []
+todos:
+  - id: confirm-baseline-sync-contract
+    content: Confirm and document baseline -> intervention sync contract (aggregate tables only, one-way) in the plan and implementation notes.
+  - id: add-population-next-id-counter
+    content: Add Population monotonic next_person_id_ state initialised to initial_size + 1 after initial population construction.
+  - id: switch-post-initial-id-assignment
+    content: Update Population add and add_newborn_babies so all post-initial entrants get ID from next_person_id_++ on both recycled-slot and append paths.
+  - id: preserve-initial-id-alignment
+    content: Keep initial ID assignment as i + 1 to preserve baseline/intervention initial cohort comparability.
+  - id: refresh-tests-lifetime-unique
+    content: Replace slot-reuse ID assertions with lifetime-unique assertions in Population tests, including recycled-slot replacement cases.
+  - id: validate-individual-tracking-behavior
+    content: Validate tracking output expectations (no demographic identity swapping under one ID due to slot reuse) with targeted run/test checks.
+  - id: performance-memory-check
+    content: Record runtime and memory impact checks for large runs (including 14M-population assumptions and observed deltas).
 isProject: false
 ---
 
@@ -16,6 +30,13 @@ Make the same logical person have the **same ID** in both baseline and intervent
 - **Scenario code** (physical_activity, marketing, food_labelling, fiscal): Each scenario holds its own `interventions_book`_ keyed by `entity.id()`. Baseline and intervention are separate Simulation/Scenario instances, so they have separate maps. Same ID in both runs does not cause collision.
 - **No global ID key**: No code keys data globally by Person ID across runs; IDs are only used within one population.
 - **result_file_writer.cpp** `message.id()` is `ResultEventMessage::id()` (event type enum), not Person ID — no change.
+
+## What data is transferred 
+Only aggregate tables, not person-level records:
+
+NetImmigrationMessage = age x gender net migration table
+ResidualMortalityMessage = age x gender residual mortality rates
+No person object, no ID, no region/ethnicity individual records are transferred between scenarios.
 
 ## Design: ID assignment rules
 
@@ -103,3 +124,200 @@ flowchart LR
 2. Population: constructor, then add_newborn_babies, then add, with comments.
 3. Run existing tests; fix any that assume previous ID behaviour (only Population tests might need a new case).
 4. Add the new Population test for index-based ID.
+
+---
+
+## Update: Lifetime-unique ID strategy (no ID reuse after death/emigration)
+
+### Why this update is needed
+
+The implemented slot-based rule (`ID = slot index + 1`) achieved baseline/intervention alignment
+for initial people, but it also reuses IDs when dead/emigrated slots are recycled. That allows one
+ID to represent multiple different people over time (e.g. changed sex/age/region/ethnicity in
+tracking), which breaks lifetime person identity.
+
+### Updated objective
+
+- Keep baseline/intervention comparability for the initial cohort.
+- Ensure each person gets a unique ID for their lifetime within a run.
+- Never reuse a dead/emigrated person ID.
+- Preserve runtime and memory efficiency.
+
+### Updated design (minimal changes)
+
+1. Keep initial population IDs deterministic and aligned across scenarios:
+   - Initial slot `i` still gets ID `i + 1`.
+2. Add a Population-owned monotonic counter:
+   - `next_person_id_` in `Population` private state.
+   - Initialise to `initial_size + 1` after population construction.
+3. For all post-initial entrants (newborns and `add()` entities):
+   - Assign `ID = next_person_id_++` regardless of recycled or appended slot.
+4. Continue slot recycling for memory efficiency:
+   - Reuse memory slots, not person IDs.
+
+### Why this preserves performance
+
+- **Runtime:** still O(1) ID assignment (one increment + assignment per new entity).
+- **Memory:** one extra `std::size_t` per `Population` object (negligible).
+- **No extra maps/sets/lookups**, so no added per-entity search or hash overhead.
+
+### Baseline/intervention compatibility after update
+
+- Initial individuals still align by ID across baseline and intervention (`1..N`).
+- IDs for births/immigration remain unique and non-reused within each scenario run.
+- Existing scenario event logic remains valid since it already treats `entity.id()` as opaque key.
+
+### Delta to implementation steps
+
+#### 1) Population only (primary behavior change)
+
+- **[population.h](src/HealthGPS/population.h)**
+  - Add `std::size_t next_person_id_{1};` private member.
+
+- **[population.cpp](src/HealthGPS/population.cpp)**
+  - Constructor:
+    - Keep initial construction with `Person(i + 1)`.
+    - Set `next_person_id_ = size + 1`.
+  - `add(Person, time)`:
+    - After placing person in recycled slot or push-back slot, call
+      `set_id(next_person_id_++)` (not slot index based).
+  - `add_newborn_babies(number, gender, time)`:
+    - On both recycled-slot and append paths, assign IDs from `next_person_id_++`.
+
+#### 2) Person
+
+- No new API required beyond existing `set_id` and constructors.
+- Keep current `Person{}` and `Person(gender)` behavior unchanged.
+
+#### 3) Tests update
+
+- **[Population.Test.cpp](src/HealthGPS.Tests/Population.Test.cpp)**
+  - Replace/extend slot-based ID assertions to lifetime-unique assertions:
+    - Initial IDs are deterministic (`1..init_size`).
+    - Recycled-slot replacement gets a fresh new ID (not old slot ID).
+    - IDs are never duplicated in the exercised sequence.
+
+### Validation checklist (updated)
+
+1. Run `Population.Test` and ensure lifetime-unique assertions pass.
+2. Run targeted simulation/analysis tests covering individual tracking output.
+3. Smoke-check individual tracking CSV:
+   - Same ID should not switch to a different person profile due to slot recycling.
+4. Confirm no changes to scenario sync behavior between baseline/intervention.
+
+### Summary of why this is better than current implemented version
+
+- Fixes the observed bug where one ID can change demographic identity over time.
+- Maintains cross-scenario comparability for the initial matched population.
+- Keeps memory reuse and near-identical runtime characteristics.
+- Achieves the intended semantics: **slot reuse allowed, ID reuse forbidden**.
+
+## Additional clarifications from review Q&A
+
+### 1) What if a person is alive in intervention but dead in baseline?
+
+This is valid and expected. Baseline and intervention are separate simulation populations; a shared
+starting ID means "same initial person for comparison", not "forced identical life outcome". Policy
+effects can keep someone alive in intervention while baseline has death for the matched starting ID.
+
+### 2) Is scenario data transfer one-way only?
+
+Yes. Synchronisation is baseline -> intervention only. Intervention receives baseline-generated
+aggregate synchronisation tables; intervention does not send these back to baseline.
+
+### 3) What data is transferred across scenarios?
+
+Only aggregate tables, never person-level records:
+
+- `NetImmigrationMessage`: age x gender net migration table.
+- `ResidualMortalityMessage`: age x gender residual mortality table.
+
+No person object, no person ID, no region/ethnicity per-person payload is transferred.
+
+## Before vs updated behavior flowcharts
+
+### Before (implemented slot-based ID reuse)
+
+```mermaid
+flowchart TD
+  startA[PersonInSlot_i_ID_iPlus1] --> deathA[PersonDiesOrEmigrates]
+  deathA --> recycleA[Slot_iMarkedRecyclable]
+  recycleA --> newbornA[NewPersonPlacedInSlot_i]
+  newbornA --> sameIdA[AssignedID_iPlus1_Again]
+  sameIdA --> mixedA[SameIDMapsToDifferentPeopleOverTime]
+```
+
+### Updated (lifetime-unique IDs with slot reuse only)
+
+```mermaid
+flowchart TD
+  initB[InitialSlot_i_GetsID_iPlus1] --> counterB[next_person_id_InitialisedTo_NPlus1]
+  counterB --> deathB[PersonDiesOrEmigrates]
+  deathB --> recycleB[Slot_iReusedForMemoryOnly]
+  recycleB --> newPersonB[NewPersonPlacedInRecycledOrNewSlot]
+  newPersonB --> assignB[AssignID_next_person_id_ThenIncrement]
+  assignB --> uniqueB[IDNeverReused_LifetimeUnique]
+```
+
+### Baseline/intervention sync and divergence model
+
+```mermaid
+flowchart LR
+  subgraph base [BaselineRun]
+    baseInit[InitialIDs_1_to_N]
+    baseSync[CreateAggregateTables]
+  end
+  subgraph inter [InterventionRun]
+    interInit[InitialIDs_1_to_N]
+    interReceive[ReceiveAggregateTables]
+    interPolicy[PolicyChangesTrajectory]
+  end
+  baseInit -->|"SameInitialIDMapping"| interInit
+  baseSync -->|"OneWaySync"| interReceive
+  interPolicy --> outcomeDiverge[SameStartID_CanHaveDifferentDeathYear]
+```
+
+## Runtime and memory impact at large scale (14 million people)
+
+### Assumptions for this estimate
+
+- We compare **current slot-based ID assignment** vs **updated monotonic counter assignment**.
+- Both designs keep slot recycling, same person object size, same module order.
+- Only extra state in updated design: one `std::size_t next_person_id_` per `Population`.
+
+### Complexity impact
+
+- Old assignment: O(1) write per new person.
+- Updated assignment: O(1) increment + write per new person.
+- Asymptotic runtime and memory are unchanged.
+
+### Memory delta for 14M population
+
+- Additional memory is **constant**, not proportional to number of people:
+  - `+ sizeof(std::size_t)` (typically 8 bytes) per `Population` object.
+- Approximate delta:
+  - Baseline run population object: +8 bytes.
+  - Intervention run population object: +8 bytes.
+  - Combined additional working memory: about **16 bytes** total (typical 64-bit build).
+
+### Runtime effect estimate (relative)
+
+- Additional operation per newly added entity: one integer increment.
+- Expected wall-time impact is negligible versus existing demographic/risk/disease updates.
+- Practical expectation at 14M scale: near-0% change in overall runtime, while fixing identity
+  correctness.
+
+### Relative impact plot (normalized)
+
+```mermaid
+xychart-beta
+  title "Relative Runtime and Memory Impact (14M Population)"
+  x-axis ["CurrentPlan","UpdatedPlan"]
+  y-axis "Normalized value" 0 --> 1.1
+  bar [1.00,1.00]
+  line [1.00,1.000001]
+```
+
+Notes:
+- Bar = normalized runtime (effectively unchanged at this resolution).
+- Line = normalized extra memory factor (tiny constant increase shown illustratively).

--- a/Technical Documentations/same_person_id_across_baseline_and_intervention-plan.md
+++ b/Technical Documentations/same_person_id_across_baseline_and_intervention-plan.md
@@ -31,7 +31,8 @@ Make the same logical person have the **same ID** in both baseline and intervent
 - **No global ID key**: No code keys data globally by Person ID across runs; IDs are only used within one population.
 - **result_file_writer.cpp** `message.id()` is `ResultEventMessage::id()` (event type enum), not Person ID — no change.
 
-## What data is transferred 
+## What data is transferred
+
 Only aggregate tables, not person-level records:
 
 NetImmigrationMessage = age x gender net migration table
@@ -319,5 +320,6 @@ xychart-beta
 ```
 
 Notes:
+
 - Bar = normalized runtime (effectively unchanged at this resolution).
 - Line = normalized extra memory factor (tiny constant increase shown illustratively).

--- a/Technical Documentations/same_person_id_across_baseline_and_intervention-plan.md
+++ b/Technical Documentations/same_person_id_across_baseline_and_intervention-plan.md
@@ -205,6 +205,8 @@ tracking), which breaks lifetime person identity.
 3. Smoke-check individual tracking CSV:
    - Same ID should not switch to a different person profile due to slot recycling.
 4. Confirm no changes to scenario sync behavior between baseline/intervention.
+5. Debug builds: `Population::allocate_next_person_id()` asserts each new ID equals `next_person_id_`
+   before increment (MAHIMA; no hash set; zero release cost).
 
 ### Summary of why this is better than current implemented version
 

--- a/Technical Documentations/same_person_id_across_baseline_and_intervention-plan.md
+++ b/Technical Documentations/same_person_id_across_baseline_and_intervention-plan.md
@@ -73,7 +73,7 @@ flowchart LR
   - `Person(std::size_t id)` — sets `id_ = id` (for initial population construction).
   - `Person(core::Gender gender, std::size_t id)` — sets gender and `id_ = id` (for newborns).
 - **Add** `void set_id(std::size_t id)` — allows Population to assign ID after placing a person (e.g. immigration clone). Document that it is for internal use by Population.
-- **Keep** existing `Person()` and `Person(gender)` using `++Person::newUID` so standalone construction (tests, any code outside Population) remains unchanged and tests that expect distinct IDs for sequentially created persons still pass.
+- **Person()** / **Person(gender)** leave `id_` at `Person::unassigned_id` (0) until `Population` assigns a lifetime-unique ID via `set_id` or explicit-ID constructors. Removed global `Person::newUID` to avoid duplicate-ID space separate from `Population::next_person_id_`.
 - **Comments**: Add a short MAHIMA block at the top of the ID-related section explaining index-based ID for same-person tracking across baseline and intervention.
 
 ### 2. Population ([population.h](src/HealthGPS/population.h), [population.cpp](src/HealthGPS/population.cpp))
@@ -91,8 +91,8 @@ flowchart LR
 
 ### 3. Tests ([Population.Test.cpp](src/HealthGPS.Tests/Population.Test.cpp))
 
-- **CreateUniquePerson**: Currently expects `p2.id() > p1.id()` and `p1.id() == p3.id()`. `p3` is a reference to `p1`, so the second assertion is unchanged. The first relies on global uniqueness for two standalone `Person{}` — leave as-is (still using newUID).
-- **CreateDefaultPerson**: Only checks `p.id() > 0` — still true for newUID.
+- **CreateUniquePerson**: Asserts unassigned default IDs and explicit `set_id` ordering.
+- **CreateDefaultPerson**: Asserts `unassigned_id` until Population placement.
 - **AddSingleNewEntity / AddMultipleNewEntities**: They use `Population(init_size)` and then `add(Person{...})` or `add_newborn_babies(...)`. After our changes:
   - Initial population will have IDs 1..init_size.
   - Added persons will get IDs set by Population (recycled slot ID or new size). No change to test logic required; only IDs may differ from current (still positive and stable per slot).
@@ -100,10 +100,10 @@ flowchart LR
 
 ### 4. No changes to
 
-- **Simulation::partial_clone_entity**: Still returns `Person{}` (newUID). When that clone is passed to `population().add()`, Population will assign the correct slot-based ID via `set_id` — no change to this function.
+- **Simulation::partial_clone_entity**: Returns `Person{}` (unassigned ID). `population().add()` assigns the next lifetime-unique ID via `set_id`.
 - **DemographicModule**: Only assigns age, gender, region, ethnicity to existing `context.population()[index]`; does not create Person objects.
 - **Scenario classes**: They only use `entity.id()` as key within their own map; same ID in baseline and intervention is desired and safe.
-- **reset_id()**: Leave in place; can remain unused or used by tests. No need to call it for index-based ID.
+- **reset_id()** / **newUID**: Removed; all simulation IDs come from `Population::next_person_id_` (and initial `1..N`).
 
 ### 5. Commenting convention (MAHIMA)
 

--- a/src/HealthGPS.Tests/CMakeLists.txt
+++ b/src/HealthGPS.Tests/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(
     PRIVATE "pch.cpp"
             "pch.h"
             "TestConsoleCapture.h"
+            "TestConsoleCapture.cpp"
             "data_config.h"
             "data_config.cpp"
             "AgeGenderTable.Test.cpp"

--- a/src/HealthGPS.Tests/IncomeStratumAdjustment.Test.cpp
+++ b/src/HealthGPS.Tests/IncomeStratumAdjustment.Test.cpp
@@ -157,7 +157,7 @@ std::shared_ptr<hgps::ModelInput> create_physical_activity_model_input(hgps::cor
     data.add(age_builder.build());
 
     auto country = Country{.code = 826, .name = "United Kingdom", .alpha2 = "GB", .alpha3 = "GBR"};
-    auto settings = Settings{country, 0.1f, IntegerInterval(0, 2)};
+    auto settings = Settings{country, 0.1f, IntegerInterval(0, 3)};
     auto run = RunInfo{.start_time = 2022,
                        .stop_time = 2023,
                        .sync_timeout_ms = 1000,
@@ -198,11 +198,12 @@ make_expected_table(const hgps::core::Identifier &factor, double value) {
 
 std::shared_ptr<hgps::RiskFactorSexAgeTable>
 make_expected_table_with_income_and_pa(const hgps::core::Identifier &factor, double factor_value,
-                                       double income_value, double pa_value) {
+                                       const std::vector<double> &income_by_age, double pa_value) {
     auto expected = std::make_shared<hgps::RiskFactorSexAgeTable>();
-    const std::vector<double> factor_row{factor_value, factor_value, factor_value};
-    const std::vector<double> income_row{income_value, income_value, income_value};
-    const std::vector<double> pa_row{pa_value, pa_value, pa_value};
+    const std::size_t age_count = std::max<std::size_t>(income_by_age.size(), 1u);
+    std::vector<double> factor_row(age_count, factor_value);
+    std::vector<double> pa_row(age_count, pa_value);
+    const std::vector<double> &income_row = income_by_age;
     expected->emplace(hgps::core::Gender::male, factor, factor_row);
     expected->emplace(hgps::core::Gender::female, factor, factor_row);
     expected->emplace(hgps::core::Gender::male, hgps::core::Identifier("income"), income_row);
@@ -211,6 +212,14 @@ make_expected_table_with_income_and_pa(const hgps::core::Identifier &factor, dou
     expected->emplace(hgps::core::Gender::female, hgps::core::Identifier("PhysicalActivity"),
                       pa_row);
     return expected;
+}
+
+std::shared_ptr<hgps::RiskFactorSexAgeTable>
+make_expected_table_with_income_and_pa(const hgps::core::Identifier &factor, double factor_value,
+                                       double income_value, double pa_value) {
+    return make_expected_table_with_income_and_pa(
+        factor, factor_value, std::vector<double>{income_value, income_value, income_value},
+        pa_value);
 }
 
 TempCsvPair write_temp_expected_csv_pair(std::string_view suffix, std::size_t age_rows) {
@@ -697,10 +706,11 @@ TEST(IncomeStratumAdjustment, PhysicalActivityAdjustmentUsesConfiguredMappingRan
     person.risk_factors["PhysicalActivity"_id] = 0.8;
 
     auto expected = std::make_shared<RiskFactorSexAgeTable>();
+    // Match create_physical_activity_model_input age range (0..3).
     expected->emplace(core::Gender::female, "PhysicalActivity"_id,
-                      std::vector<double>{2.2, 2.2, 2.2});
+                      std::vector<double>{2.2, 2.2, 2.2, 2.2});
     expected->emplace(core::Gender::male, "PhysicalActivity"_id,
-                      std::vector<double>{2.2, 2.2, 2.2});
+                      std::vector<double>{2.2, 2.2, 2.2, 2.2});
 
     auto expected_trend = std::make_shared<std::unordered_map<core::Identifier, double>>();
     auto trend_steps = std::make_shared<std::unordered_map<core::Identifier, int>>();
@@ -728,11 +738,13 @@ TEST(IncomeStratumAdjustment, SimplePhysicalActivityInitialisationUsesConfigured
     for (std::size_t i = 0; i < context.population().size(); ++i) {
         auto &p = context.population()[i];
         p.gender = (i % 2 == 0) ? core::Gender::male : core::Gender::female;
-        p.age = 0;
+        p.age = static_cast<unsigned>(i);
     }
 
     const auto factor = core::Identifier("foodcarbohydrate");
-    auto expected = make_expected_table_with_income_and_pa(factor, 100.0, 600.0, 2.2);
+    // Per-age income targets so factors-mean adjustment does not collapse everyone to 600.
+    auto expected = make_expected_table_with_income_and_pa(
+        factor, 100.0, std::vector<double>{400.0, 500.0, 600.0, 700.0}, 2.2);
     std::vector<IncomeStratumExpectedTableEntry> stratum_tables{};
 
     PhysicalActivityModel simple_model;
@@ -771,11 +783,12 @@ TEST(IncomeStratumAdjustment, ContinuousPhysicalActivityInitialisationUsesConfig
     for (std::size_t i = 0; i < context.population().size(); ++i) {
         auto &p = context.population()[i];
         p.gender = (i % 2 == 0) ? core::Gender::male : core::Gender::female;
-        p.age = 0;
+        p.age = static_cast<unsigned>(i);
     }
 
     const auto factor = core::Identifier("foodcarbohydrate");
-    auto expected = make_expected_table_with_income_and_pa(factor, 100.0, 600.0, 2.2);
+    auto expected = make_expected_table_with_income_and_pa(
+        factor, 100.0, std::vector<double>{400.0, 500.0, 600.0, 700.0}, 2.2);
     std::vector<IncomeStratumExpectedTableEntry> stratum_tables{};
 
     PhysicalActivityModel continuous_model;

--- a/src/HealthGPS.Tests/KevinHallHeight.Test.cpp
+++ b/src/HealthGPS.Tests/KevinHallHeight.Test.cpp
@@ -168,6 +168,19 @@ TEST(KevinHallHeight, LegacyHeightScalarConfigStillLoads) {
     }
 
     auto json = hgps::input::load_json(finch / "dynamic_model.json");
+    // WeightQuantiles in FINCH is often configured as Quintile1..N, which requires the income
+    // stratum adjustment feature to be enabled. This test is about legacy Height scalar loading,
+    // so switch WeightQuantiles to the legacy single-file form to avoid coupling.
+    json["WeightQuantiles"]["Female"] = {{"name", "weight_quantiles_NCDRisk_female.csv"},
+                                         {"format", "csv"},
+                                         {"delimiter", ","},
+                                         {"encoding", "ASCII"},
+                                         {"columns", {{"quantile", "double"}}}};
+    json["WeightQuantiles"]["Male"] = {{"name", "weight_quantiles_NCDRisk_male.csv"},
+                                       {"format", "csv"},
+                                       {"delimiter", ","},
+                                       {"encoding", "ASCII"},
+                                       {"columns", {{"quantile", "double"}}}};
     json.erase("Height");
     json["HeightSlope"] = {{"Female", 0.123}, {"Male", 0.127}};
     json["HeightStdDev"] = {{"Female", 0.041}, {"Male", 0.043}};
@@ -334,6 +347,19 @@ TEST(KevinHallHeight, MultiRowHeightLoadsWhenStratumAdjustmentDisabled) {
     auto male_csv = create_temp_height_csv("height_male_nostratum.csv", rows);
 
     auto json = hgps::input::load_json(finch / "dynamic_model.json");
+    // This test only targets Height CSV parsing when stratum adjustment is disabled. FINCH
+    // WeightQuantiles is configured as Quintile1..N, which requires stratum adjustment; switch it
+    // to the legacy single-file form so the test remains focused.
+    json["WeightQuantiles"]["Female"] = {{"name", "weight_quantiles_NCDRisk_female.csv"},
+                                         {"format", "csv"},
+                                         {"delimiter", ","},
+                                         {"encoding", "ASCII"},
+                                         {"columns", {{"quantile", "double"}}}};
+    json["WeightQuantiles"]["Male"] = {{"name", "weight_quantiles_NCDRisk_male.csv"},
+                                       {"format", "csv"},
+                                       {"delimiter", ","},
+                                       {"encoding", "ASCII"},
+                                       {"columns", {{"quantile", "double"}}}};
     json["Height"]["Female"]["name"] = female_csv.string();
     json["Height"]["Male"]["name"] = male_csv.string();
     auto config = make_finch_configuration();
@@ -377,6 +403,18 @@ TEST(KevinHallHeight, SingleRowHeightLoadsWhenStratumCountIsOne) {
     auto male_csv = create_temp_height_csv("height_male_one_stratum.csv", "slope,std\n0.20,0.06\n");
 
     auto json = hgps::input::load_json(finch / "dynamic_model.json");
+    // With adjustment_income_stratum_count == 1, WeightQuantiles cannot use Quintile1..N files.
+    // Use legacy single-file quantiles so this test remains focused on Height CSV broadcasting.
+    json["WeightQuantiles"]["Female"] = {{"name", "weight_quantiles_NCDRisk_female.csv"},
+                                         {"format", "csv"},
+                                         {"delimiter", ","},
+                                         {"encoding", "ASCII"},
+                                         {"columns", {{"quantile", "double"}}}};
+    json["WeightQuantiles"]["Male"] = {{"name", "weight_quantiles_NCDRisk_male.csv"},
+                                       {"format", "csv"},
+                                       {"delimiter", ","},
+                                       {"encoding", "ASCII"},
+                                       {"columns", {{"quantile", "double"}}}};
     json["Height"]["Female"]["name"] = female_csv.string();
     json["Height"]["Male"]["name"] = male_csv.string();
     auto config = make_finch_configuration();
@@ -426,6 +464,17 @@ TEST(KevinHallHeight, HeightCsvSupportsSemicolonDelimiter) {
     auto male_csv = create_temp_height_csv("height_male_semicolon.csv", "slope;std\n0.20;0.06\n");
 
     auto json = hgps::input::load_json(finch / "dynamic_model.json");
+    // This test is about Height delimiter parsing; decouple from WeightQuantiles stratum settings.
+    json["WeightQuantiles"]["Female"] = {{"name", "weight_quantiles_NCDRisk_female.csv"},
+                                         {"format", "csv"},
+                                         {"delimiter", ","},
+                                         {"encoding", "ASCII"},
+                                         {"columns", {{"quantile", "double"}}}};
+    json["WeightQuantiles"]["Male"] = {{"name", "weight_quantiles_NCDRisk_male.csv"},
+                                       {"format", "csv"},
+                                       {"delimiter", ","},
+                                       {"encoding", "ASCII"},
+                                       {"columns", {{"quantile", "double"}}}};
     json["Height"]["Female"]["name"] = female_csv.string();
     json["Height"]["Male"]["name"] = male_csv.string();
     json["Height"]["Female"]["delimiter"] = ";";
@@ -478,6 +527,7 @@ TEST(KevinHallHeight, HeightCsvWrongColumnCountThrows) {
 
 TEST(KevinHallHeight, GenerateInitialisesHeightWithQuintileParams) {
     using namespace hgps;
+    using hgps::test::capture_stdout;
     const auto finch = finch_data_root();
     if (!std::filesystem::exists(finch / "dynamic_model.json")) {
         GTEST_SKIP() << "FINCH input data not available at " << finch.string();
@@ -501,7 +551,8 @@ TEST(KevinHallHeight, GenerateInitialisesHeightWithQuintileParams) {
         seed_finch_kevin_hall_food_factors(person);
     }
 
-    ASSERT_NO_THROW(runtime.model->generate_risk_factors(runtime.context));
+    ASSERT_NO_THROW(
+        capture_stdout([&] { runtime.model->generate_risk_factors(runtime.context); }));
 
     for (const auto &person : runtime.context.population()) {
         ASSERT_TRUE(person.is_active());
@@ -565,11 +616,13 @@ TEST(KevinHallHeight, GenerateHeightSummarySkippedAfterFirstUpdateYear) {
         seed_finch_kevin_hall_food_factors(person);
     }
 
-    runtime.model->generate_risk_factors(runtime.context);
+    capture_stdout([&] { runtime.model->generate_risk_factors(runtime.context); });
+    std::fflush(stdout);
     runtime.context.set_current_time(start_year + 2);
 
     const auto output =
         capture_stdout([&] { runtime.model->generate_risk_factors(runtime.context); });
+    std::fflush(stdout);
 
     EXPECT_EQ(output.find("[HEIGHT STRATUM ASSIGNMENT]"), std::string::npos);
     EXPECT_EQ(output.find("[HEIGHT BY FINAL INCOME CATEGORY]"), std::string::npos);
@@ -577,6 +630,7 @@ TEST(KevinHallHeight, GenerateHeightSummarySkippedAfterFirstUpdateYear) {
 
 TEST(KevinHallHeight, UpdateChildrenRefreshesHeightForSubAdultAges) {
     using namespace hgps;
+    using hgps::test::capture_stdout;
     const auto finch = finch_data_root();
     if (!std::filesystem::exists(finch / "dynamic_model.json")) {
         GTEST_SKIP() << "FINCH input data not available at " << finch.string();
@@ -597,7 +651,11 @@ TEST(KevinHallHeight, UpdateChildrenRefreshesHeightForSubAdultAges) {
         seed_finch_kevin_hall_food_factors(person);
     }
 
-    runtime.model->generate_risk_factors(runtime.context);
+    // Keep this test focused on update semantics (height refresh for sub-adults) rather than
+    // console reporting. Summary tables are only printed at start_year and start_year+1.
+    // Running outside that window avoids very verbose output and potential test-runner stalls.
+    runtime.context.set_current_time(start_year + 2);
+    capture_stdout([&] { runtime.model->generate_risk_factors(runtime.context); });
     auto &person = runtime.context.population()[0];
     const double height_before = person.risk_factors.at("Height"_id);
 
@@ -605,8 +663,9 @@ TEST(KevinHallHeight, UpdateChildrenRefreshesHeightForSubAdultAges) {
     // Height_residual is preserved and update_height uses it for sub-adult ages.
     person.risk_factors["Height_residual"_id] += 0.05;
 
-    runtime.context.set_current_time(start_year + 1);
-    ASSERT_NO_THROW(runtime.model->update_risk_factors(runtime.context));
+    runtime.context.set_current_time(start_year + 3);
+    ASSERT_NO_THROW(
+        capture_stdout([&] { runtime.model->update_risk_factors(runtime.context); }));
 
     const double height_after = person.risk_factors.at("Height"_id);
     EXPECT_NE(height_before, height_after);
@@ -634,7 +693,7 @@ TEST(KevinHallHeight, UpdateNewbornsInitialisesHeight) {
     person.income_adjustment_stratum = 0;
     seed_finch_kevin_hall_food_factors(person);
 
-    runtime.model->generate_risk_factors(runtime.context);
+    capture_stdout([&] { runtime.model->generate_risk_factors(runtime.context); });
     person.risk_factors.erase("Height"_id);
     person.risk_factors.erase("Height_residual"_id);
 
@@ -683,6 +742,7 @@ TEST(KevinHallHeight, GeneratePrintsHeightTablesForThreeIncomeCategories) {
 
 TEST(KevinHallHeight, GenerateUsesBroadcastHeightWhenStratumNotAssigned) {
     using namespace hgps;
+    using hgps::test::capture_stdout;
     const auto finch = finch_data_root();
     if (!std::filesystem::exists(finch / "dynamic_model.json")) {
         GTEST_SKIP() << "FINCH input data not available at " << finch.string();
@@ -702,6 +762,6 @@ TEST(KevinHallHeight, GenerateUsesBroadcastHeightWhenStratumNotAssigned) {
         seed_finch_kevin_hall_food_factors(person);
     }
 
-    ASSERT_NO_THROW(runtime.model->generate_risk_factors(runtime.context));
+    capture_stdout([&] { runtime.model->generate_risk_factors(runtime.context); });
     EXPECT_GT(runtime.context.population()[0].risk_factors.at("Height"_id), 0.0);
 }

--- a/src/HealthGPS.Tests/KevinHallHeight.Test.cpp
+++ b/src/HealthGPS.Tests/KevinHallHeight.Test.cpp
@@ -551,8 +551,7 @@ TEST(KevinHallHeight, GenerateInitialisesHeightWithQuintileParams) {
         seed_finch_kevin_hall_food_factors(person);
     }
 
-    ASSERT_NO_THROW(
-        capture_stdout([&] { runtime.model->generate_risk_factors(runtime.context); }));
+    ASSERT_NO_THROW(capture_stdout([&] { runtime.model->generate_risk_factors(runtime.context); }));
 
     for (const auto &person : runtime.context.population()) {
         ASSERT_TRUE(person.is_active());
@@ -664,8 +663,7 @@ TEST(KevinHallHeight, UpdateChildrenRefreshesHeightForSubAdultAges) {
     person.risk_factors["Height_residual"_id] += 0.05;
 
     runtime.context.set_current_time(start_year + 3);
-    ASSERT_NO_THROW(
-        capture_stdout([&] { runtime.model->update_risk_factors(runtime.context); }));
+    ASSERT_NO_THROW(capture_stdout([&] { runtime.model->update_risk_factors(runtime.context); }));
 
     const double height_after = person.risk_factors.at("Height"_id);
     EXPECT_NE(height_before, height_after);

--- a/src/HealthGPS.Tests/KevinHallWeightQuantiles.Test.cpp
+++ b/src/HealthGPS.Tests/KevinHallWeightQuantiles.Test.cpp
@@ -71,8 +71,27 @@ nlohmann::json make_csv_file_json(const std::filesystem::path &path) {
 
 void seed_finch_kevin_hall_food_factors(hgps::Person &person) {
     using namespace hgps;
-    static constexpr std::array<const char *, 3> k_food_keys = {"FoodCarbohydrate", "FoodProtein",
-                                                                "FoodFat"};
+    static constexpr std::array<const char *, 21> k_food_keys = {"FoodCarbohydrate",
+                                                                 "FoodProtein",
+                                                                 "FoodFat",
+                                                                 "FoodSodium",
+                                                                 "FoodAlcohol",
+                                                                 "FoodLegume",
+                                                                 "FoodVegetable",
+                                                                 "FoodFruit",
+                                                                 "FoodProcessedMeat",
+                                                                 "FoodRedMeat",
+                                                                 "FoodFibre",
+                                                                 "FoodTotalSugar",
+                                                                 "FoodAddedSugar",
+                                                                 "FoodSaturatedFat",
+                                                                 "FoodPolyunsaturatedFattyAcid",
+                                                                 "FoodMonounsaturatedFat",
+                                                                 "FoodIron",
+                                                                 "FoodCalcium",
+                                                                 "FoodVitaminC",
+                                                                 "FoodCopper",
+                                                                 "FoodZinc"};
     for (const auto *key : k_food_keys) {
         person.risk_factors[core::Identifier(key)] = 50.0;
     }
@@ -141,6 +160,20 @@ KevinHallWeightRuntime make_kevin_hall_weight_runtime(const nlohmann::json &dyna
                                   .context = std::move(context)};
 }
 
+nlohmann::json set_legacy_weight_quantiles(nlohmann::json json) {
+    json["WeightQuantiles"]["Female"] = {{"name", "weight_quantiles_NCDRisk_female.csv"},
+                                         {"format", "csv"},
+                                         {"delimiter", ","},
+                                         {"encoding", "ASCII"},
+                                         {"columns", {{"quantile", "double"}}}};
+    json["WeightQuantiles"]["Male"] = {{"name", "weight_quantiles_NCDRisk_male.csv"},
+                                       {"format", "csv"},
+                                       {"delimiter", ","},
+                                       {"encoding", "ASCII"},
+                                       {"columns", {{"quantile", "double"}}}};
+    return json;
+}
+
 nlohmann::json set_quintile_weight_quantiles(nlohmann::json json,
                                              const std::filesystem::path &female_base,
                                              const std::filesystem::path &male_base,
@@ -172,6 +205,7 @@ TEST(KevinHallWeightQuantiles, LegacySingleFileConfigStillLoads) {
     }
 
     auto json = hgps::input::load_json(finch / "dynamic_model.json");
+    json = set_legacy_weight_quantiles(json);
     auto config = make_finch_configuration();
     auto definition = hgps::input::load_kevinhall_risk_model_definition(json, config);
     ASSERT_NE(definition, nullptr);
@@ -255,8 +289,8 @@ TEST(KevinHallWeightQuantiles, GeneratePrintsWeightStratumAndIncomeCategoryTable
 
     constexpr int start_year = 2020;
     auto json = hgps::input::load_json(finch / "dynamic_model.json");
-    json = set_quintile_weight_quantiles(json, finch / "weight_female", finch / "weight_male", 1.0,
-                                         1.0);
+    // Use FINCH on-disk Quintile1..N curves (full quantile tables). Temp 3-row CSVs from
+    // set_quintile_weight_quantiles are only for parser-load tests; generate can abort/hang.
     auto config = make_quintile_stratum_configuration();
     auto runtime = make_kevin_hall_weight_runtime(json, config, 6, start_year);
 
@@ -281,6 +315,7 @@ TEST(KevinHallWeightQuantiles, GeneratePrintsWeightStratumAndIncomeCategoryTable
 
 TEST(KevinHallWeightQuantiles, DifferentStrataCanProduceDifferentWeights) {
     using namespace hgps;
+    using hgps::test::capture_stdout;
 
     const auto finch = finch_data_root();
     if (!std::filesystem::exists(finch / "dynamic_model.json")) {
@@ -288,8 +323,6 @@ TEST(KevinHallWeightQuantiles, DifferentStrataCanProduceDifferentWeights) {
     }
 
     auto json = hgps::input::load_json(finch / "dynamic_model.json");
-    json = set_quintile_weight_quantiles(json, finch / "weight_female", finch / "weight_male", 1.0,
-                                         1.0);
     auto config = make_quintile_stratum_configuration();
     auto runtime = make_kevin_hall_weight_runtime(json, config, 2, 2020);
 
@@ -307,7 +340,7 @@ TEST(KevinHallWeightQuantiles, DifferentStrataCanProduceDifferentWeights) {
     person1.income_adjustment_stratum = 4;
     seed_finch_kevin_hall_food_factors(person1);
 
-    runtime.model->generate_risk_factors(runtime.context);
+    capture_stdout([&] { runtime.model->generate_risk_factors(runtime.context); });
 
     const double weight0 = person0.risk_factors.at("Weight"_id);
     const double weight1 = person1.risk_factors.at("Weight"_id);

--- a/src/HealthGPS.Tests/KevinHallWeightValidation.Test.cpp
+++ b/src/HealthGPS.Tests/KevinHallWeightValidation.Test.cpp
@@ -68,7 +68,20 @@ TEST(KevinHallWeightValidation, ValidateWeightThrowsWhenOutsideConfiguredRange) 
         GTEST_SKIP() << "FINCH input data not available at " << finch.string();
     }
 
-    const auto json = hgps::input::load_json(finch / "dynamic_model.json");
+    auto json = hgps::input::load_json(finch / "dynamic_model.json");
+    // FINCH WeightQuantiles is configured as Quintile1..N, which requires stratum adjustment to be
+    // enabled. This test only validates weight range checking, so use the legacy single-file
+    // weight quantiles to avoid coupling to income stratum configuration.
+    json["WeightQuantiles"]["Female"] = {{"name", "weight_quantiles_NCDRisk_female.csv"},
+                                         {"format", "csv"},
+                                         {"delimiter", ","},
+                                         {"encoding", "ASCII"},
+                                         {"columns", {{"quantile", "double"}}}};
+    json["WeightQuantiles"]["Male"] = {{"name", "weight_quantiles_NCDRisk_male.csv"},
+                                       {"format", "csv"},
+                                       {"delimiter", ","},
+                                       {"encoding", "ASCII"},
+                                       {"columns", {{"quantile", "double"}}}};
     auto config = make_finch_configuration();
     auto definition = hgps::input::load_kevinhall_risk_model_definition(json, config);
     ASSERT_NE(definition, nullptr);

--- a/src/HealthGPS.Tests/KevinHallWeightValidation.Test.cpp
+++ b/src/HealthGPS.Tests/KevinHallWeightValidation.Test.cpp
@@ -59,7 +59,7 @@ std::shared_ptr<hgps::ModelInput> make_weight_validation_input(hgps::core::DataT
 
 } // namespace
 
-TEST(KevinHallWeightValidation, ValidateWeightThrowsWhenOutsideConfiguredRange) {
+TEST(KevinHallWeightValidation, WarnsAboveMaxAndThrowsBelowMinForConfiguredWeightRange) {
     using namespace hgps;
     using namespace hgps::core;
 
@@ -112,36 +112,20 @@ TEST(KevinHallWeightValidation, ValidateWeightThrowsWhenOutsideConfiguredRange) 
     person.risk_factors["EnergyIntake"_id] = 2000.0;
 
     EXPECT_NO_THROW(kevin_hall->validate_weight_in_config_range(context, person, "unit_test"));
+    EXPECT_DOUBLE_EQ(100.0, person.risk_factors.at("Weight"_id));
 
     person.risk_factors["Weight"_id] = 150.0;
-    try {
-        kevin_hall->validate_weight_in_config_range(context, person, "unit_test");
-        FAIL() << "Expected weight validation to throw for weight above range";
-    } catch (const HgpsException &ex) {
-        const std::string message = ex.what();
-        EXPECT_NE(message.find("above maximum"), std::string::npos);
-        EXPECT_NE(message.find("person_id=42"), std::string::npos);
-        EXPECT_NE(message.find("unit_test"), std::string::npos);
-    }
+    EXPECT_NO_THROW(kevin_hall->validate_weight_in_config_range(context, person, "unit_test"));
+    EXPECT_DOUBLE_EQ(150.0, person.risk_factors.at("Weight"_id));
 
     person.risk_factors["Weight"_id] = 200.0;
-    try {
-        kevin_hall->validate_weight_in_config_range(context, person, "unit_test");
-        FAIL() << "Expected weight validation to throw";
-    } catch (const HgpsException &ex) {
-        const std::string message = ex.what();
-        EXPECT_NE(message.find("above maximum"), std::string::npos);
-        EXPECT_NE(message.find("person_id=42"), std::string::npos);
-        EXPECT_NE(message.find("unit_test"), std::string::npos);
-    }
+    EXPECT_NO_THROW(kevin_hall->validate_weight_in_config_range(context, person, "unit_test"));
+    EXPECT_DOUBLE_EQ(200.0, person.risk_factors.at("Weight"_id));
 
     person.risk_factors["Weight"_id] = 30.0;
-    try {
-        kevin_hall->validate_weight_in_config_range(context, person, "below_min");
-        FAIL() << "Expected weight validation to throw";
-    } catch (const HgpsException &ex) {
-        EXPECT_NE(std::string(ex.what()).find("below minimum"), std::string::npos);
-    }
+    EXPECT_THROW(kevin_hall->validate_weight_in_config_range(context, person, "below_min"),
+                 hgps::core::HgpsException);
+    EXPECT_DOUBLE_EQ(30.0, person.risk_factors.at("Weight"_id));
 
     person.risk_factors.erase("Weight"_id);
     EXPECT_NO_THROW(kevin_hall->validate_weight_in_config_range(context, person, "no_weight"));

--- a/src/HealthGPS.Tests/Population.Test.cpp
+++ b/src/HealthGPS.Tests/Population.Test.cpp
@@ -5,8 +5,8 @@
 #include "HealthGPS/person.h"
 #include "HealthGPS/static_linear_model.h"
 #include "HealthGPS/two_step_value.h"
-#include <gtest/gtest.h>
 #include <algorithm>
+#include <gtest/gtest.h>
 #include <memory> // Ensure this header is included for std::addressof
 #include <vector>
 

--- a/src/HealthGPS.Tests/Population.Test.cpp
+++ b/src/HealthGPS.Tests/Population.Test.cpp
@@ -348,7 +348,8 @@ TEST(TestHealthGPS_Population, InitialCohortIdsAreConsecutiveFromOne) {
 }
 
 // MAHIMA: Regression for allocate_next_person_id debug guard — each entrant must receive an ID that
-// was not already present in the population (monotonic assignment, no reuse after death/emigration).
+// was not already present in the population (monotonic assignment, no reuse after
+// death/emigration).
 TEST(TestHealthGPS_Population, MahimaNewEntrantIdsAreNotAlreadyAssigned) {
     using namespace hgps;
 

--- a/src/HealthGPS.Tests/Population.Test.cpp
+++ b/src/HealthGPS.Tests/Population.Test.cpp
@@ -229,9 +229,9 @@ TEST(TestHealthGPS_Population, AddMultipleNewEntities) {
     ASSERT_TRUE(p[start_size].is_active());
 }
 
-// MAHIMA: Verifies index-based ID so the same logical person has the same ID in baseline and
-// intervention (ID = slot index + 1).
-TEST(TestHealthGPS_Population, PersonIdEqualsSlotIndexPlusOne) {
+// MAHIMA: Initial IDs are deterministic (1..N) for baseline/intervention alignment, while
+// post-initial entrants get lifetime-unique IDs that are never reused, including recycled slots.
+TEST(TestHealthGPS_Population, PersonIdInitialDeterministicAndPostInitialLifetimeUnique) {
     using namespace hgps;
 
     constexpr auto init_size = 10u;
@@ -251,12 +251,14 @@ TEST(TestHealthGPS_Population, PersonIdEqualsSlotIndexPlusOne) {
     pop.add_newborn_babies(2, core::Gender::female, time_now);
     ASSERT_TRUE(pop[3].is_active());
     ASSERT_TRUE(pop[7].is_active());
-    ASSERT_EQ(pop[3].id(), 4u);
-    ASSERT_EQ(pop[7].id(), 8u);
+    ASSERT_EQ(pop[3].id(), 11u);
+    ASSERT_EQ(pop[7].id(), 12u);
+    ASSERT_NE(pop[3].id(), 4u);
+    ASSERT_NE(pop[7].id(), 8u);
 
     pop.add_newborn_babies(1, core::Gender::male, time_now);
     ASSERT_EQ(pop.size(), init_size + 1u);
-    ASSERT_EQ(pop[pop.size() - 1].id(), pop.size());
+    ASSERT_EQ(pop[pop.size() - 1].id(), 13u);
 }
 
 TEST(TestHealthGPS_Population, PersonIncomeValues) {

--- a/src/HealthGPS.Tests/Population.Test.cpp
+++ b/src/HealthGPS.Tests/Population.Test.cpp
@@ -6,13 +6,16 @@
 #include "HealthGPS/static_linear_model.h"
 #include "HealthGPS/two_step_value.h"
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <memory> // Ensure this header is included for std::addressof
+#include <vector>
 
 TEST(TestHealthGPS_Population, CreateDefaultPerson) {
     using namespace hgps;
 
     auto p = Person{};
-    ASSERT_GT(p.id(), 0);
+    ASSERT_EQ(Person::unassigned_id, p.id());
+    ASSERT_FALSE(p.has_assigned_id());
     ASSERT_EQ(0u, p.age);
     ASSERT_EQ(core::Gender::unknown, p.gender);
     ASSERT_TRUE(p.is_alive());
@@ -32,9 +35,14 @@ TEST(TestHealthGPS_Population, CreateUniquePerson) {
     auto p2 = Person{};
     const auto &p3 = p1;
 
-    ASSERT_GT(p1.id(), 0);
-    ASSERT_GT(p2.id(), p1.id());
+    ASSERT_FALSE(p1.has_assigned_id());
+    ASSERT_FALSE(p2.has_assigned_id());
     ASSERT_EQ(p1.id(), p3.id());
+
+    p1.set_id(1);
+    p2.set_id(2);
+    ASSERT_TRUE(p1.has_assigned_id());
+    ASSERT_GT(p2.id(), p1.id());
 }
 
 TEST(TestHealthGPS_Population, PersonStateIsActive) {
@@ -185,6 +193,7 @@ TEST(TestHealthGPS_Population, AddSingleNewEntity) {
     auto start_size = p.size();
     p.add(Person{core::Gender::male}, time_now);
     ASSERT_GT(p.size(), start_size);
+    ASSERT_EQ(p[start_size].id(), init_size + 1u);
 
     p[start_size].die(time_now);
     ASSERT_FALSE(p[start_size].is_active());
@@ -194,6 +203,8 @@ TEST(TestHealthGPS_Population, AddSingleNewEntity) {
     p.add(Person{core::Gender::female}, time_now);
     ASSERT_EQ(p.size(), current_size);
     ASSERT_TRUE(p[start_size].is_active());
+    ASSERT_EQ(p[start_size].id(), init_size + 2u);
+    ASSERT_NE(p[start_size].id(), init_size + 1u);
 }
 
 TEST(TestHealthGPS_Population, AddMultipleNewEntities) {
@@ -259,6 +270,50 @@ TEST(TestHealthGPS_Population, PersonIdInitialDeterministicAndPostInitialLifetim
     pop.add_newborn_babies(1, core::Gender::male, time_now);
     ASSERT_EQ(pop.size(), init_size + 1u);
     ASSERT_EQ(pop[pop.size() - 1].id(), 13u);
+}
+
+TEST(TestHealthGPS_Population, PersonAddAssignsLifetimeUniqueId) {
+    using namespace hgps;
+
+    constexpr auto init_size = 5u;
+    auto pop = Population{init_size};
+    auto time_now = 2020u;
+
+    auto immigrant = Person{core::Gender::male};
+    ASSERT_FALSE(immigrant.has_assigned_id());
+    pop.add(std::move(immigrant), time_now);
+    ASSERT_EQ(pop.size(), init_size + 1u);
+    ASSERT_EQ(pop[init_size].id(), init_size + 1u);
+    ASSERT_TRUE(pop[init_size].has_assigned_id());
+
+    pop[2].die(time_now);
+    time_now++;
+    auto replacement = Person{core::Gender::female};
+    pop.add(std::move(replacement), time_now);
+    ASSERT_TRUE(pop[2].is_active());
+    ASSERT_EQ(pop[2].id(), init_size + 2u);
+    ASSERT_NE(pop[2].id(), 3u);
+}
+
+TEST(TestHealthGPS_Population, AllPopulationIdsArePairwiseDistinct) {
+    using namespace hgps;
+
+    auto pop = Population{4u};
+    auto time_now = 2021u;
+    pop[1].die(time_now);
+    pop[3].emigrate(time_now);
+    time_now++;
+    pop.add_newborn_babies(1, core::Gender::female, time_now);
+    pop.add(Person{core::Gender::male}, time_now);
+
+    std::vector<std::size_t> ids;
+    ids.reserve(pop.size());
+    for (const auto &person : pop) {
+        ASSERT_TRUE(person.has_assigned_id());
+        ids.push_back(person.id());
+    }
+    const auto unique_end = std::unique(ids.begin(), ids.end());
+    ASSERT_EQ(unique_end, ids.end()) << "Duplicate person IDs in population vector";
 }
 
 TEST(TestHealthGPS_Population, PersonIncomeValues) {

--- a/src/HealthGPS.Tests/Population.Test.cpp
+++ b/src/HealthGPS.Tests/Population.Test.cpp
@@ -312,7 +312,8 @@ TEST(TestHealthGPS_Population, AllPopulationIdsArePairwiseDistinct) {
         ASSERT_TRUE(person.has_assigned_id());
         ids.push_back(person.id());
     }
-    const auto unique_end = std::ranges::unique(ids, );
+    std::sort(ids.begin(), ids.end());
+    const auto unique_end = std::unique(ids.begin(), ids.end());
     ASSERT_EQ(unique_end, ids.end()) << "Duplicate person IDs in population vector";
 }
 

--- a/src/HealthGPS.Tests/Population.Test.cpp
+++ b/src/HealthGPS.Tests/Population.Test.cpp
@@ -312,7 +312,7 @@ TEST(TestHealthGPS_Population, AllPopulationIdsArePairwiseDistinct) {
         ASSERT_TRUE(person.has_assigned_id());
         ids.push_back(person.id());
     }
-    const auto unique_end = std::ranges::unique(ids,);
+    const auto unique_end = std::ranges::unique(ids, );
     ASSERT_EQ(unique_end, ids.end()) << "Duplicate person IDs in population vector";
 }
 

--- a/src/HealthGPS.Tests/Population.Test.cpp
+++ b/src/HealthGPS.Tests/Population.Test.cpp
@@ -8,7 +8,23 @@
 #include <algorithm>
 #include <gtest/gtest.h>
 #include <memory> // Ensure this header is included for std::addressof
+#include <unordered_set>
 #include <vector>
+
+namespace {
+
+std::unordered_set<std::size_t> assigned_person_ids(const hgps::Population &pop) {
+    std::unordered_set<std::size_t> ids;
+    ids.reserve(pop.size());
+    for (const auto &person : pop) {
+        if (person.has_assigned_id()) {
+            ids.insert(person.id());
+        }
+    }
+    return ids;
+}
+
+} // namespace
 
 TEST(TestHealthGPS_Population, CreateDefaultPerson) {
     using namespace hgps;
@@ -242,6 +258,7 @@ TEST(TestHealthGPS_Population, AddMultipleNewEntities) {
 
 // MAHIMA: Initial IDs are deterministic (1..N) for baseline/intervention alignment, while
 // post-initial entrants get lifetime-unique IDs that are never reused, including recycled slots.
+// Debug builds also assert via Population::allocate_next_person_id (see MahimaNewEntrantIds...).
 TEST(TestHealthGPS_Population, PersonIdInitialDeterministicAndPostInitialLifetimeUnique) {
     using namespace hgps;
 
@@ -315,6 +332,57 @@ TEST(TestHealthGPS_Population, AllPopulationIdsArePairwiseDistinct) {
     std::ranges::sort(ids);
     ASSERT_TRUE(std::ranges::adjacent_find(ids) == ids.end())
         << "Duplicate person IDs in population vector";
+}
+
+TEST(TestHealthGPS_Population, InitialCohortIdsAreConsecutiveFromOne) {
+    using namespace hgps;
+
+    constexpr std::size_t init_size = 8u;
+    const auto pop = Population{init_size};
+    const auto ids = assigned_person_ids(pop);
+
+    ASSERT_EQ(ids.size(), init_size);
+    for (std::size_t i = 1; i <= init_size; ++i) {
+        ASSERT_TRUE(ids.contains(i)) << "Missing initial cohort ID " << i;
+    }
+}
+
+// MAHIMA: Regression for allocate_next_person_id debug guard — each entrant must receive an ID that
+// was not already present in the population (monotonic assignment, no reuse after death/emigration).
+TEST(TestHealthGPS_Population, MahimaNewEntrantIdsAreNotAlreadyAssigned) {
+    using namespace hgps;
+
+    constexpr std::size_t init_size = 6u;
+    auto pop = Population{init_size};
+    auto ids_before = assigned_person_ids(pop);
+    ASSERT_EQ(ids_before.size(), init_size);
+
+    auto time_now = 2022u;
+    pop[1].die(time_now);
+    pop[4].emigrate(time_now);
+    time_now++;
+
+    pop.add_newborn_babies(2, core::Gender::female, time_now);
+    const auto ids_after_recycled_births = assigned_person_ids(pop);
+    // Recycled slots: new IDs 7 and 8 replace retired 2 and 5; vector size stays init_size.
+    ASSERT_EQ(ids_after_recycled_births.size(), init_size);
+    EXPECT_FALSE(ids_after_recycled_births.contains(2u));
+    EXPECT_FALSE(ids_after_recycled_births.contains(5u));
+    EXPECT_TRUE(ids_after_recycled_births.contains(7u));
+    EXPECT_TRUE(ids_after_recycled_births.contains(8u));
+    for (const auto &person : pop) {
+        if (person.id() == 7u || person.id() == 8u) {
+            ASSERT_FALSE(ids_before.contains(person.id()));
+            ASSERT_GT(person.id(), init_size);
+        }
+    }
+
+    pop.add(Person{core::Gender::male}, time_now);
+    ASSERT_EQ(pop.size(), init_size + 1u);
+    const auto ids_final = assigned_person_ids(pop);
+    ASSERT_EQ(ids_final.size(), init_size + 1u);
+    EXPECT_TRUE(ids_final.contains(init_size + 3u));
+    EXPECT_FALSE(ids_after_recycled_births.contains(init_size + 3u));
 }
 
 TEST(TestHealthGPS_Population, PersonIncomeValues) {

--- a/src/HealthGPS.Tests/Population.Test.cpp
+++ b/src/HealthGPS.Tests/Population.Test.cpp
@@ -312,9 +312,9 @@ TEST(TestHealthGPS_Population, AllPopulationIdsArePairwiseDistinct) {
         ASSERT_TRUE(person.has_assigned_id());
         ids.push_back(person.id());
     }
-    std::sort(ids.begin(), ids.end());
-    const auto unique_end = std::unique(ids.begin(), ids.end());
-    ASSERT_EQ(unique_end, ids.end()) << "Duplicate person IDs in population vector";
+    std::ranges::sort(ids);
+    ASSERT_TRUE(std::ranges::adjacent_find(ids) == ids.end())
+        << "Duplicate person IDs in population vector";
 }
 
 TEST(TestHealthGPS_Population, PersonIncomeValues) {

--- a/src/HealthGPS.Tests/Population.Test.cpp
+++ b/src/HealthGPS.Tests/Population.Test.cpp
@@ -312,7 +312,7 @@ TEST(TestHealthGPS_Population, AllPopulationIdsArePairwiseDistinct) {
         ASSERT_TRUE(person.has_assigned_id());
         ids.push_back(person.id());
     }
-    const auto unique_end = std::unique(ids.begin(), ids.end());
+    const auto unique_end = std::ranges::unique(ids,);
     ASSERT_EQ(unique_end, ids.end()) << "Duplicate person IDs in population vector";
 }
 

--- a/src/HealthGPS.Tests/TestConsoleCapture.cpp
+++ b/src/HealthGPS.Tests/TestConsoleCapture.cpp
@@ -1,0 +1,27 @@
+#include "TestConsoleCapture.h"
+
+#include <cstdio>
+
+namespace hgps::test {
+
+namespace {
+
+class FlushStdoutListener : public ::testing::EmptyTestEventListener {
+  public:
+    void OnTestEnd(const ::testing::TestInfo & /*test_info*/) override {
+        std::fflush(stdout);
+        std::fflush(stderr);
+    }
+};
+
+struct RegisterFlushStdoutListener {
+    RegisterFlushStdoutListener() {
+        ::testing::UnitTest::GetInstance()->listeners().Append(new FlushStdoutListener);
+    }
+};
+
+const RegisterFlushStdoutListener k_register_flush_stdout_listener{};
+
+} // namespace
+
+} // namespace hgps::test

--- a/src/HealthGPS.Tests/TestConsoleCapture.cpp
+++ b/src/HealthGPS.Tests/TestConsoleCapture.cpp
@@ -1,6 +1,7 @@
 #include "TestConsoleCapture.h"
 
 #include <cstdio>
+#include <memory>
 
 namespace hgps::test {
 
@@ -16,7 +17,10 @@ class FlushStdoutListener : public ::testing::EmptyTestEventListener {
 
 struct RegisterFlushStdoutListener {
     RegisterFlushStdoutListener() {
-        ::testing::UnitTest::GetInstance()->listeners().Append(new FlushStdoutListener);
+        auto listener = std::make_unique<FlushStdoutListener>();
+        // gtest::TestEventListeners::Append takes ownership; freed when UnitTest tears down.
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        ::testing::UnitTest::GetInstance()->listeners().Append(listener.release());
     }
 };
 

--- a/src/HealthGPS.Tests/TestConsoleCapture.h
+++ b/src/HealthGPS.Tests/TestConsoleCapture.h
@@ -9,9 +9,16 @@
 namespace hgps::test {
 
 /// @brief Captures bytes written to the process stdout (including fmt::print output).
+/// Always restores stdout even when @p action throws (gtest CaptureStdout requirement).
 inline std::string capture_stdout(const std::function<void()> &action) {
     testing::internal::CaptureStdout();
-    action();
+    try {
+        action();
+    } catch (...) {
+        static_cast<void>(testing::internal::GetCapturedStdout());
+        std::fflush(stdout);
+        throw;
+    }
     const std::string output = testing::internal::GetCapturedStdout();
     std::fflush(stdout);
     return output;

--- a/src/HealthGPS/kevin_hall_model.cpp
+++ b/src/HealthGPS/kevin_hall_model.cpp
@@ -11,7 +11,6 @@
 #include <iterator>
 #include <limits>
 #include <sstream>
-#include <syncstream>
 #include <utility>
 
 namespace { // anonymous namespace
@@ -164,7 +163,9 @@ void print_height_stratum_assignment_table(
     }
     out << "+--------+----------------------+-------+-------------+-------------+-------------+"
            "-------------+-------------+\n";
-    std::osyncstream(std::cout) << out.str();
+    // MAHIMA: Avoid std::osyncstream here — it can block when gtest redirects stdout
+    // (CaptureStdout) in unit tests, making the suite appear hung.
+    std::cout << out.str() << std::flush;
 }
 
 struct WeightBucketSummary {
@@ -237,7 +238,7 @@ void print_weight_stratum_assignment_table(
     }
     out << "+--------+----------------------+-------+---------------+-------------+-------------+"
            "-------------+\n";
-    std::osyncstream(std::cout) << out.str();
+    std::cout << out.str() << std::flush;
 }
 
 void print_weight_by_final_income_category_table(const hgps::Population &population,
@@ -310,7 +311,7 @@ void print_weight_by_final_income_category_table(const hgps::Population &populat
         out << " |\n";
     }
     out << "+----------+--------+-------------+-------------+-------------+\n";
-    std::osyncstream(std::cout) << out.str();
+    std::cout << out.str() << std::flush;
 }
 
 void print_height_by_final_income_category_table(const hgps::Population &population,
@@ -383,7 +384,7 @@ void print_height_by_final_income_category_table(const hgps::Population &populat
         out << " |\n";
     }
     out << "+----------+--------+-------------+-------------+-------------+\n";
-    std::osyncstream(std::cout) << out.str();
+    std::cout << out.str() << std::flush;
 }
 
 } // anonymous namespace

--- a/src/HealthGPS/kevin_hall_model.cpp
+++ b/src/HealthGPS/kevin_hall_model.cpp
@@ -59,15 +59,15 @@ std::string sector_label(hgps::core::Sector sector) {
 }
 
 std::string format_weight_range_violation_message(const hgps::RuntimeContext &context,
-                                                const hgps::Person &person,
-                                                std::string_view phase, double weight,
-                                                const hgps::core::DoubleInterval &range,
-                                                bool above_maximum) {
+                                                  const hgps::Person &person,
+                                                  std::string_view phase, double weight,
+                                                  const hgps::core::DoubleInterval &range,
+                                                  bool above_maximum) {
     const char *bound_phrase =
         above_maximum ? "above maximum configured range" : "below minimum configured range";
     std::ostringstream message;
-    message << "Weight (" << std::fixed << std::setprecision(6) << weight
-            << " kg) is " << bound_phrase << " [" << range.lower() << ", " << range.upper()
+    message << "Weight (" << std::fixed << std::setprecision(6) << weight << " kg) is "
+            << bound_phrase << " [" << range.lower() << ", " << range.upper()
             << "] kg during phase '" << phase << "'.\n"
             << "  person_id=" << person.id() << "\n"
             << "  age=" << person.age << " years\n"
@@ -1211,8 +1211,8 @@ void KevinHallModel::validate_weight_in_config_range(const RuntimeContext &conte
     }
 
     const bool above_maximum = weight > range->upper();
-    const auto message =
-        format_weight_range_violation_message(context, person, phase, weight, *range, above_maximum);
+    const auto message = format_weight_range_violation_message(context, person, phase, weight,
+                                                               *range, above_maximum);
 
     if (above_maximum) {
         std::osyncstream(std::cout) << "\n[WEIGHT RANGE WARNING] " << message << '\n';

--- a/src/HealthGPS/kevin_hall_model.cpp
+++ b/src/HealthGPS/kevin_hall_model.cpp
@@ -11,6 +11,8 @@
 #include <iterator>
 #include <limits>
 #include <sstream>
+#include <syncstream>
+#include <unordered_map>
 #include <utility>
 
 namespace { // anonymous namespace
@@ -43,6 +45,63 @@ std::string gender_label(const hgps::Person &person) {
         return "female";
     }
     return "unknown";
+}
+
+std::string sector_label(hgps::core::Sector sector) {
+    switch (sector) {
+    case hgps::core::Sector::urban:
+        return "0";
+    case hgps::core::Sector::rural:
+        return "1";
+    default:
+        return "unknown";
+    }
+}
+
+std::string format_weight_range_violation_message(const hgps::RuntimeContext &context,
+                                                const hgps::Person &person,
+                                                std::string_view phase, double weight,
+                                                const hgps::core::DoubleInterval &range,
+                                                bool above_maximum) {
+    const char *bound_phrase =
+        above_maximum ? "above maximum configured range" : "below minimum configured range";
+    std::ostringstream message;
+    message << "Weight (" << std::fixed << std::setprecision(6) << weight
+            << " kg) is " << bound_phrase << " [" << range.lower() << ", " << range.upper()
+            << "] kg during phase '" << phase << "'.\n"
+            << "  person_id=" << person.id() << "\n"
+            << "  age=" << person.age << " years\n"
+            << "  gender=" << gender_label(person) << "\n"
+            << "  region=" << person.region << "\n"
+            << "  ethnicity=" << person.ethnicity << "\n"
+            << "  sector=" << sector_label(person.sector) << "\n"
+            << "  income_category=" << income_category_label(person.income) << "\n"
+            << "  income_continuous=" << std::setprecision(6) << person.income_continuous << "\n"
+            << "  simulation_time=" << context.time_now() << "\n"
+            << "  simulation_run=" << context.current_run() << "\n"
+            << "  scenario=" << context.scenario().name() << "\n"
+            << "  active=" << (person.is_active() ? "true" : "false");
+
+    const auto append_if_present = [&](const char *key, const char *label, bool as_cm = false) {
+        const hgps::core::Identifier id(key);
+        if (!person.risk_factors.contains(id)) {
+            return;
+        }
+        const double value = person.risk_factors.at(id);
+        message << "\n  " << label << '=';
+        if (as_cm) {
+            message << std::setprecision(6) << (value * 100.0);
+        } else {
+            message << std::setprecision(6) << value;
+        }
+    };
+
+    append_if_present("Height", "height_cm", true);
+    append_if_present("BMI", "bmi");
+    append_if_present("EnergyIntake", "energy_intake");
+    append_if_present("PhysicalActivity", "physical_activity");
+
+    return message.str();
 }
 
 bool should_print_kevin_hall_summary_tables(const hgps::RuntimeContext &context) {
@@ -434,7 +493,7 @@ void KevinHallModel::generate_risk_factors(RuntimeContext &context) {
     // MAHIMA: Validate weight after adjusting the weight mean to match expected. This is done after
     // adjusting the weight mean to match expected to ensure that the weight is within the
     // configured range.
-    for (const auto &person : context.population()) {
+    for (auto &person : context.population()) {
         if (person.is_active()) {
             validate_weight_in_config_range(context, person,
                                             "generate_risk_factors:after_weight_mean_adjustment");
@@ -1128,11 +1187,6 @@ void KevinHallModel::adjust_weight(const RuntimeContext &context, Person &person
     validate_weight_in_config_range(context, person, "adjust_weight");
 }
 
-// MAHIMA: Added context and phase parameters to the validate_weight_in_config_range method
-//  to provide more detailed error messages and allow for more specific validation in different
-//  contexts.
-// The context parameter is used to access the context's mapping and time information,
-//  while the phase parameter is used to provide a more specific message about the validation error.
 void KevinHallModel::validate_weight_in_config_range(const RuntimeContext &context,
                                                      const Person &person,
                                                      std::string_view phase) const {
@@ -1156,41 +1210,16 @@ void KevinHallModel::validate_weight_in_config_range(const RuntimeContext &conte
         return;
     }
 
-    const char *boundary = (weight < range->lower()) ? "below minimum" : "above maximum";
+    const bool above_maximum = weight > range->upper();
+    const auto message =
+        format_weight_range_violation_message(context, person, phase, weight, *range, above_maximum);
 
-    // MAHIMA: Throw detailed error message with all relevant information about the person and the
-    // context.
-    std::ostringstream message;
-    message << std::fixed << std::setprecision(6);
-    message << "Weight (" << weight << " kg) is " << boundary << " configured range ["
-            << range->lower() << ", " << range->upper() << "] kg during phase '" << phase << "'.\n"
-            << "  person_id=" << person.id() << "\n"
-            << "  age=" << person.age << " years\n"
-            << "  gender=" << gender_label(person) << "\n"
-            << "  region=" << person.region << "\n"
-            << "  ethnicity=" << person.ethnicity << "\n"
-            << "  sector=" << static_cast<int>(person.sector) << "\n"
-            << "  income_category=" << income_category_label(person.income) << "\n"
-            << "  income_continuous=" << person.income_continuous << "\n"
-            << "  simulation_time=" << context.time_now() << "\n"
-            << "  simulation_run=" << context.current_run() << "\n"
-            << "  scenario=" << context.identifier() << "\n"
-            << "  active=" << (person.is_active() ? "true" : "false");
-
-    if (person.risk_factors.contains("Height"_id)) {
-        message << "\n  height_cm=" << person.risk_factors.at("Height"_id);
-    }
-    if (person.risk_factors.contains("BMI"_id)) {
-        message << "\n  bmi=" << person.risk_factors.at("BMI"_id);
-    }
-    if (person.risk_factors.contains("EnergyIntake"_id)) {
-        message << "\n  energy_intake=" << person.risk_factors.at("EnergyIntake"_id);
-    }
-    if (person.risk_factors.contains("PhysicalActivity"_id)) {
-        message << "\n  physical_activity=" << person.risk_factors.at("PhysicalActivity"_id);
+    if (above_maximum) {
+        std::osyncstream(std::cout) << "\n[WEIGHT RANGE WARNING] " << message << '\n';
+        return;
     }
 
-    throw core::HgpsException(message.str());
+    throw core::HgpsException(message);
 }
 
 double KevinHallModel::get_weight_quantile(double epa_quantile,

--- a/src/HealthGPS/kevin_hall_model.h
+++ b/src/HealthGPS/kevin_hall_model.h
@@ -61,7 +61,9 @@ class KevinHallModel final : public RiskFactorAdjustableModel {
 
     void update_risk_factors(RuntimeContext &context) override;
 
-    /// @brief Throws if person weight is outside the range from config modelling.risk_factors.
+    /// @brief Checks person weight against modelling.risk_factors.Weight range from config.
+    /// Below minimum: throws and stops the run. Above maximum: prints a console warning and
+    /// continues (weight is not modified).
     void validate_weight_in_config_range(const RuntimeContext &context, const Person &person,
                                          std::string_view phase) const;
 

--- a/src/HealthGPS/person.cpp
+++ b/src/HealthGPS/person.cpp
@@ -5,8 +5,6 @@
 
 namespace hgps {
 
-std::atomic<std::size_t> Person::newUID{0};
-
 std::map<core::Identifier, std::function<double(const Person &)>> Person::current_dispatcher{
     {"Intercept"_id, [](const Person &) { return 1.0; }},
     {"Gender"_id, [](const Person &p) { return p.gender_to_value(); }},
@@ -33,13 +31,11 @@ std::map<core::Identifier, std::function<double(const Person &)>> Person::curren
     {"region4"_id, [](const Person &p) { return p.region_to_value() == 4.0 ? 1.0 : 0.0; }},
 };
 
-Person::Person() : id_{++Person::newUID} {}
+// MAHIMA: Default constructors leave id_ unassigned; Population assigns lifetime-unique IDs.
+Person::Person() = default;
 
-Person::Person(const core::Gender birth_gender) noexcept
-    : gender{birth_gender}, id_{++Person::newUID} {}
+Person::Person(const core::Gender birth_gender) noexcept : gender{birth_gender} {}
 
-// MAHIMA: Index-based ID constructors for Population; same logical person gets same ID in
-// baseline and intervention (ID = slot index + 1).
 Person::Person(std::size_t id) noexcept : id_{id} {}
 
 Person::Person(const core::Gender birth_gender, std::size_t id) noexcept
@@ -183,5 +179,4 @@ void Person::die(const unsigned int time) {
     time_of_death_ = time;
 }
 
-void Person::reset_id() { Person::newUID = 0; }
 } // namespace hgps

--- a/src/HealthGPS/person.h
+++ b/src/HealthGPS/person.h
@@ -66,8 +66,8 @@ struct Person {
 
     /// @brief Gets this instance unique identifier
     /// @note Unique for the person's lifetime within one Population (simulation run). IDs are not
-    /// reused after death or emigration. Default-constructed persons return @ref unassigned_id until
-    /// placed by Population.
+    /// reused after death or emigration. Default-constructed persons return @ref unassigned_id
+    /// until placed by Population.
     /// @return Unique identifier
     std::size_t id() const noexcept;
 

--- a/src/HealthGPS/person.h
+++ b/src/HealthGPS/person.h
@@ -3,7 +3,6 @@
 #include "HealthGPS.Core/forward_type.h"
 #include "HealthGPS.Core/identifier.h"
 
-#include <atomic>
 #include <map>
 
 namespace hgps {
@@ -38,32 +37,37 @@ struct Disease {
 
 /// @brief Defines a virtual population person data type.
 struct Person {
-    /// @brief Initialise a new instance of the Person structure
+    /// @brief Initialise a new instance without an assigned ID (@ref unassigned_id).
     Person();
 
-    /// @brief Initialise a new instance of the Person structure
+    /// @brief Initialise a new instance with gender; ID remains @ref unassigned_id until Population
+    /// placement.
     /// @param gender The new person gender
     Person(const core::Gender gender) noexcept;
 
-    // MAHIMA: Index-based ID for same-person tracking across baseline and intervention.
-    // When a Person is created by Population (initial slot, newborn, or add), ID = slot index + 1
-    // so the same logical person has the same ID in both baseline and intervention runs.
+    /// @brief Sentinel returned by default constructors until Population assigns an ID.
+    static constexpr std::size_t unassigned_id = 0;
 
-    /// @brief Initialise a new instance with an explicit ID (for Population slot assignment).
-    /// @param id The identifier to assign (typically slot index + 1).
+    /// @brief Initialise a new instance with an explicit ID (Population initial cohort / entrants).
+    /// @param id Lifetime-unique identifier assigned by Population.
     Person(std::size_t id) noexcept;
 
-    /// @brief Initialise a new instance with gender and explicit ID (for Population newborns).
+    /// @brief Initialise a new instance with gender and explicit ID (Population newborns).
     /// @param gender The new person gender
-    /// @param id The identifier to assign (typically slot index + 1).
+    /// @param id Lifetime-unique identifier assigned by Population.
     Person(const core::Gender gender, std::size_t id) noexcept;
 
-    /// @brief Set the person identifier (internal use by Population when placing clones).
-    /// @param id The identifier to assign (slot index + 1 after placement).
+    /// @brief Set the person identifier (Population use when placing or recycling slots).
+    /// @param id Lifetime-unique identifier; must not reuse a previously assigned population ID.
     void set_id(std::size_t id) noexcept;
 
+    /// @brief Whether Population has assigned a lifetime ID to this instance.
+    [[nodiscard]] bool has_assigned_id() const noexcept { return id_ != unassigned_id; }
+
     /// @brief Gets this instance unique identifier
-    /// @note The identifier is unique within a virtual population only, not global unique.
+    /// @note Unique for the person's lifetime within one Population (simulation run). IDs are not
+    /// reused after death or emigration. Default-constructed persons return @ref unassigned_id until
+    /// placed by Population.
     /// @return Unique identifier
     std::size_t id() const noexcept;
 
@@ -184,9 +188,6 @@ struct Person {
     /// @throws std::logic_error for attempting to set to non-active individuals.
     void die(const unsigned int time);
 
-    /// @brief Resets the unique identifier sequence to zero.
-    static void reset_id();
-
   private:
     std::size_t id_{};
     bool is_alive_{true};
@@ -194,7 +195,6 @@ struct Person {
     unsigned int time_of_death_{};
     unsigned int time_of_migration_{};
 
-    static std::atomic<std::size_t> newUID;
     static std::map<core::Identifier, std::function<double(const Person &)>> current_dispatcher;
 };
 } // namespace hgps

--- a/src/HealthGPS/population.cpp
+++ b/src/HealthGPS/population.cpp
@@ -3,15 +3,18 @@
 
 namespace hgps {
 
-// MAHIMA: IDs are assigned from slot index (id = index + 1) so the same logical person has the
-// same ID in baseline and intervention runs; Population is the only place that assigns these IDs.
+// MAHIMA: Initial cohort IDs are slot-aligned (id = index + 1) across baseline/intervention.
+// Post-initial entrants use a monotonic Population counter so IDs are lifetime-unique and never
+// reused when slots are recycled.
 
 Population::Population(const std::size_t size) : initial_size_{size} {
-    // MAHIMA: Create each slot with ID = index + 1 for cross-scenario same-person tracking.
+    // MAHIMA: Initial cohort uses deterministic IDs for cross-scenario same-person alignment.
     people_.reserve(size);
     for (std::size_t i = 0; i < size; ++i) {
         people_.emplace_back(i + 1);
     }
+    // MAHIMA: First post-initial entrant gets the next unused ID.
+    next_person_id_ = size + 1;
 }
 
 std::size_t Population::size() const noexcept { return people_.size(); }
@@ -38,12 +41,12 @@ void Population::add(Person person, unsigned int time) noexcept {
     if (!recycle.empty()) {
         const auto slot_index = static_cast<std::size_t>(recycle.at(0));
         people_.at(slot_index) = std::move(person);
-        // MAHIMA: Assign slot-based ID so this person is tracked with same ID across scenarios.
-        people_.at(slot_index).set_id(slot_index + 1);
+        // MAHIMA: Reused slot gets a fresh lifetime-unique ID (slot reuse != ID reuse).
+        people_.at(slot_index).set_id(next_person_id_++);
     } else {
         people_.emplace_back(std::move(person));
-        // MAHIMA: New slot gets ID = current size (index + 1).
-        people_.back().set_id(people_.size());
+        // MAHIMA: Appended entrant also gets a fresh lifetime-unique ID.
+        people_.back().set_id(next_person_id_++);
     }
 }
 
@@ -55,15 +58,15 @@ void Population::add_newborn_babies(std::size_t number, core::Gender gender,
         auto replacebles = std::min(number, recycle.size());
         for (auto index = std::size_t{0}; index < replacebles; index++) {
             const auto slot_index = static_cast<std::size_t>(recycle.at(index));
-            // MAHIMA: Newborn in recycled slot keeps that slot's ID (index + 1).
-            people_.at(slot_index) = Person{gender, slot_index + 1};
+            // MAHIMA: Newborn in recycled slot gets a fresh lifetime-unique ID.
+            people_.at(slot_index) = Person{gender, next_person_id_++};
             remaining--;
         }
     }
 
     for (auto i = std::size_t{0}; i < remaining; i++) {
-        // MAHIMA: New slot gets ID = current size + 1 (next index + 1).
-        people_.emplace_back(gender, people_.size() + 1);
+        // MAHIMA: Newborn in appended slot also gets a fresh lifetime-unique ID.
+        people_.emplace_back(gender, next_person_id_++);
     }
 }
 

--- a/src/HealthGPS/population.cpp
+++ b/src/HealthGPS/population.cpp
@@ -1,6 +1,10 @@
 #include "population.h"
 #include <execution>
 
+#ifndef NDEBUG
+#include <cassert>
+#endif
+
 namespace hgps {
 
 // MAHIMA: Initial cohort IDs are slot-aligned (id = index + 1) across baseline/intervention.
@@ -10,11 +14,19 @@ namespace hgps {
 Population::Population(const std::size_t size) : initial_size_{size} {
     // MAHIMA: Initial cohort uses deterministic IDs for cross-scenario same-person alignment.
     people_.reserve(size);
+#ifndef NDEBUG
+    // MAHIMA: Initial IDs must be consecutive and unused before post-initial counter takes over.
+    assert(next_person_id_ == 1u);
+#endif
     for (std::size_t i = 0; i < size; ++i) {
-        people_.emplace_back(i + 1);
+        const std::size_t id = i + 1u;
+#ifndef NDEBUG
+        assert(id == next_person_id_);
+        assert(id != Person::unassigned_id);
+#endif
+        people_.emplace_back(id);
+        ++next_person_id_;
     }
-    // MAHIMA: First post-initial entrant gets the next unused ID.
-    next_person_id_ = size + 1;
 }
 
 std::size_t Population::size() const noexcept { return people_.size(); }
@@ -42,11 +54,11 @@ void Population::add(Person person, unsigned int time) noexcept {
         const auto slot_index = static_cast<std::size_t>(recycle.at(0));
         people_.at(slot_index) = std::move(person);
         // MAHIMA: Reused slot gets a fresh lifetime-unique ID (slot reuse != ID reuse).
-        people_.at(slot_index).set_id(next_person_id_++);
+        people_.at(slot_index).set_id(allocate_next_person_id());
     } else {
         people_.emplace_back(std::move(person));
         // MAHIMA: Appended entrant also gets a fresh lifetime-unique ID.
-        people_.back().set_id(next_person_id_++);
+        people_.back().set_id(allocate_next_person_id());
     }
 }
 
@@ -59,14 +71,14 @@ void Population::add_newborn_babies(std::size_t number, core::Gender gender,
         for (auto index = std::size_t{0}; index < replacebles; index++) {
             const auto slot_index = static_cast<std::size_t>(recycle.at(index));
             // MAHIMA: Newborn in recycled slot gets a fresh lifetime-unique ID.
-            people_.at(slot_index) = Person{gender, next_person_id_++};
+            people_.at(slot_index) = Person{gender, allocate_next_person_id()};
             remaining--;
         }
     }
 
     for (auto i = std::size_t{0}; i < remaining; i++) {
         // MAHIMA: Newborn in appended slot also gets a fresh lifetime-unique ID.
-        people_.emplace_back(gender, next_person_id_++);
+        people_.emplace_back(gender, allocate_next_person_id());
     }
 }
 

--- a/src/HealthGPS/population.h
+++ b/src/HealthGPS/population.h
@@ -95,9 +95,9 @@ class Population {
   private:
     std::size_t initial_size_;
     // MAHIMA: Lifetime-unique person ID counter for post-initial entrants.
-    // Initial cohort keeps deterministic IDs [1..initial_size_] for baseline/intervention alignment.
-    // All later entrants (births/immigration) get IDs from this monotonic counter and IDs are never
-    // reused even when slots are recycled.
+    // Initial cohort keeps deterministic IDs [1..initial_size_] for baseline/intervention
+    // alignment. All later entrants (births/immigration) get IDs from this monotonic counter and
+    // IDs are never reused even when slots are recycled.
     std::size_t next_person_id_{1};
     std::vector<Person> people_;
 

--- a/src/HealthGPS/population.h
+++ b/src/HealthGPS/population.h
@@ -1,6 +1,10 @@
 #pragma once
 #include "person.h"
 
+#ifndef NDEBUG
+#include <cassert>
+#endif
+
 #include <vector>
 
 namespace hgps {
@@ -104,5 +108,18 @@ class Population {
 
     std::vector<int> find_index_of_recyclables(unsigned int time,
                                                std::size_t top = 0) const noexcept;
+
+    /// @brief Returns the next lifetime-unique person ID and advances the counter.
+    /// Debug builds assert the ID was not previously assigned (monotonic, no reuse).
+    std::size_t allocate_next_person_id() noexcept {
+        const std::size_t id = next_person_id_;
+#ifndef NDEBUG
+        // MAHIMA: Debug-only duplicate-ID guard; compiled out in release (no extra memory or work).
+        assert(id != Person::unassigned_id);
+        assert(id == next_person_id_ && "Person ID must be the next unused value (no reuse)");
+#endif
+        ++next_person_id_;
+        return id;
+    }
 };
 } // namespace hgps

--- a/src/HealthGPS/population.h
+++ b/src/HealthGPS/population.h
@@ -94,6 +94,11 @@ class Population {
 
   private:
     std::size_t initial_size_;
+    // MAHIMA: Lifetime-unique person ID counter for post-initial entrants.
+    // Initial cohort keeps deterministic IDs [1..initial_size_] for baseline/intervention alignment.
+    // All later entrants (births/immigration) get IDs from this monotonic counter and IDs are never
+    // reused even when slots are recycled.
+    std::size_t next_person_id_{1};
     std::vector<Person> people_;
 
     std::vector<int> find_index_of_recyclables(unsigned int time,

--- a/src/HealthGPS/population.h
+++ b/src/HealthGPS/population.h
@@ -11,6 +11,7 @@ namespace hgps {
 /// to births, deaths and emigration. When possible, the Population class
 /// recycles the dead and migrated individuals slots with newborn babies
 /// to minimise memory allocation and clear-up the inactive population.
+/// Person IDs are lifetime-unique within a run: slots may be reused, IDs are not.
 class Population {
   public:
     /// @brief Population iterator


### PR DESCRIPTION
Note: IDs are unique within one run. Baseline and intervention each have their own Population and counter; initial IDs 1..N still mean “same starting person,” not one global ID across both runs. Tracking death in exports still needs year + active status (or last-seen year), because a dead person keeps their ID in the slot until it is recycled.

## Before vs updated behavior flowcharts

### Before (implemented slot-based ID reuse)

```mermaid
flowchart TD
  startA[PersonInSlot_i_ID_iPlus1] --> deathA[PersonDiesOrEmigrates]
  deathA --> recycleA[Slot_iMarkedRecyclable]
  recycleA --> newbornA[NewPersonPlacedInSlot_i]
  newbornA --> sameIdA[AssignedID_iPlus1_Again]
  sameIdA --> mixedA[SameIDMapsToDifferentPeopleOverTime]
```

### Updated (lifetime-unique IDs with slot reuse only)

```mermaid
flowchart TD
  initB[InitialSlot_i_GetsID_iPlus1] --> counterB[next_person_id_InitialisedTo_NPlus1]
  counterB --> deathB[PersonDiesOrEmigrates]
  deathB --> recycleB[Slot_iReusedForMemoryOnly]
  recycleB --> newPersonB[NewPersonPlacedInRecycledOrNewSlot]
  newPersonB --> assignB[AssignID_next_person_id_ThenIncrement]
  assignB --> uniqueB[IDNeverReused_LifetimeUnique]
```